### PR TITLE
fix: update error message for missing change option in parser

### DIFF
--- a/system/core/utils/parser.go
+++ b/system/core/utils/parser.go
@@ -481,7 +481,7 @@ func ParseChange(argStr string) (*CommandDetails, string) {
 	// 追加オプションチェック
 	fields := strings.Fields(argStr)
 	if len(fields) == 0 {
-		return nil, i18n.T("parse:missing-change-option")
+		return nil, i18n.T("parse:invalid-option")
 	}
 	options, message := ParseMinWorkOrderOptions(argStr)
 	if message != "" {


### PR DESCRIPTION
This pull request includes a small but important change to the error message in the `ParseChange` function within the `system/core/utils/parser.go` file. The change updates the error message to be more accurate when no options are provided.

* [`system/core/utils/parser.go`](diffhunk://#diff-d5c162ea9d4472b4d9d9c3447a97e7d1bf91791ee73113f76f09aacc4f6318c3L484-R484): Updated the error message from "parse:missing-change-option" to "parse:invalid-option" in the `ParseChange` function to better reflect the nature of the error.