### PR TITLE
JestとTypeScriptの設定を更新し、ターゲットをES2020に変更

### DIFF
--- a/youtube-monitor/jest.config.ts
+++ b/youtube-monitor/jest.config.ts
@@ -177,6 +177,16 @@ const config: Config = {
 		'^.+\\.(ts|tsx)$': 'ts-jest',
 	},
 
+	// ts-jest configuration
+	preset: 'ts-jest',
+	globals: {
+		'ts-jest': {
+			tsconfig: {
+				target: 'es2020',
+			},
+		},
+	},
+
 	// An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
 	// transformIgnorePatterns: [
 	//   "\\\\node_modules\\\\",

--- a/youtube-monitor/tsconfig.json
+++ b/youtube-monitor/tsconfig.json
@@ -3,7 +3,7 @@
 		"sourceMap": true,
 		"noImplicitAny": true,
 		"module": "esnext",
-		"target": "es6",
+		"target": "es2020",
 		"jsx": "preserve",
 		"jsxImportSource": "@emotion/react",
 		"lib": ["dom", "dom.iterable", "esnext"],


### PR DESCRIPTION
This pull request updates the TypeScript configuration and testing setup for the `youtube-monitor` project to align with modern standards and improve compatibility. The changes include updating the TypeScript target version and configuring `ts-jest` for better TypeScript testing support.

### TypeScript Configuration Updates:
* Updated the `target` property in `tsconfig.json` from `es6` to `es2020` to leverage newer JavaScript features. (`youtube-monitor/tsconfig.json`, [youtube-monitor/tsconfig.jsonL6-R6](diffhunk://#diff-52d67cadbde96249c90fc596cd54f1b47b79cf53dcb48391f4b939bfa39b3f7eL6-R6))

### Testing Configuration Enhancements:
* Added `ts-jest` configuration in `jest.config.ts` to specify a `tsconfig` target of `es2020`, ensuring consistency between the TypeScript compiler and the Jest testing environment. (`youtube-monitor/jest.config.ts`, [youtube-monitor/jest.config.tsR180-R189](diffhunk://#diff-4fc016bc83e696fe040faf228edd4b25ca38f07bc025492691b1e5d6a80b241bR180-R189))…しました。