### PR TITLE
fix #485

### DIFF
--- a/system/core/utils/parser.go
+++ b/system/core/utils/parser.go
@@ -527,13 +527,13 @@ func ParseMore(argStr string) (*CommandDetails, string) {
 		if fields[0] == TimeOptionKey {
 			value, err := strconv.Atoi(fields[1])
 			if err != nil {
-				return nil, i18n.T("parse:invalid-time-option")
+				return nil, i18n.T("parse:invalid-option")
 			}
 			durationMin = value
 		} else {
 			value, err := strconv.Atoi(fields[0])
 			if err != nil {
-				return nil, i18n.T("parse:invalid-time-option")
+				return nil, i18n.T("parse:invalid-option")
 			}
 			durationMin = value
 		}
@@ -543,7 +543,7 @@ func ParseMore(argStr string) (*CommandDetails, string) {
 		}
 		value, err := strconv.Atoi(fields[0])
 		if err != nil {
-			return nil, i18n.T("parse:invalid-time-option")
+			return nil, i18n.T("parse:invalid-option")
 		}
 		durationMin = value
 	} else {


### PR DESCRIPTION
This pull request includes updates to the `ParseMore` function in the `system/core/utils/parser.go` file to standardize error messages. The changes replace specific error messages with a more generic one.

Standardization of error messages:

* [`system/core/utils/parser.go`](diffhunk://#diff-d5c162ea9d4472b4d9d9c3447a97e7d1bf91791ee73113f76f09aacc4f6318c3L530-R536): Updated error message from `i18n.T("parse:invalid-time-option")` to `i18n.T("parse:invalid-option")` in three locations within the `ParseMore` function. [[1]](diffhunk://#diff-d5c162ea9d4472b4d9d9c3447a97e7d1bf91791ee73113f76f09aacc4f6318c3L530-R536) [[2]](diffhunk://#diff-d5c162ea9d4472b4d9d9c3447a97e7d1bf91791ee73113f76f09aacc4f6318c3L546-R546)