### PR TITLE
Presenter化: 返信文生成をTx外に分離（イベント導入）

### DIFF
--- a/system/.vscode/settings.json
+++ b/system/.vscode/settings.json
@@ -7,6 +7,7 @@
     "Okawari",
     "stretchr",
     "studyspaceerror",
+    "usecase",
     "wordsreader",
     "workspaceapp",
     "youtubebot"

--- a/system/core/workspaceapp/command_seat.go
+++ b/system/core/workspaceapp/command_seat.go
@@ -629,8 +629,8 @@ func (app *WorkspaceApp) More(ctx context.Context, moreOption *utils.MoreOption)
 }
 
 func (app *WorkspaceApp) Break(ctx context.Context, breakOption *utils.MinWorkOrderOption) error {
-    replyMessage := ""
-    var result usecase.Result
+	replyMessage := ""
+	var result usecase.Result
 	txErr := app.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
 		// 入室しているか？
 		isInMemberRoom, isInGeneralRoom, err := app.IsUserInRoom(ctx, app.ProcessedUserId)
@@ -648,15 +648,15 @@ func (app *WorkspaceApp) Break(ctx context.Context, breakOption *utils.MinWorkOr
 		if err != nil {
 			return fmt.Errorf("failed app.CurrentSeat(): %w", err)
 		}
-        if currentSeat.State != repository.WorkState {
-            replyMessage = i18n.T("command-break:work-only", app.ProcessedUserDisplayName)
+		if currentSeat.State != repository.WorkState {
+			replyMessage = i18n.T("command-break:work-only", app.ProcessedUserDisplayName)
 			return nil
 		}
 
 		// 前回の入室または再開から、最低休憩間隔経っているか？
 		currentWorkedMin := int(utils.NoNegativeDuration(utils.JstNow().Sub(currentSeat.CurrentStateStartedAt)).Minutes())
-        if currentWorkedMin < app.Configs.Constants.MinBreakIntervalMin {
-            replyMessage = i18n.T("command-break:warn", app.ProcessedUserDisplayName, app.Configs.Constants.MinBreakIntervalMin, currentWorkedMin)
+		if currentWorkedMin < app.Configs.Constants.MinBreakIntervalMin {
+			replyMessage = i18n.T("command-break:warn", app.ProcessedUserDisplayName, app.Configs.Constants.MinBreakIntervalMin, currentWorkedMin)
 			return nil
 		}
 
@@ -702,18 +702,18 @@ func (app *WorkspaceApp) Break(ctx context.Context, breakOption *utils.MinWorkOr
 			return fmt.Errorf("in CreateUserActivityDoc: %w", err)
 		}
 
-        result.Add(usecase.BreakStarted{SeatID: currentSeat.SeatId, IsMemberSeat: isInMemberRoom, WorkName: breakOption.WorkName, DurationMin: breakOption.DurationMin})
+		result.Add(usecase.BreakStarted{SeatID: currentSeat.SeatId, IsMemberSeat: isInMemberRoom, WorkName: breakOption.WorkName, DurationMin: breakOption.DurationMin})
 		return nil
 	})
 	if txErr != nil {
 		slog.Error("txErr in Break()", "txErr", txErr)
 		replyMessage = i18n.T("command:error", app.ProcessedUserDisplayName)
 	}
-    if txErr == nil {
-        if len(result.Events) > 0 {
-            replyMessage = presenter.BuildBreakMessage(result, app.ProcessedUserDisplayName)
-        }
-    }
+	if txErr == nil {
+		if len(result.Events) > 0 {
+			replyMessage = presenter.BuildBreakMessage(result, app.ProcessedUserDisplayName)
+		}
+	}
 	app.MessageToLiveChat(ctx, replyMessage)
 	return txErr
 }

--- a/system/core/workspaceapp/presenter/break.go
+++ b/system/core/workspaceapp/presenter/break.go
@@ -13,6 +13,10 @@ func BuildBreakMessage(res usecase.Result, displayName string) string {
 	msg := ""
 	for _, ev := range res.Events {
 		switch e := ev.(type) {
+		case usecase.BreakWorkOnly:
+			msg += t("work-only", displayName)
+		case usecase.BreakWarn:
+			msg += t("warn", displayName, e.MinBreakIntervalMin, e.CurrentWorkedMin)
 		case usecase.BreakStarted:
 			seat := seatIDStr(e.SeatID, e.IsMemberSeat)
 			msg += t("break", displayName, e.WorkName, e.DurationMin, seat)

--- a/system/core/workspaceapp/presenter/break.go
+++ b/system/core/workspaceapp/presenter/break.go
@@ -1,0 +1,24 @@
+package presenter
+
+import (
+    "app.modules/core/i18n"
+    "app.modules/core/workspaceapp/usecase"
+)
+
+// BuildBreakMessage converts Break events into a localized response.
+// Namespace: command-break
+// Note: Breakの文面は先頭のsir接頭辞を付けない（既存テスト準拠）
+func BuildBreakMessage(res usecase.Result, displayName string) string {
+    t := i18n.GetTFunc("command-break")
+    msg := ""
+    for _, ev := range res.Events {
+        switch e := ev.(type) {
+        case usecase.BreakStarted:
+            seat := seatIDStr(e.SeatID, e.IsMemberSeat)
+            msg += t("break", displayName, e.WorkName, e.DurationMin, seat)
+        }
+    }
+    return msg
+}
+
+

--- a/system/core/workspaceapp/presenter/break.go
+++ b/system/core/workspaceapp/presenter/break.go
@@ -11,8 +11,8 @@ import (
 func BuildBreakMessage(res usecase.Result, displayName string) string {
 	t := i18n.GetTFunc("command-break")
 	msg := ""
-	for _, ev := range res.Events {
-		switch e := ev.(type) {
+	for _, event := range res.Events {
+		switch e := event.(type) {
 		case usecase.BreakWorkOnly:
 			msg += t("work-only", displayName)
 		case usecase.BreakWarn:

--- a/system/core/workspaceapp/presenter/break.go
+++ b/system/core/workspaceapp/presenter/break.go
@@ -1,24 +1,22 @@
 package presenter
 
 import (
-    "app.modules/core/i18n"
-    "app.modules/core/workspaceapp/usecase"
+	"app.modules/core/i18n"
+	"app.modules/core/workspaceapp/usecase"
 )
 
 // BuildBreakMessage converts Break events into a localized response.
 // Namespace: command-break
 // Note: Breakの文面は先頭のsir接頭辞を付けない（既存テスト準拠）
 func BuildBreakMessage(res usecase.Result, displayName string) string {
-    t := i18n.GetTFunc("command-break")
-    msg := ""
-    for _, ev := range res.Events {
-        switch e := ev.(type) {
-        case usecase.BreakStarted:
-            seat := seatIDStr(e.SeatID, e.IsMemberSeat)
-            msg += t("break", displayName, e.WorkName, e.DurationMin, seat)
-        }
-    }
-    return msg
+	t := i18n.GetTFunc("command-break")
+	msg := ""
+	for _, ev := range res.Events {
+		switch e := ev.(type) {
+		case usecase.BreakStarted:
+			seat := seatIDStr(e.SeatID, e.IsMemberSeat)
+			msg += t("break", displayName, e.WorkName, e.DurationMin, seat)
+		}
+	}
+	return msg
 }
-
-

--- a/system/core/workspaceapp/presenter/change.go
+++ b/system/core/workspaceapp/presenter/change.go
@@ -1,14 +1,14 @@
 package presenter
 
 import (
-    "app.modules/core/i18n"
+	"app.modules/core/i18n"
 	"app.modules/core/workspaceapp/usecase"
 )
 
 // BuildChangeMessage converts Change usecase events into a localized response.
 func BuildChangeMessage(res usecase.Result, displayName string) string {
-    t := i18n.GetTFunc("command-change")
-    msg := i18n.T("common:sir", displayName)
+	t := i18n.GetTFunc("command-change")
+	msg := i18n.T("common:sir", displayName)
 	for _, event := range res.Events {
 		switch e := event.(type) {
 		case usecase.ChangeUpdatedWork:

--- a/system/core/workspaceapp/presenter/change.go
+++ b/system/core/workspaceapp/presenter/change.go
@@ -11,6 +11,8 @@ func BuildChangeMessage(res usecase.Result, displayName string) string {
 	msg := i18n.T("common:sir", displayName)
 	for _, event := range res.Events {
 		switch e := event.(type) {
+		case usecase.ChangeValidationError:
+			msg += e.Message
 		case usecase.ChangeUpdatedWork:
 			seat := seatIDStr(e.SeatID, e.IsMemberSeat)
 			msg += t("update-work", e.WorkName, seat)

--- a/system/core/workspaceapp/presenter/change.go
+++ b/system/core/workspaceapp/presenter/change.go
@@ -1,0 +1,33 @@
+package presenter
+
+import (
+    "app.modules/core/i18n"
+	"app.modules/core/workspaceapp/usecase"
+)
+
+// BuildChangeMessage converts Change usecase events into a localized response.
+func BuildChangeMessage(res usecase.Result, displayName string) string {
+    t := i18n.GetTFunc("command-change")
+    msg := i18n.T("common:sir", displayName)
+	for _, event := range res.Events {
+		switch e := event.(type) {
+		case usecase.ChangeUpdatedWork:
+			seat := seatIDStr(e.SeatID, e.IsMemberSeat)
+			msg += t("update-work", e.WorkName, seat)
+		case usecase.ChangeUpdatedBreak:
+			seat := seatIDStr(e.SeatID, e.IsMemberSeat)
+			msg += t("update-break", e.WorkName, seat)
+		case usecase.ChangeWorkDurationRejectedBefore:
+			msg += t("work-duration-before", e.RequestedMin, e.RealtimeEntryDurationMin, e.RemainingWorkMin)
+		case usecase.ChangeWorkDurationRejectedAfter:
+			msg += t("work-duration-after", e.MaxWorkTimeMin, e.RealtimeEntryDurationMin, e.RemainingWorkMin)
+		case usecase.ChangeWorkDurationUpdated:
+			msg += t("work-duration", e.RequestedMin, e.RealtimeEntryDurationMin, e.RemainingWorkMin)
+		case usecase.ChangeBreakDurationRejectedBefore:
+			msg += t("break-duration-before", e.RequestedMin, e.RealtimeBreakDurationMin, e.RemainingBreakMin)
+		case usecase.ChangeBreakDurationUpdated:
+			msg += t("break-duration", e.RequestedMin, e.RealtimeBreakDurationMin, e.RemainingBreakMin)
+		}
+	}
+	return msg
+}

--- a/system/core/workspaceapp/presenter/clear.go
+++ b/system/core/workspaceapp/presenter/clear.go
@@ -10,8 +10,8 @@ import (
 // Note: Clearはsir接頭辞なし（既存テスト準拠）
 func BuildClearMessage(res usecase.Result, displayName string) string {
 	msg := ""
-	for _, ev := range res.Events {
-		switch e := ev.(type) {
+	for _, event := range res.Events {
+		switch e := event.(type) {
 		case usecase.ClearEnterOnly:
 			msg += i18n.T("command:enter-only", displayName)
 		case usecase.ClearWork:

--- a/system/core/workspaceapp/presenter/clear.go
+++ b/system/core/workspaceapp/presenter/clear.go
@@ -1,0 +1,24 @@
+package presenter
+
+import (
+	"app.modules/core/i18n"
+	"app.modules/core/workspaceapp/usecase"
+)
+
+// BuildClearMessage converts Clear events into a localized response.
+// Namespace: others
+// Note: Clearはsir接頭辞なし（既存テスト準拠）
+func BuildClearMessage(res usecase.Result, displayName string) string {
+	msg := ""
+	for _, ev := range res.Events {
+		switch e := ev.(type) {
+		case usecase.ClearEnterOnly:
+			msg += i18n.T("command:enter-only", displayName)
+		case usecase.ClearWork:
+			msg += i18n.T("others:clear-work", displayName, e.SeatID)
+		case usecase.ClearBreak:
+			msg += i18n.T("others:clear-break", displayName, e.SeatID)
+		}
+	}
+	return msg
+}

--- a/system/core/workspaceapp/presenter/common.go
+++ b/system/core/workspaceapp/presenter/common.go
@@ -1,16 +1,14 @@
 package presenter
 
 import (
-    "strconv"
+	"strconv"
 
-    "app.modules/core/i18n"
+	"app.modules/core/i18n"
 )
 
 func seatIDStr(seatID int, isMemberSeat bool) string {
-    if isMemberSeat {
-        return i18n.T("common:vip-seat-id", seatID)
-    }
-    return strconv.Itoa(seatID)
+	if isMemberSeat {
+		return i18n.T("common:vip-seat-id", seatID)
+	}
+	return strconv.Itoa(seatID)
 }
-
-

--- a/system/core/workspaceapp/presenter/common.go
+++ b/system/core/workspaceapp/presenter/common.go
@@ -1,0 +1,16 @@
+package presenter
+
+import (
+    "strconv"
+
+    "app.modules/core/i18n"
+)
+
+func seatIDStr(seatID int, isMemberSeat bool) string {
+    if isMemberSeat {
+        return i18n.T("common:vip-seat-id", seatID)
+    }
+    return strconv.Itoa(seatID)
+}
+
+

--- a/system/core/workspaceapp/presenter/in.go
+++ b/system/core/workspaceapp/presenter/in.go
@@ -1,0 +1,41 @@
+package presenter
+
+import (
+	"strconv"
+
+	"app.modules/core/i18n"
+	"app.modules/core/workspaceapp/usecase"
+)
+
+// BuildInMessage converts In usecase result events into a localized response message.
+// t must be a localizer with namespace "command-in".
+func BuildInMessage(res usecase.Result, t i18n.TFuncType, displayName string) string {
+	msg := ""
+	for _, event := range res.Events {
+		switch e := event.(type) {
+		case usecase.OrderLimitExceeded:
+			msg += t("too-many-orders", e.MaxDailyOrderCount)
+		case usecase.MenuOrdered:
+			msg += t("ordered", e.MenuName, e.CountAfter)
+		case usecase.SeatMoved:
+			rpEarned := ""
+			if e.RankVisible && e.AddedRP != 0 {
+				rpEarned = i18n.T("command:rp-earned", e.AddedRP)
+			}
+			prevSeat := seatIDStr(e.FromSeatID, e.FromIsMemberSeat)
+			nextSeat := seatIDStr(e.ToSeatID, e.ToIsMemberSeat)
+			msg += t("seat-move", displayName, e.WorkName, prevSeat, nextSeat, e.WorkedTimeSec/60, rpEarned, e.UntilExitMin)
+		case usecase.SeatEntered:
+			seat := seatIDStr(e.SeatID, e.IsMemberSeat)
+			msg += t("start", displayName, e.WorkName, e.UntilExitMin, seat)
+		}
+	}
+	return msg
+}
+
+func seatIDStr(seatID int, isMemberSeat bool) string {
+	if isMemberSeat {
+		return i18n.T("common:vip-seat-id", seatID)
+	}
+	return strconv.Itoa(seatID)
+}

--- a/system/core/workspaceapp/presenter/in.go
+++ b/system/core/workspaceapp/presenter/in.go
@@ -1,15 +1,13 @@
 package presenter
 
 import (
-	"strconv"
-
 	"app.modules/core/i18n"
 	"app.modules/core/workspaceapp/usecase"
 )
 
 // BuildInMessage converts In usecase result events into a localized response message.
-// t must be a localizer with namespace "command-in".
-func BuildInMessage(res usecase.Result, t i18n.TFuncType, displayName string) string {
+func BuildInMessage(res usecase.Result, displayName string) string {
+	t := i18n.GetTFunc("command-in")
 	msg := ""
 	for _, event := range res.Events {
 		switch e := event.(type) {
@@ -31,11 +29,4 @@ func BuildInMessage(res usecase.Result, t i18n.TFuncType, displayName string) st
 		}
 	}
 	return msg
-}
-
-func seatIDStr(seatID int, isMemberSeat bool) string {
-	if isMemberSeat {
-		return i18n.T("common:vip-seat-id", seatID)
-	}
-	return strconv.Itoa(seatID)
 }

--- a/system/core/workspaceapp/presenter/more.go
+++ b/system/core/workspaceapp/presenter/more.go
@@ -1,30 +1,28 @@
 package presenter
 
 import (
-    "app.modules/core/i18n"
-    "app.modules/core/workspaceapp/usecase"
+	"app.modules/core/i18n"
+	"app.modules/core/workspaceapp/usecase"
 )
 
 // BuildMoreMessage converts More events into a localized response.
 // Namespace: command-more
 func BuildMoreMessage(res usecase.Result, displayName string) string {
-    t := i18n.GetTFunc("command-more")
-    msg := i18n.T("common:sir", displayName)
-    for _, ev := range res.Events {
-        switch e := ev.(type) {
-        case usecase.MoreMaxWork:
-            msg += t("max-work", e.MaxWorkTimeMin)
-        case usecase.MoreWorkExtended:
-            msg += t("reply-work", e.AddedMin)
-        case usecase.MoreMaxBreak:
-            msg += t("max-break", e.MaxBreakDurationMin)
-        case usecase.MoreBreakExtended:
-            msg += t("reply-break", e.AddedMin, e.RemainingBreakMin)
-        case usecase.MoreSummary:
-            msg += t("reply", e.RealtimeEnteredMin, e.RemainingUntilExitMin)
-        }
-    }
-    return msg
+	t := i18n.GetTFunc("command-more")
+	msg := i18n.T("common:sir", displayName)
+	for _, ev := range res.Events {
+		switch e := ev.(type) {
+		case usecase.MoreMaxWork:
+			msg += t("max-work", e.MaxWorkTimeMin)
+		case usecase.MoreWorkExtended:
+			msg += t("reply-work", e.AddedMin)
+		case usecase.MoreMaxBreak:
+			msg += t("max-break", e.MaxBreakDurationMin)
+		case usecase.MoreBreakExtended:
+			msg += t("reply-break", e.AddedMin, e.RemainingBreakMin)
+		case usecase.MoreSummary:
+			msg += t("reply", e.RealtimeEnteredMin, e.RemainingUntilExitMin)
+		}
+	}
+	return msg
 }
-
-

--- a/system/core/workspaceapp/presenter/more.go
+++ b/system/core/workspaceapp/presenter/more.go
@@ -1,0 +1,30 @@
+package presenter
+
+import (
+    "app.modules/core/i18n"
+    "app.modules/core/workspaceapp/usecase"
+)
+
+// BuildMoreMessage converts More events into a localized response.
+// Namespace: command-more
+func BuildMoreMessage(res usecase.Result, displayName string) string {
+    t := i18n.GetTFunc("command-more")
+    msg := i18n.T("common:sir", displayName)
+    for _, ev := range res.Events {
+        switch e := ev.(type) {
+        case usecase.MoreMaxWork:
+            msg += t("max-work", e.MaxWorkTimeMin)
+        case usecase.MoreWorkExtended:
+            msg += t("reply-work", e.AddedMin)
+        case usecase.MoreMaxBreak:
+            msg += t("max-break", e.MaxBreakDurationMin)
+        case usecase.MoreBreakExtended:
+            msg += t("reply-break", e.AddedMin, e.RemainingBreakMin)
+        case usecase.MoreSummary:
+            msg += t("reply", e.RealtimeEnteredMin, e.RemainingUntilExitMin)
+        }
+    }
+    return msg
+}
+
+

--- a/system/core/workspaceapp/presenter/more.go
+++ b/system/core/workspaceapp/presenter/more.go
@@ -10,8 +10,8 @@ import (
 func BuildMoreMessage(res usecase.Result, displayName string) string {
 	t := i18n.GetTFunc("command-more")
 	msg := i18n.T("common:sir", displayName)
-	for _, ev := range res.Events {
-		switch e := ev.(type) {
+	for _, event := range res.Events {
+		switch e := event.(type) {
 		case usecase.MoreMaxWork:
 			msg += t("max-work", e.MaxWorkTimeMin)
 		case usecase.MoreWorkExtended:

--- a/system/core/workspaceapp/presenter/order.go
+++ b/system/core/workspaceapp/presenter/order.go
@@ -11,8 +11,8 @@ import (
 func BuildOrderMessage(res usecase.Result, displayName string) string {
 	t := i18n.GetTFunc("command-order")
 	msg := ""
-	for _, ev := range res.Events {
-		switch e := ev.(type) {
+	for _, event := range res.Events {
+		switch e := event.(type) {
 		case usecase.OrderEnterOnly:
 			msg += i18n.T("command:enter-only", displayName)
 		case usecase.OrderTooMany:

--- a/system/core/workspaceapp/presenter/order.go
+++ b/system/core/workspaceapp/presenter/order.go
@@ -1,0 +1,27 @@
+package presenter
+
+import (
+	"app.modules/core/i18n"
+	"app.modules/core/workspaceapp/usecase"
+)
+
+// BuildOrderMessage converts Order events into a localized response.
+// Namespace: command-order
+// Note: Orderはsir接頭辞なし（既存テスト準拠）
+func BuildOrderMessage(res usecase.Result, displayName string) string {
+	t := i18n.GetTFunc("command-order")
+	msg := ""
+	for _, ev := range res.Events {
+		switch e := ev.(type) {
+		case usecase.OrderEnterOnly:
+			msg += i18n.T("command:enter-only", displayName)
+		case usecase.OrderTooMany:
+			msg += t("too-many-orders", displayName, e.MaxDailyOrderCount)
+		case usecase.OrderCleared:
+			msg += t("cleared", displayName)
+		case usecase.OrderOrdered:
+			msg += t("ordered", displayName, e.MenuName, e.CountAfter)
+		}
+	}
+	return msg
+}

--- a/system/core/workspaceapp/presenter/resume.go
+++ b/system/core/workspaceapp/presenter/resume.go
@@ -1,0 +1,24 @@
+package presenter
+
+import (
+	"app.modules/core/i18n"
+	"app.modules/core/workspaceapp/usecase"
+)
+
+// BuildResumeMessage converts Resume events into a localized response.
+// Namespace: command-resume
+// Note: Resumeはsir接頭辞なし（テスト準拠）
+func BuildResumeMessage(res usecase.Result, displayName string) string {
+	t := i18n.GetTFunc("command-resume")
+	msg := ""
+	for _, ev := range res.Events {
+		switch e := ev.(type) {
+		case usecase.ResumeBreakOnly:
+			msg += t("break-only", displayName)
+		case usecase.ResumeStarted:
+			seat := seatIDStr(e.SeatID, e.IsMemberSeat)
+			msg += t("work", displayName, seat, e.RemainingUntilExitMin)
+		}
+	}
+	return msg
+}

--- a/system/core/workspaceapp/presenter/resume.go
+++ b/system/core/workspaceapp/presenter/resume.go
@@ -11,8 +11,8 @@ import (
 func BuildResumeMessage(res usecase.Result, displayName string) string {
 	t := i18n.GetTFunc("command-resume")
 	msg := ""
-	for _, ev := range res.Events {
-		switch e := ev.(type) {
+	for _, event := range res.Events {
+		switch e := event.(type) {
 		case usecase.ResumeBreakOnly:
 			msg += t("break-only", displayName)
 		case usecase.ResumeStarted:

--- a/system/core/workspaceapp/usecase/events.go
+++ b/system/core/workspaceapp/usecase/events.go
@@ -48,60 +48,95 @@ func (OrderLimitExceeded) isEvent() {}
 // or rejections, and then formatted by presenter/change.go outside the tx.
 
 type ChangeUpdatedWork struct {
-    WorkName     string
-    SeatID       int
-    IsMemberSeat bool
+	WorkName     string
+	SeatID       int
+	IsMemberSeat bool
 }
 
 func (ChangeUpdatedWork) isEvent() {}
 
 type ChangeUpdatedBreak struct {
-    WorkName     string
-    SeatID       int
-    IsMemberSeat bool
+	WorkName     string
+	SeatID       int
+	IsMemberSeat bool
 }
 
 func (ChangeUpdatedBreak) isEvent() {}
 
 type ChangeWorkDurationRejectedBefore struct {
-    RequestedMin             int
-    RealtimeEntryDurationMin int
-    RemainingWorkMin         int
+	RequestedMin             int
+	RealtimeEntryDurationMin int
+	RemainingWorkMin         int
 }
 
 func (ChangeWorkDurationRejectedBefore) isEvent() {}
 
 type ChangeWorkDurationRejectedAfter struct {
-    MaxWorkTimeMin           int
-    RealtimeEntryDurationMin int
-    RemainingWorkMin         int
+	MaxWorkTimeMin           int
+	RealtimeEntryDurationMin int
+	RemainingWorkMin         int
 }
 
 func (ChangeWorkDurationRejectedAfter) isEvent() {}
 
 type ChangeWorkDurationUpdated struct {
-    RequestedMin             int
-    RealtimeEntryDurationMin int
-    RemainingWorkMin         int
+	RequestedMin             int
+	RealtimeEntryDurationMin int
+	RemainingWorkMin         int
 }
 
 func (ChangeWorkDurationUpdated) isEvent() {}
 
 type ChangeBreakDurationRejectedBefore struct {
-    RequestedMin              int
-    RealtimeBreakDurationMin  int
-    RemainingBreakMin         int
+	RequestedMin             int
+	RealtimeBreakDurationMin int
+	RemainingBreakMin        int
 }
 
 func (ChangeBreakDurationRejectedBefore) isEvent() {}
 
 type ChangeBreakDurationUpdated struct {
-    RequestedMin             int
-    RealtimeBreakDurationMin int
-    RemainingBreakMin        int
+	RequestedMin             int
+	RealtimeBreakDurationMin int
+	RemainingBreakMin        int
 }
 
 func (ChangeBreakDurationUpdated) isEvent() {}
+
+// ============ More usecase events ============
+// Events produced by the More handler.
+
+type MoreMaxWork struct {
+    MaxWorkTimeMin int
+}
+
+func (MoreMaxWork) isEvent() {}
+
+type MoreWorkExtended struct {
+    AddedMin int
+}
+
+func (MoreWorkExtended) isEvent() {}
+
+type MoreMaxBreak struct {
+    MaxBreakDurationMin int
+}
+
+func (MoreMaxBreak) isEvent() {}
+
+type MoreBreakExtended struct {
+    AddedMin           int
+    RemainingBreakMin  int
+}
+
+func (MoreBreakExtended) isEvent() {}
+
+type MoreSummary struct {
+    RealtimeEnteredMin      int
+    RemainingUntilExitMin   int
+}
+
+func (MoreSummary) isEvent() {}
 
 // Result aggregates events produced by a usecase execution.
 type Result struct {

--- a/system/core/workspaceapp/usecase/events.go
+++ b/system/core/workspaceapp/usecase/events.go
@@ -141,10 +141,10 @@ func (MoreSummary) isEvent() {}
 // ============ Break usecase events ============
 // Event produced when a break is successfully started.
 type BreakStarted struct {
-    SeatID       int
-    IsMemberSeat bool
-    WorkName     string
-    DurationMin  int
+	SeatID       int
+	IsMemberSeat bool
+	WorkName     string
+	DurationMin  int
 }
 
 func (BreakStarted) isEvent() {}

--- a/system/core/workspaceapp/usecase/events.go
+++ b/system/core/workspaceapp/usecase/events.go
@@ -43,6 +43,66 @@ type OrderLimitExceeded struct {
 
 func (OrderLimitExceeded) isEvent() {}
 
+// ============ Change usecase events ============
+// These events are used by the Change handler to describe state changes
+// or rejections, and then formatted by presenter/change.go outside the tx.
+
+type ChangeUpdatedWork struct {
+    WorkName     string
+    SeatID       int
+    IsMemberSeat bool
+}
+
+func (ChangeUpdatedWork) isEvent() {}
+
+type ChangeUpdatedBreak struct {
+    WorkName     string
+    SeatID       int
+    IsMemberSeat bool
+}
+
+func (ChangeUpdatedBreak) isEvent() {}
+
+type ChangeWorkDurationRejectedBefore struct {
+    RequestedMin             int
+    RealtimeEntryDurationMin int
+    RemainingWorkMin         int
+}
+
+func (ChangeWorkDurationRejectedBefore) isEvent() {}
+
+type ChangeWorkDurationRejectedAfter struct {
+    MaxWorkTimeMin           int
+    RealtimeEntryDurationMin int
+    RemainingWorkMin         int
+}
+
+func (ChangeWorkDurationRejectedAfter) isEvent() {}
+
+type ChangeWorkDurationUpdated struct {
+    RequestedMin             int
+    RealtimeEntryDurationMin int
+    RemainingWorkMin         int
+}
+
+func (ChangeWorkDurationUpdated) isEvent() {}
+
+type ChangeBreakDurationRejectedBefore struct {
+    RequestedMin              int
+    RealtimeBreakDurationMin  int
+    RemainingBreakMin         int
+}
+
+func (ChangeBreakDurationRejectedBefore) isEvent() {}
+
+type ChangeBreakDurationUpdated struct {
+    RequestedMin             int
+    RealtimeBreakDurationMin int
+    RemainingBreakMin        int
+}
+
+func (ChangeBreakDurationUpdated) isEvent() {}
+
 // Result aggregates events produced by a usecase execution.
 type Result struct {
 	Events []Event

--- a/system/core/workspaceapp/usecase/events.go
+++ b/system/core/workspaceapp/usecase/events.go
@@ -107,36 +107,47 @@ func (ChangeBreakDurationUpdated) isEvent() {}
 // Events produced by the More handler.
 
 type MoreMaxWork struct {
-    MaxWorkTimeMin int
+	MaxWorkTimeMin int
 }
 
 func (MoreMaxWork) isEvent() {}
 
 type MoreWorkExtended struct {
-    AddedMin int
+	AddedMin int
 }
 
 func (MoreWorkExtended) isEvent() {}
 
 type MoreMaxBreak struct {
-    MaxBreakDurationMin int
+	MaxBreakDurationMin int
 }
 
 func (MoreMaxBreak) isEvent() {}
 
 type MoreBreakExtended struct {
-    AddedMin           int
-    RemainingBreakMin  int
+	AddedMin          int
+	RemainingBreakMin int
 }
 
 func (MoreBreakExtended) isEvent() {}
 
 type MoreSummary struct {
-    RealtimeEnteredMin      int
-    RemainingUntilExitMin   int
+	RealtimeEnteredMin    int
+	RemainingUntilExitMin int
 }
 
 func (MoreSummary) isEvent() {}
+
+// ============ Break usecase events ============
+// Event produced when a break is successfully started.
+type BreakStarted struct {
+    SeatID       int
+    IsMemberSeat bool
+    WorkName     string
+    DurationMin  int
+}
+
+func (BreakStarted) isEvent() {}
 
 // Result aggregates events produced by a usecase execution.
 type Result struct {

--- a/system/core/workspaceapp/usecase/events.go
+++ b/system/core/workspaceapp/usecase/events.go
@@ -1,0 +1,54 @@
+package usecase
+
+// Event is a marker interface for usecase events.
+type Event interface{ isEvent() }
+
+// SeatMoved represents that a user moved seats.
+type SeatMoved struct {
+	FromSeatID       int
+	FromIsMemberSeat bool
+	ToSeatID         int
+	ToIsMemberSeat   bool
+	WorkName         string
+	WorkedTimeSec    int
+	AddedRP          int
+	RankVisible      bool
+	UntilExitMin     int
+}
+
+func (SeatMoved) isEvent() {}
+
+// SeatEntered represents that a user entered a seat.
+type SeatEntered struct {
+	SeatID       int
+	IsMemberSeat bool
+	WorkName     string
+	UntilExitMin int
+}
+
+func (SeatEntered) isEvent() {}
+
+// MenuOrdered represents that a user ordered a menu item.
+type MenuOrdered struct {
+	MenuName   string
+	CountAfter int64
+}
+
+func (MenuOrdered) isEvent() {}
+
+// OrderLimitExceeded represents that order count exceeded the daily limit.
+type OrderLimitExceeded struct {
+	MaxDailyOrderCount int
+}
+
+func (OrderLimitExceeded) isEvent() {}
+
+// Result aggregates events produced by a usecase execution.
+type Result struct {
+	Events []Event
+}
+
+// Add appends an event to the result.
+func (r *Result) Add(e Event) {
+	r.Events = append(r.Events, e)
+}

--- a/system/core/workspaceapp/usecase/events.go
+++ b/system/core/workspaceapp/usecase/events.go
@@ -168,6 +168,19 @@ type BreakWarn struct {
 
 func (BreakWarn) isEvent() {}
 
+// ============ Resume usecase events ============
+type ResumeBreakOnly struct{}
+
+func (ResumeBreakOnly) isEvent() {}
+
+type ResumeStarted struct {
+	SeatID                int
+	IsMemberSeat          bool
+	RemainingUntilExitMin int
+}
+
+func (ResumeStarted) isEvent() {}
+
 // Result aggregates events produced by a usecase execution.
 type Result struct {
 	Events []Event

--- a/system/core/workspaceapp/usecase/events.go
+++ b/system/core/workspaceapp/usecase/events.go
@@ -181,6 +181,45 @@ type ResumeStarted struct {
 
 func (ResumeStarted) isEvent() {}
 
+// ============ Order usecase events ============
+type OrderEnterOnly struct{}
+
+func (OrderEnterOnly) isEvent() {}
+
+type OrderTooMany struct {
+	MaxDailyOrderCount int
+}
+
+func (OrderTooMany) isEvent() {}
+
+type OrderCleared struct{}
+
+func (OrderCleared) isEvent() {}
+
+type OrderOrdered struct {
+	MenuName   string
+	CountAfter int64
+}
+
+func (OrderOrdered) isEvent() {}
+
+// ============ Clear usecase events ============
+type ClearEnterOnly struct{}
+
+func (ClearEnterOnly) isEvent() {}
+
+type ClearWork struct {
+	SeatID int
+}
+
+func (ClearWork) isEvent() {}
+
+type ClearBreak struct {
+	SeatID int
+}
+
+func (ClearBreak) isEvent() {}
+
 // Result aggregates events produced by a usecase execution.
 type Result struct {
 	Events []Event

--- a/system/core/workspaceapp/usecase/events.go
+++ b/system/core/workspaceapp/usecase/events.go
@@ -103,6 +103,13 @@ type ChangeBreakDurationUpdated struct {
 
 func (ChangeBreakDurationUpdated) isEvent() {}
 
+// Validation error occurred in Change usecase (message already localized)
+type ChangeValidationError struct {
+	Message string
+}
+
+func (ChangeValidationError) isEvent() {}
+
 // ============ More usecase events ============
 // Events produced by the More handler.
 
@@ -148,6 +155,18 @@ type BreakStarted struct {
 }
 
 func (BreakStarted) isEvent() {}
+
+// Early-return reasons for Break
+type BreakWorkOnly struct{}
+
+func (BreakWorkOnly) isEvent() {}
+
+type BreakWarn struct {
+	MinBreakIntervalMin int
+	CurrentWorkedMin    int
+}
+
+func (BreakWarn) isEvent() {}
 
 // Result aggregates events produced by a usecase execution.
 type Result struct {


### PR DESCRIPTION
# PR: 返信文生成のPresenter化とイベント導入（Tx外）

## 概要
- コマンド処理で生成していた返信文を Presenter に集約し、Tx 外で組み立てるように変更
- ユースケースの結果をイベントとして表現し、Tx 内では「状態確定（読み取り→判定→書き込み）」に限定
- 既存の文面・順序・sir 接頭辞の仕様は維持し、全テストを通過

比較: [refactor-#519...refactor-520](https://github.com/kani3camp/youtube-study-space/compare/refactor-%23519...refactor-520?expand=1)

## 変更点（主なポイント）
- usecase/events.go:
  - In/Change/More/Break/Resume/Order/Clear 用のイベント型を追加
  - 例: `SeatEntered`, `SeatMoved`, `OrderOrdered`, `ChangeValidationError`, `BreakWarn`, `ResumeStarted` など
- presenter/* 新規追加:
  - `presenter/in.go`, `presenter/change.go`, `presenter/more.go`, `presenter/break.go`, `presenter/resume.go`, `presenter/order.go`, `presenter/clear.go`
  - `presenter/common.go`: `seatIDStr` を共通化
  - Presenter 側で `i18n.GetTFunc(...)` を内部取得（TFunc の引数受け渡しを廃止）
- command_seat.go:
  - 各コマンド（In/Change/More/Break/Resume/Order/Clear）で文字列連結を排し、イベントを積み上げるように統一
  - Tx 外で対応する Presenter によって返信文を生成
  - 早期リターン系（enter-only / work-only / warn / validation error など）も段階的にイベント化（Phase 1 完了）

## 互換性と仕様の維持
- 文面の厳密一致（テスト準拠）
  - sir 接頭辞の有無と順序は既存仕様通り
    - sir あり: Change / More / In
    - sir なし: Break / Resume / Order / Clear
  - Change の文面は「更新メッセージ→時間系メッセージ」の順序を維持
- i18n キー・名前空間は既存を踏襲

## テスト
- 実行: `go test ./...`
- 結果: 全パッケージ PASS（workspaceapp 含む）

## リスク・影響
- Tx 内の副作用（DB 書き込み）と Tx 外の返信文生成を分離したのみで、ビジネスロジックの挙動は変えていません
- 既存の i18n 文面・順序・sir の振る舞いは維持
- 変更範囲は `workspaceapp` 配下に限定（infra など他層には非侵襲）

## 移行手順
- 追加の作業は不要。マージ後も既存の運用フローでそのまま動作します

## 今後の展開（任意）
- 共通イベント（例: EnterOnly）を横断で整理
- Clock/Now を全ユースケースで注入する構成への移行
- `workspaceapp` の責務分割（ports/usecase/domain/presenter/infra へのファイル配置の明確化）
