### PR TITLE
check_live_stream_statusのタイムアウト秒数を10から20へ変更

### DIFF
--- a/aws-cdk/lib/aws-cdk-stack.ts
+++ b/aws-cdk/lib/aws-cdk-stack.ts
@@ -542,7 +542,7 @@ export class AwsCdkStack extends cdk.Stack {
             entrypoint: ['/app/check_live_stream_status'],
           }
         ),
-        timeout: cdk.Duration.seconds(10),
+        timeout: cdk.Duration.seconds(20),
         reservedConcurrentExecutions: undefined,
       }
     );


### PR DESCRIPTION
This pull request makes a minor adjustment to the AWS Lambda function configuration in `aws-cdk/lib/aws-cdk-stack.ts`. The timeout for the Lambda function has been increased from 10 seconds to 20 seconds to allow more time for execution.