### PR TITLE
GitHub Actionsの設定を更新し、Goのバージョンを1.21から1.22に、golangci-lintのバージョンを1.54から…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
         with:
           version: v1.57
           working-directory: system
+          args: --timeout=5m
 
   jest:
     name: Jest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Set up Go 1.21
-        uses: actions/setup-go@v4
+      - name: Set up Go 1.22
+        uses: actions/setup-go@v5
         with:
-          go-version: ^1.21
+          go-version: ^1.22
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Get dependencies and run tests
         working-directory: system
@@ -33,11 +33,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.54
+          version: v1.57
           working-directory: system
 
   jest:
@@ -48,7 +48,7 @@ jobs:
       run:
         working-directory: youtube-monitor
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Node.js
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/test.yml` to use newer versions of tools and actions. The changes aim to ensure compatibility with the latest versions and improve the workflow's reliability.

### Updates to tool and action versions:

* Updated the Go version from `1.21` to `1.22` and switched from `actions/setup-go@v4` to `actions/setup-go@v5` for better support and features. (`[[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L13-R20)`, `[[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L36-R40)`)
* Updated `golangci-lint` to version `v1.57` from `v1.54` to use the latest linting features and fixes. (`[.github/workflows/test.ymlL36-R40](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L36-R40)`)

### Updates to GitHub Actions:

* Upgraded `actions/checkout` from version `v3` to `v4` to leverage improvements in the newer version. (`[[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L13-R20)`, `[[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L53-R52)`)…1.57に変更しました。また、actions/checkoutのバージョンをv3からv4に更新しました。