### PR TITLE
Migrate jsmedatags to music-metadata

### DIFF
--- a/.idea/sqldialects.xml
+++ b/.idea/sqldialects.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="SqlDialectMappings">
-    <file url="file://$PROJECT_DIR$/system/core/mybigquery/bigquery_controller.go" dialect="GenericSQL" />
     <file url="PROJECT" dialect="BigQuery" />
   </component>
 </project>

--- a/youtube-monitor/package-lock.json
+++ b/youtube-monitor/package-lock.json
@@ -17,7 +17,7 @@
 				"chroma-js": "^2.4.2",
 				"firebase": "^11.2.0",
 				"framer-motion": "^10.16.4",
-				"jsmediatags": "^3.9.7",
+				"music-metadata": "^11.2.2",
 				"next": "^14.2.22",
 				"next-i18next": "^15.0.0",
 				"react": "^18.2.0",
@@ -6707,6 +6707,30 @@
 				"@testing-library/dom": ">=7.21.4"
 			}
 		},
+		"node_modules/@tokenizer/inflate": {
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
+			"integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.0",
+				"fflate": "^0.8.2",
+				"token-types": "^6.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
+		"node_modules/@tokenizer/token": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+			"integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+			"license": "MIT"
+		},
 		"node_modules/@tootallnate/once": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -9059,6 +9083,15 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/content-type": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+			"integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/convert-source-map": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -9469,11 +9502,12 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.4",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+			"license": "MIT",
 			"dependencies": {
-				"ms": "2.1.2"
+				"ms": "^2.1.3"
 			},
 			"engines": {
 				"node": ">=6.0"
@@ -10321,6 +10355,12 @@
 				"bser": "2.1.1"
 			}
 		},
+		"node_modules/fflate": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+			"integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+			"license": "MIT"
+		},
 		"node_modules/file-loader": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/file-loader/-/file-loader-6.2.0.tgz",
@@ -10353,6 +10393,24 @@
 			},
 			"engines": {
 				"node": ">=8.9.0"
+			}
+		},
+		"node_modules/file-type": {
+			"version": "20.5.0",
+			"resolved": "https://registry.npmjs.org/file-type/-/file-type-20.5.0.tgz",
+			"integrity": "sha512-BfHZtG/l9iMm4Ecianu7P8HRD2tBHLtjXinm4X62XBOYzi7CYA7jyqfJzOvXHqzVrVPYqBo2/GvbARMaaJkKVg==",
+			"license": "MIT",
+			"dependencies": {
+				"@tokenizer/inflate": "^0.2.6",
+				"strtok3": "^10.2.0",
+				"token-types": "^6.0.0",
+				"uint8array-extras": "^1.4.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sindresorhus/file-type?sponsor=1"
 			}
 		},
 		"node_modules/filesize": {
@@ -13084,18 +13142,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/jsmediatags": {
-			"version": "3.9.7",
-			"resolved": "https://registry.npmjs.org/jsmediatags/-/jsmediatags-3.9.7.tgz",
-			"integrity": "sha512-xCAO8C3li3t5hYkXqn8iv8zQQUB4T1QqRN2aSONHMls21ICdEvXi4xtb6W70/fAFYSDwMHd32hIqvo4YuXoNcQ==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"xhr2": "^0.1.4"
-			},
-			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -13398,6 +13444,15 @@
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.1.2"
+			}
+		},
+		"node_modules/media-typer": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+			"integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/memfs": {
@@ -14039,9 +14094,39 @@
 			}
 		},
 		"node_modules/ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+			"license": "MIT"
+		},
+		"node_modules/music-metadata": {
+			"version": "11.2.2",
+			"resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-11.2.2.tgz",
+			"integrity": "sha512-jCm36KMvUxi6YWxsc2y0kzBLvFI5auLllSidur4kCbdBmEZAVV/Gy9mqSZvUiLIQAhWCGDMXQK2DmEHLE78kVw==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/Borewit"
+				},
+				{
+					"type": "buymeacoffee",
+					"url": "https://buymeacoffee.com/borewit"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0",
+				"content-type": "^1.0.5",
+				"debug": "^4.4.1",
+				"file-type": "^20.5.0",
+				"media-typer": "^1.1.0",
+				"strtok3": "^10.2.2",
+				"token-types": "^6.0.0",
+				"uint8array-extras": "^1.4.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.8",
@@ -14681,6 +14766,19 @@
 			},
 			"engines": {
 				"node": ">=0.12"
+			}
+		},
+		"node_modules/peek-readable": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-7.0.0.tgz",
+			"integrity": "sha512-nri2TO5JE3/mRryik9LlHFT53cgHfRK0Lt0BAZQXku/AW3E6XLt2GaY8siWi7dvW/m1z0ecn+J+bpDa9ZN3IsQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
 		"node_modules/picocolors": {
@@ -16254,13 +16352,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/send/node_modules/ms": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-			"optional": true,
-			"peer": true
-		},
 		"node_modules/serialize-error": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
@@ -16803,6 +16894,23 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/strtok3": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.2.2.tgz",
+			"integrity": "sha512-Xt18+h4s7Z8xyZ0tmBoRmzxcop97R4BAh+dXouUDCYn+Em+1P3qpkUfI5ueWLT8ynC5hZ+q4iPEmGG1urvQGBg==",
+			"license": "MIT",
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0",
+				"peek-readable": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
 		"node_modules/style-loader": {
 			"version": "3.3.4",
 			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.4.tgz",
@@ -17248,6 +17356,23 @@
 				"node": ">=0.6"
 			}
 		},
+		"node_modules/token-types": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.0.tgz",
+			"integrity": "sha512-lbDrTLVsHhOMljPscd0yitpozq7Ga2M5Cvez5AjGg8GASBjtt6iERCAJ93yommPmz62fb45oFIXHEZ3u9bfJEA==",
+			"license": "MIT",
+			"dependencies": {
+				"@tokenizer/token": "^0.3.0",
+				"ieee754": "^1.2.1"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/Borewit"
+			}
+		},
 		"node_modules/tough-cookie": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
@@ -17532,6 +17657,18 @@
 			},
 			"engines": {
 				"node": ">=14.17"
+			}
+		},
+		"node_modules/uint8array-extras": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.4.0.tgz",
+			"integrity": "sha512-ZPtzy0hu4cZjv3z5NW9gfKnNLjoz4y6uv4HlelAjDK7sY/xOkKZv9xK/WQpcsBB3jEybChz9DPC2U/+cusjJVQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/undici-types": {
@@ -18232,15 +18369,6 @@
 				"utf-8-validate": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/xhr2": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
-			"integrity": "sha512-3QGhDryRzTbIDj+waTRvMBe8SyPhW79kz3YnNb+HQt/6LPYQT3zT3Jt0Y8pBofZqQX26x8Ecfv0FXR72uH5VpA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/xml-name-validator": {

--- a/youtube-monitor/package.json
+++ b/youtube-monitor/package.json
@@ -30,7 +30,7 @@
 		"chroma-js": "^2.4.2",
 		"firebase": "^11.2.0",
 		"framer-motion": "^10.16.4",
-		"jsmediatags": "^3.9.7",
+		"music-metadata": "^11.2.2",
 		"next": "^14.2.22",
 		"next-i18next": "^15.0.0",
 		"react": "^18.2.0",

--- a/youtube-monitor/src/components/BgmPlayer.tsx
+++ b/youtube-monitor/src/components/BgmPlayer.tsx
@@ -1,5 +1,5 @@
 import { Wave } from '@foobar404/wave'
-import { parseWebStream, parseBlob } from 'music-metadata'
+import { parseWebStream, parseBlob, type IAudioMetadata } from 'music-metadata'
 import type React from 'react'
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { getCurrentRandomBgm } from '../lib/bgm'
@@ -68,39 +68,47 @@ const BgmPlayer: React.FC = () => {
 
 	const audioNext = useCallback(async () => {
 		try {
-			const audio = document.getElementById(audioDivId) as HTMLAudioElement | null;
+			const audio = document.getElementById(
+				audioDivId,
+			) as HTMLAudioElement | null
 			if (!audio) {
-				console.error(`Audio element with ID '${audioDivId}' not found.`);
-				return;
+				console.error(`Audio element with ID '${audioDivId}' not found.`)
+				return
 			}
 
-			const bgm = await getCurrentRandomBgm();
+			const bgm = await getCurrentRandomBgm()
+			audio.src = bgm
 
-			const response = await fetch(audio.src);
+			const response = await fetch(audio.src)
 			if (!response.ok) {
-				throw new Error(`Failed to fetch audio: ${response.status} ${response.statusText}`);
+				throw new Error(
+					`Failed to fetch audio: ${response.status} ${response.statusText}`,
+				)
 			}
 
-			let metadata;
+			let metadata: IAudioMetadata
 			if (!response.body) {
 				// Fall back on Blob if web stream is not supported
-				const blob = await response.blob();
-				metadata = await parseBlob(blob);
+				const blob = await response.blob()
+				metadata = await parseBlob(blob)
 			} else {
-				const contentLength = response.headers.get('Content-Length');
-				const size = contentLength ? parseInt(contentLength) : undefined;
-				metadata = await parseWebStream(response.body, {mimeType: response.headers.get('Content-Type') ?? undefined, size});
+				const contentLength = response.headers.get('Content-Length')
+				const size = contentLength ? Number.parseInt(contentLength) : undefined
+				metadata = await parseWebStream(response.body, {
+					mimeType: response.headers.get('Content-Type') ?? undefined,
+					size,
+				})
 			}
 
-			setAudioTitle(metadata.common.title ?? 'BGM TITLE');
-			setAudioArtist(metadata.common.artist ?? 'BGM ARTIST');
+			setAudioTitle(metadata.common.title ?? 'BGM TITLE')
+			setAudioArtist(metadata.common.artist ?? 'BGM ARTIST')
 
-			audio.volume = Constants.bgmVolume;
-			await audio.play();
+			audio.volume = Constants.bgmVolume
+			await audio.play()
 		} catch (error) {
-			console.error('Failed to play audio or parse metadata:', error);
+			console.error('Failed to play audio or parse metadata:', error)
 		}
-	}, []);
+	}, [])
 
 	const audioStart = useCallback(() => {
 		const audio = document.getElementById(audioDivId) as HTMLAudioElement

--- a/youtube-monitor/src/components/BgmPlayer.tsx
+++ b/youtube-monitor/src/components/BgmPlayer.tsx
@@ -1,5 +1,5 @@
 import { Wave } from '@foobar404/wave'
-import jsmediatags from 'jsmediatags'
+import { parseWebStream, parseBlob } from 'music-metadata'
 import type React from 'react'
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { getCurrentRandomBgm } from '../lib/bgm'
@@ -67,29 +67,40 @@ const BgmPlayer: React.FC = () => {
 	}
 
 	const audioNext = useCallback(async () => {
-		const audio = document.getElementById(audioDivId) as HTMLAudioElement
+		try {
+			const audio = document.getElementById(audioDivId) as HTMLAudioElement | null;
+			if (!audio) {
+				console.error(`Audio element with ID '${audioDivId}' not found.`);
+				return;
+			}
 
-		const bgm = await getCurrentRandomBgm()
-		audio.src = bgm
-		jsmediatags.read(audio.src, {
-			onSuccess(tag: ID3Tag) {
-				const title = tag.tags.title
-				const artist = tag.tags.artist
-				setAudioTitle(
-					title !== null && title !== undefined ? title : 'BGM TITLE',
-				)
-				setAudioArtist(
-					artist !== null && artist !== undefined ? artist : 'BGM ARTIST',
-				)
-			},
-			onError(error: Error) {
-				console.error(error)
-			},
-		})
-		audio.volume = Constants.bgmVolume
+			const bgm = await getCurrentRandomBgm();
 
-		audio.play()
-	}, [])
+			const response = await fetch(audio.src);
+			if (!response.ok) {
+				throw new Error(`Failed to fetch audio: ${response.status} ${response.statusText}`);
+			}
+
+			let metadata;
+			if (!response.body) {
+				// Fall back on Blob if web stream is not supported
+				const blob = await response.blob();
+				metadata = await parseBlob(blob);
+			} else {
+				const contentLength = response.headers.get('Content-Length');
+				const size = contentLength ? parseInt(contentLength) : undefined;
+				metadata = await parseWebStream(response.body, {mimeType: response.headers.get('Content-Type') ?? undefined, size});
+			}
+
+			setAudioTitle(metadata.common.title ?? 'BGM TITLE');
+			setAudioArtist(metadata.common.artist ?? 'BGM ARTIST');
+
+			audio.volume = Constants.bgmVolume;
+			await audio.play();
+		} catch (error) {
+			console.error('Failed to play audio or parse metadata:', error);
+		}
+	}, []);
 
 	const audioStart = useCallback(() => {
 		const audio = document.getElementById(audioDivId) as HTMLAudioElement


### PR DESCRIPTION
Maybe you want to consider to migrate to [music-metadata](https://github.com/Borewit/music-metadata).

This has a few advantages:

1. jsmediatags is abandoned, music-metadata is well maintained
2. music-metadata supports virtual any audio and meta tag header format

I failed to get your project up and running, and therefor failed to test the implementation.
With some guidance how to setup the dev environment, I am more then happy to give it another try.