### PR TITLE
PR10: Fargate日次バッチの冪等化・失敗継続・単発実行追加

### DIFF
--- a/aws-cdk/lib/aws-cdk-stack.ts
+++ b/aws-cdk/lib/aws-cdk-stack.ts
@@ -453,7 +453,6 @@ export class AwsCdkStack extends cdk.Stack {
       },
     });
     startDailyBatchFunction.grantInvoke(schedulerRole);
-    // [NOTE FOR REVIEW] Grant permission to start the SFN execution without relying on role casting
     dailyBatchStateMachine.grantStartExecution(startDailyBatchFunction);
 
     new scheduler.CfnSchedule(this, 'DailyBatchScheduler', {

--- a/aws-cdk/lib/aws-cdk-stack.ts
+++ b/aws-cdk/lib/aws-cdk-stack.ts
@@ -313,7 +313,7 @@ export class AwsCdkStack extends cdk.Stack {
       this,
       'daily-batch-sfn',
       {
-        definition: definition,
+        definitionBody: sfn.DefinitionBody.fromChainable(definition),
         tracingEnabled: false,
         logs: {
           destination: new logs.LogGroup(this, 'DailyBatchSfnLogs', {
@@ -360,7 +360,7 @@ export class AwsCdkStack extends cdk.Stack {
     });
     const manualResetDefinition = manualResetDailyTotalTask.addCatch(manualResetNotify, { resultPath: sfn.JsonPath.DISCARD });
     const manualResetDailyTotalSfn = new sfn.StateMachine(this, 'manual-reset-daily-total-sfn', {
-      definition: manualResetDefinition,
+      definitionBody: sfn.DefinitionBody.fromChainable(manualResetDefinition),
       tracingEnabled: false,
       logs: {
         destination: new logs.LogGroup(this, 'ManualResetDailyTotalSfnLogs', {
@@ -389,7 +389,7 @@ export class AwsCdkStack extends cdk.Stack {
     });
     const manualUpdateDefinition = manualUpdateRpTask.addCatch(manualUpdateNotify, { resultPath: sfn.JsonPath.DISCARD });
     const manualUpdateRpSfn = new sfn.StateMachine(this, 'manual-update-rp-sfn', {
-      definition: manualUpdateDefinition,
+      definitionBody: sfn.DefinitionBody.fromChainable(manualUpdateDefinition),
       tracingEnabled: false,
       logs: {
         destination: new logs.LogGroup(this, 'ManualUpdateRpSfnLogs', {
@@ -418,7 +418,7 @@ export class AwsCdkStack extends cdk.Stack {
     });
     const manualTransferDefinition = manualTransferBqTask.addCatch(manualTransferNotify, { resultPath: sfn.JsonPath.DISCARD });
     const manualTransferBqSfn = new sfn.StateMachine(this, 'manual-transfer-bq-sfn', {
-      definition: manualTransferDefinition,
+      definitionBody: sfn.DefinitionBody.fromChainable(manualTransferDefinition),
       tracingEnabled: false,
       logs: {
         destination: new logs.LogGroup(this, 'ManualTransferBqSfnLogs', {

--- a/aws-cdk/lib/aws-cdk-stack.ts
+++ b/aws-cdk/lib/aws-cdk-stack.ts
@@ -453,11 +453,8 @@ export class AwsCdkStack extends cdk.Stack {
       },
     });
     startDailyBatchFunction.grantInvoke(schedulerRole);
-    (startDailyBatchFunction.role as iam.Role).addToPolicy(new iam.PolicyStatement({
-      actions: ['states:StartExecution'],
-      effect: iam.Effect.ALLOW,
-      resources: [dailyBatchStateMachine.stateMachineArn],
-    }));
+    // [NOTE FOR REVIEW] Grant permission to start the SFN execution without relying on role casting
+    dailyBatchStateMachine.grantStartExecution(startDailyBatchFunction);
 
     new scheduler.CfnSchedule(this, 'DailyBatchScheduler', {
       flexibleTimeWindow: { mode: 'OFF' },

--- a/system/Dockerfile.lambda
+++ b/system/Dockerfile.lambda
@@ -7,6 +7,7 @@ RUN --mount=type=cache,target="/root/.cache/go-build" go build -tags lambda.norp
 RUN --mount=type=cache,target="/root/.cache/go-build" go build -tags lambda.norpc -o youtube_organize_database aws-lambda/youtube_organize_database/main.go
 RUN --mount=type=cache,target="/root/.cache/go-build" go build -tags lambda.norpc -o check_live_stream_status aws-lambda/check_live_stream_status/main.go
 RUN --mount=type=cache,target="/root/.cache/go-build" go build -tags lambda.norpc -o sns_notify_discord aws-lambda/sns_notify_discord/main.go
+RUN --mount=type=cache,target="/root/.cache/go-build" go build -tags lambda.norpc -o start_daily_batch aws-lambda/start_daily_batch/main.go
 
 # Copy artifacts to a clean image
 FROM public.ecr.aws/lambda/provided:al2023
@@ -16,3 +17,4 @@ COPY --from=build /var/task/set_desired_max_seats ./set_desired_max_seats
 COPY --from=build /var/task/youtube_organize_database ./youtube_organize_database
 COPY --from=build /var/task/check_live_stream_status ./check_live_stream_status
 COPY --from=build /var/task/sns_notify_discord ./sns_notify_discord
+COPY --from=build /var/task/start_daily_batch ./start_daily_batch

--- a/system/aws-lambda/start_daily_batch/main.go
+++ b/system/aws-lambda/start_daily_batch/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/aws/aws-lambda-go/lambda"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	sfn "github.com/aws/aws-sdk-go/service/stepfunctions"
+)
+
+func handler(ctx context.Context) error {
+	stateMachineArn := os.Getenv("STATE_MACHINE_ARN")
+	if stateMachineArn == "" {
+		return fmt.Errorf("STATE_MACHINE_ARN is not set")
+	}
+
+	region := os.Getenv("AWS_REGION")
+	if region == "" {
+		region = os.Getenv("AWS_DEFAULT_REGION")
+	}
+	if region == "" {
+		return fmt.Errorf("AWS region is not set")
+	}
+
+	// Build idempotent execution name based on JST date
+	jst := time.FixedZone("JST", 9*60*60)
+	today := time.Now().In(jst).Format("20060102")
+	execName := fmt.Sprintf("daily-batch-%s", today)
+
+	sess := session.Must(session.NewSession())
+	client := sfn.New(sess, aws.NewConfig().WithRegion(region))
+
+	input := "{}"
+	_, err := client.StartExecutionWithContext(ctx, &sfn.StartExecutionInput{
+		StateMachineArn: aws.String(stateMachineArn),
+		Name:            aws.String(execName),
+		Input:           aws.String(input),
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "failed to start state machine execution", "name", execName, "err", err)
+		return err
+	}
+	slog.InfoContext(ctx, "started state machine execution", "name", execName)
+	return nil
+}
+
+func main() {
+	lambda.Start(handler)
+}

--- a/system/aws-lambda/start_daily_batch/main.go
+++ b/system/aws-lambda/start_daily_batch/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
-	sfn "github.com/aws/aws-sdk-go/service/stepfunctions"
+	sfn "github.com/aws/aws-sdk-go/service/sfn"
 )
 
 func handler(ctx context.Context) error {


### PR DESCRIPTION
- Step Functions: 各タスク個別catchで失敗しても続行しSNS通知\n- EventBridge Scheduler → start_daily_batch Lambda → daily-batch-sfn（実行名=JST日付で冪等）\n- manual-batch-sfn（Input.jobで単発実行: reset-daily-total|update-rp|transfer-bq）\n- 旧EventBridge Ruleの直接起動を削除（Schedulerに置換）\n\n確認観点:\n- cdk synth OK\n- 既存LambdaのCloudWatch Errors>0 アラームはSNSへ通知\n- FargateはPublic Subnet/最小egress/Container Insights有効\n