### PR TITLE
security: restrict public reads of Firestore config

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -15,9 +15,13 @@ service cloud.firestore {
     	allow write: if false;
     }
     
-    match /config/{doc} {
+    match /config/constants {
     	allow read: if true;
       allow write: if false;
+    }
+
+    match /config/{doc} {
+    	allow read, write: if false;
     }
 
     match /menu/{doc} {


### PR DESCRIPTION
## 概要

Firestore の `config` collection 全体が anonymous client から read 可能になっており、Go server側が同じ collection の `credentials` document に保存しているBot tokenやOAuth secret/refresh token等がClient SDKから公開され得る状態でした。

このPRでは、緊急対応としてFirestore Rulesだけを最小変更し、公開範囲を修正します。

## 変更内容

- `config/constants` は従来どおり anonymous client からread可能
- `config/constants` のwriteは禁止
- `config/{doc}` のデフォルトread/writeをdeny
- これにより `config/credentials` と将来追加されるその他のconfig documentをClient SDKから遮断
- `seats`、`member-seats`、`menu`、`work-name-trend` の公開範囲は変更なし
- `youtube-monitor`、Go Repository、credential保存方式には変更なし

## 互換性・影響

`config/constants` のread契約は維持しています。GoのFirestore server clientはFirebase Security Rulesとは別の認可経路を使用するため、Go server側への影響はない想定です。

## 検証

- Firestore Rulesの変更差分を確認（変更ファイルは `firebase/firestore.rules` のみ）
- `config/constants` のanonymous read許可、`config/{doc}` のdeny、既存公開collectionの不変を静的検証
- 既存CIを実行
- 既存のFirestore Emulator integration testはGo server clientを使用するため、Security Rules専用テストではありません

Security Rules専用のClient SDK/Firestore Emulatorテスト基盤は後続PRで追加します。

## 別途判断する事項

今回のコード変更は公開範囲の遮断に限定しています。既に公開された可能性があるcredentialのrotationは、コード変更とは別途判断・実施します。
