### PR TITLE
update youtube-monitor: TickerBoardのマルキー速度を100から85に変更

### DIFF
--- a/youtube-monitor/src/components/TickerBoard.tsx
+++ b/youtube-monitor/src/components/TickerBoard.tsx
@@ -17,7 +17,7 @@ const TickerBoard: FC<Props> = ({ workNameTrend }) => {
 			<div css={styles.container}>
 				<Marquee
 					css={styles.marquee}
-					speed={100}
+					speed={85}
 					pauseOnHover
 					autoFill
 					gradient={false}


### PR DESCRIPTION
アンケートの結果、少しだけ作業トレンドの文字の流れるスピードを遅くしてみる。
<img width="530" height="206" alt="image" src="https://github.com/user-attachments/assets/0414af08-322c-4934-8342-2eec7320aa6c" />
