### PR TITLE
CIの設定を更新: actions/checkoutとactions/setup-goのバージョンをそれぞれv4とv5に、golangci…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,17 +30,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: "1.21"
-          cache: false
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: v1.54
           working-directory: system
-          args: --timeout 5m
 
   jest:
     name: Jest


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration to use newer versions of actions and tools, improving compatibility and access to the latest features.

Updates to GitHub Actions workflow:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L33-L43): Updated `actions/checkout` from `v3` to `v4`, `actions/setup-go` from `v4` to `v5`, and `golangci/golangci-lint-action` from `v3` to `v6`. Removed the `cache` and `args` parameters from `setup-go` and `golangci-lint` steps, respectively.…-lint-actionをv6にアップデート