### PR TITLE
fix #482

### DIFF
--- a/system/core/utils/parse_in_test.go
+++ b/system/core/utils/parse_in_test.go
@@ -366,6 +366,22 @@ func TestParseIn(t *testing.T) {
 			},
 		},
 		{
+			Name:  "作業内容に!が含まれる場合",
+			Input: "!in がんばる! min 90",
+			Output: &CommandDetails{
+				CommandType: In,
+				InOption: InOption{
+					IsSeatIdSet: false,
+					MinWorkOrderOption: &MinWorkOrderOption{
+						IsWorkNameSet:    true,
+						IsDurationMinSet: true,
+						WorkName:         "がんばる!",
+						DurationMin:      90,
+					},
+				},
+			},
+		},
+		{
 			Name:  "全角の／によるメンバー入室",
 			Input: "／in",
 			Output: &CommandDetails{

--- a/system/core/utils/parser.go
+++ b/system/core/utils/parser.go
@@ -237,8 +237,12 @@ func FormatStringToParse(fullString string) string {
 	fullString = strings.Join(strings.Fields(fullString), HalfWidthSpace)
 
 	// `!`や`/`の隣が空白ならその空白を消す
-	fullString = strings.ReplaceAll(fullString, CommandPrefix+HalfWidthSpace, CommandPrefix)
-	fullString = strings.ReplaceAll(fullString, MemberCommandPrefix+HalfWidthSpace, MemberCommandPrefix)
+	if strings.HasPrefix(fullString, CommandPrefix+HalfWidthSpace) {
+		fullString = strings.Replace(fullString, CommandPrefix+HalfWidthSpace, CommandPrefix, 1) // NOTE: 最初の1つだけ
+	}
+	if strings.HasPrefix(fullString, MemberCommandPrefix+HalfWidthSpace) {
+		fullString = strings.Replace(fullString, MemberCommandPrefix+HalfWidthSpace, MemberCommandPrefix, 1) // NOTE: 最初の1つだけ
+	}
 
 	return fullString
 }


### PR DESCRIPTION
This pull request includes updates to the `parse_in_test.go` and `parser.go` files to handle specific cases involving command prefixes more accurately. The most important changes include adding a new test case for commands with exclamation marks and modifying the string formatting function to address prefix handling.

### Enhancements in test cases:

* [`system/core/utils/parse_in_test.go`](diffhunk://#diff-f8b8fdf30216de095381fc7467295dae2a4250c9d8b1cc9836311a6a32a4c962R368-R383): Added a new test case to `TestParseIn` to verify the parsing of commands containing exclamation marks in the work name.

### Improvements in string formatting:

* [`system/core/utils/parser.go`](diffhunk://#diff-d5c162ea9d4472b4d9d9c3447a97e7d1bf91791ee73113f76f09aacc4f6318c3L240-R245): Updated the `FormatStringToParse` function to replace only the first occurrence of a command prefix followed by a space, ensuring more precise handling of command prefixes.