### PR TITLE
AIレスポンスのnoteレスポンス削除

### DIFF
--- a/system/core/repository/models.go
+++ b/system/core/repository/models.go
@@ -221,5 +221,4 @@ type WorkNameTrendRanking struct {
 	Genre    string   `json:"genre" firestore:"genre"`
 	Count    int      `json:"count" firestore:"count"`
 	Examples []string `json:"examples" firestore:"examples"`
-	Note     string   `json:"note" firestore:"note"`
 }

--- a/system/core/workspaceapp/work_name_trend.go
+++ b/system/core/workspaceapp/work_name_trend.go
@@ -98,12 +98,8 @@ func (app *WorkspaceApp) UpdateWorkNameTrend(ctx context.Context, apiKey string)
 												"description": "作業項目名",
 											},
 										},
-										"note": map[string]interface{}{
-											"type":        "string",
-											"description": "備考",
-										},
 									},
-									"required":             []string{"rank", "genre", "count", "examples", "note"},
+									"required":             []string{"rank", "genre", "count", "examples"},
 									"additionalProperties": false,
 								},
 								"minItems": 0,

--- a/youtube-monitor/src/types/api.d.ts
+++ b/youtube-monitor/src/types/api.d.ts
@@ -41,7 +41,6 @@ export type WorkNameTrend = {
 		genre: string
 		count: number
 		examples: string[]
-		note: string
 	}[]
 	ranked_at: Timestamp
 }


### PR DESCRIPTION
This pull request makes a minor adjustment to the schema definition for work name trend items by removing the `note` field from both the schema properties and the list of required fields. This simplifies the schema and ensures only the relevant fields are enforced as required.

- Schema simplification:
  * Removed the `note` property from the schema and updated the `required` list to exclude `note` in `work_name_trend.go`.