### PR TITLE
feat: add public monitor config boundary

### DIFF
--- a/firebase/PUBLIC_CONFIG_MIGRATION.md
+++ b/firebase/PUBLIC_CONFIG_MIGRATION.md
@@ -1,0 +1,48 @@
+# Firestore public monitor config migration
+
+`public-config/monitor`はyoutube-monitorへ公開する唯一のconfig documentです。次の5フィールドだけを保持します。
+
+- `max-seats`
+- `member-max-seats`
+- `min-vacancy-rate`
+- `youtube-membership-enabled`
+- `fixed-max-seats-enabled`
+
+`desired-max-seats`、`desired-member-max-seats`などのbackend専用設定は`config/constants`に残します。
+
+## PR Bの本番反映手順
+
+本番には`config/constants`しか存在しない前提で、次の順序を守ります。CodexやCIから本番dataは変更しません。
+
+1. PR Aを反映し、Rules専用CIがgreenであることを確認します。
+2. PR Bの`firebase/firestore.rules`だけを先にdeployし、`public-config/monitor`のanonymous read／client write denyを有効にします。
+
+   ```bash
+   firebase deploy --config firebase/firebase.json --project <production-project-id> --only firestore:rules
+   ```
+
+3. production用のGoogle Cloud認証情報とproject IDを確認し、まずpreviewを実行します。この操作はread onlyです。
+
+   ```bash
+   cd system
+   go run ./cmd/bootstrap-public-monitor-config --project-id <production-project-id>
+   ```
+
+   ADCを使わない場合だけ`--credentials-file <path>`を追加します。
+
+4. previewのproject IDと5値を既存`config/constants`と照合後、`--apply`を付けて再実行し、表示されたproject IDを入力します。
+
+   ```bash
+   go run ./cmd/bootstrap-public-monitor-config --project-id <production-project-id> --apply
+   ```
+
+   このcommandはFirestoreのcreateだけを使うため、既存の`public-config/monitor`を上書きしません。
+
+5. Firebase Consoleまたはserver clientで、target documentが上記5フィールドだけを持つことを確認します。
+6. PR Bのbackendをdeployします。通常の最大席数更新は以後`public-config/monitor`だけを書き換えます。`config/constants`側の旧5フィールドはmigration fallback用に残りますが、新正本としては読みません。
+7. PR Cのyoutube-monitorをdeployし、horizontal／vertical双方の表示とrealtime updateを確認します。
+8. 旧monitor buildが残っていないことを確認してからPR DのRulesをdeployし、`config/*`を完全非公開化します。
+
+## Rollback
+
+PR BまたはPR Cまでのrollbackでは`config/constants`のpublic readを維持しているため、旧monitor buildへ戻せます。`public-config/monitor`は削除せず、新backendをrollbackした場合は必要に応じて5値を`config/constants`へ手動で戻します。PR Dをdeployした後に旧monitorへrollbackする場合は、先にPR DのRulesをrollbackしないと旧buildがconfigを読めません。

--- a/firebase/README.md
+++ b/firebase/README.md
@@ -15,6 +15,8 @@ bash .github/scripts/run-firestore-integration-tests.sh
 
 どちらもFirestore Emulatorだけを起動するため、実在するFirebaseプロジェクトや認証情報は不要です。Rulesテストは`@firebase/rules-unit-testing`を使い、Goテストは`-tags=integration`を付けて実行します。通常の`cd system && go test -shuffle=on -v ./...`では、integrationタグ付きテストは実行されません。
 
+`public-config/monitor`の本番bootstrapとStacked PRのdeploy順序は[PUBLIC_CONFIG_MIGRATION.md](./PUBLIC_CONFIG_MIGRATION.md)を参照してください。
+
 ## 前提条件
 - Node.jsがインストールされていること
 - npmがインストールされていること

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -24,6 +24,11 @@ service cloud.firestore {
     	allow read, write: if false;
     }
 
+    match /public-config/monitor {
+      allow read: if true;
+      allow write: if false;
+    }
+
     match /menu/{doc} {
       allow read: if true;
       allow write: if false;

--- a/firebase/firestore.rules.test.mjs
+++ b/firebase/firestore.rules.test.mjs
@@ -29,6 +29,7 @@ beforeEach(async () => {
 		for (const path of [
 			'config/constants',
 			'config/credentials',
+			'public-config/monitor',
 			'seats/1',
 			'member-seats/1',
 			'menu/default',
@@ -53,6 +54,7 @@ const anonymousFirestore = () =>
 describe('public documents', () => {
 	for (const path of [
 		'config/constants',
+		'public-config/monitor',
 		'seats/1',
 		'member-seats/1',
 		'menu/default',

--- a/system/cmd/bootstrap-public-monitor-config/main.go
+++ b/system/cmd/bootstrap-public-monitor-config/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"app.modules/core/repository"
+
+	"google.golang.org/api/option"
+)
+
+func main() {
+	if err := run(context.Background(), os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "bootstrap public monitor config: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args []string) error {
+	flags := flag.NewFlagSet("bootstrap-public-monitor-config", flag.ContinueOnError)
+	projectID := flags.String("project-id", "", "required Google Cloud project ID")
+	credentialsFile := flags.String("credentials-file", "", "optional service account credential file; defaults to ADC")
+	apply := flags.Bool("apply", false, "create public-config/monitor after an interactive project confirmation")
+	if err := flags.Parse(args); err != nil {
+		return fmt.Errorf("parse flags: %w", err)
+	}
+	if *projectID == "" {
+		return errors.New("--project-id is required")
+	}
+
+	clientOptions := make([]option.ClientOption, 0, 1)
+	if *credentialsFile != "" {
+		//nolint:staticcheck // This operator-only migration command accepts an explicit credential file by design.
+		clientOptions = append(clientOptions, option.WithCredentialsFile(*credentialsFile))
+	}
+	controller, err := repository.NewFirestoreControllerForProject(ctx, *projectID, clientOptions...)
+	if err != nil {
+		return fmt.Errorf("create Firestore client for project %q: %w", *projectID, err)
+	}
+	defer func() {
+		if closeErr := controller.FirestoreClient().Close(); closeErr != nil {
+			fmt.Fprintf(os.Stderr, "close Firestore client: %v\n", closeErr)
+		}
+	}()
+
+	monitorConfig, err := controller.PrepareMonitorPublicConfigBootstrap(ctx)
+	if err != nil {
+		return fmt.Errorf("prepare migration preview: %w", err)
+	}
+	preview, err := json.MarshalIndent(monitorConfig, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode migration preview: %w", err)
+	}
+	fmt.Printf("Project: %s\nTarget: public-config/monitor\n%s\n", *projectID, preview)
+
+	if !*apply {
+		fmt.Println("Preview only. Re-run with --apply to create the document.")
+		return nil
+	}
+
+	fmt.Printf("Type the project ID %q to confirm: ", *projectID)
+	var confirmation string
+	if _, err := fmt.Scanln(&confirmation); err != nil {
+		return fmt.Errorf("read project confirmation: %w", err)
+	}
+	if confirmation != *projectID {
+		return errors.New("project confirmation did not match; no data was written")
+	}
+	if err := controller.CreateMonitorPublicConfig(ctx, monitorConfig); err != nil {
+		return fmt.Errorf("persist migration: %w", err)
+	}
+	fmt.Println("Created public-config/monitor. Existing documents are never overwritten by this command.")
+	return nil
+}

--- a/system/core/repository/constants.go
+++ b/system/core/repository/constants.go
@@ -2,6 +2,7 @@ package repository
 
 const ( // TODO: ~~CollectionName, DocProperty~~に変更
 	CONFIG                    = "config"
+	PublicConfig              = "public-config"
 	SEATS                     = "seats"
 	MemberSeats               = "member-seats"
 	USERS                     = "users"
@@ -18,6 +19,7 @@ const ( // TODO: ~~CollectionName, DocProperty~~に変更
 
 	CredentialsConfigDocName     = "credentials"
 	SystemConstantsConfigDocName = "constants"
+	MonitorPublicConfigDocName   = "monitor"
 	WorkNameTrendDocName         = "work-name-trend"
 
 	PublishedAtDocProperty = "published-at"
@@ -42,6 +44,9 @@ const ( // TODO: ~~CollectionName, DocProperty~~に変更
 	DesiredMemberMaxSeatsDocProperty                 = "desired-member-max-seats"
 	MaxSeatsDocProperty                              = "max-seats"
 	MemberMaxSeatsDocProperty                        = "member-max-seats"
+	MinVacancyRateDocProperty                        = "min-vacancy-rate"
+	YoutubeMembershipEnabledDocProperty              = "youtube-membership-enabled"
+	FixedMaxSeatsEnabledDocProperty                  = "fixed-max-seats-enabled"
 	LastResetDailyTotalStudySecDocProperty           = "last-reset-daily-total-study-sec"
 	LastTransferCollectionHistoryBigqueryDocProperty = "last-transfer-collection-history-bigquery"
 	LastLongTimeSittingCheckedDocProperty            = "last-long-time-sitting-checked"

--- a/system/core/repository/firestore_controller.go
+++ b/system/core/repository/firestore_controller.go
@@ -21,7 +21,11 @@ type FirestoreControllerImplements struct {
 }
 
 func NewFirestoreController(ctx context.Context, clientOption option.ClientOption) (*FirestoreControllerImplements, error) {
-	client, err := firestore.NewClient(ctx, firestore.DetectProjectID, clientOption)
+	return NewFirestoreControllerForProject(ctx, firestore.DetectProjectID, clientOption)
+}
+
+func NewFirestoreControllerForProject(ctx context.Context, projectID string, clientOptions ...option.ClientOption) (*FirestoreControllerImplements, error) {
+	client, err := firestore.NewClient(ctx, projectID, clientOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("in firestore.NewClient: %w", err)
 	}
@@ -111,6 +115,10 @@ func (c *FirestoreControllerImplements) configCollection() *firestore.Collection
 	return c.firestoreClient.Collection(CONFIG)
 }
 
+func (c *FirestoreControllerImplements) publicConfigCollection() *firestore.CollectionRef {
+	return c.firestoreClient.Collection(PublicConfig)
+}
+
 func (c *FirestoreControllerImplements) usersCollection() *firestore.CollectionRef {
 	return c.firestoreClient.Collection(USERS)
 }
@@ -191,6 +199,25 @@ func (c *FirestoreControllerImplements) ReadCredentialsConfig(ctx context.Contex
 }
 
 func (c *FirestoreControllerImplements) ReadSystemConstantsConfig(ctx context.Context, tx *firestore.Transaction) (ConstantsConfigDoc, error) {
+	constantsConfig, err := c.readInternalSystemConstantsConfig(ctx, tx)
+	if err != nil {
+		return ConstantsConfigDoc{}, err
+	}
+
+	monitorConfig, err := c.readMonitorPublicConfig(ctx, tx)
+	if err != nil {
+		// Temporary migration fallback: production initially has only config/constants.
+		// Remove this after public-config/monitor has been bootstrapped everywhere.
+		if status.Code(err) == codes.NotFound {
+			return constantsConfig, nil
+		}
+		return ConstantsConfigDoc{}, fmt.Errorf("read monitor public config: %w", err)
+	}
+	monitorConfig.applyTo(&constantsConfig)
+	return constantsConfig, nil
+}
+
+func (c *FirestoreControllerImplements) readInternalSystemConstantsConfig(ctx context.Context, tx *firestore.Transaction) (ConstantsConfigDoc, error) {
 	ref := c.configCollection().Doc(SystemConstantsConfigDocName)
 	doc, err := c.get(ctx, tx, ref)
 	if err != nil {
@@ -201,6 +228,38 @@ func (c *FirestoreControllerImplements) ReadSystemConstantsConfig(ctx context.Co
 		return ConstantsConfigDoc{}, fmt.Errorf("in doc.DataTo: %w", err)
 	}
 	return constantsConfig, nil
+}
+
+func (c *FirestoreControllerImplements) readMonitorPublicConfig(ctx context.Context, tx *firestore.Transaction) (MonitorPublicConfigDoc, error) {
+	ref := c.publicConfigCollection().Doc(MonitorPublicConfigDocName)
+	doc, err := c.get(ctx, tx, ref)
+	if err != nil {
+		return MonitorPublicConfigDoc{}, err
+	}
+	var monitorConfig MonitorPublicConfigDoc
+	if err := doc.DataTo(&monitorConfig); err != nil {
+		return MonitorPublicConfigDoc{}, fmt.Errorf("decode monitor public config: %w", err)
+	}
+	return monitorConfig, nil
+}
+
+// PrepareMonitorPublicConfigBootstrap reads the five legacy values from config/constants.
+// It intentionally does not write any data; CreateMonitorPublicConfig performs the guarded create.
+func (c *FirestoreControllerImplements) PrepareMonitorPublicConfigBootstrap(ctx context.Context) (MonitorPublicConfigDoc, error) {
+	constants, err := c.readInternalSystemConstantsConfig(ctx, nil)
+	if err != nil {
+		return MonitorPublicConfigDoc{}, fmt.Errorf("read legacy system constants: %w", err)
+	}
+	return monitorPublicConfigFromConstants(constants), nil
+}
+
+// CreateMonitorPublicConfig creates public-config/monitor without overwriting an existing document.
+func (c *FirestoreControllerImplements) CreateMonitorPublicConfig(ctx context.Context, monitorConfig MonitorPublicConfigDoc) error {
+	ref := c.publicConfigCollection().Doc(MonitorPublicConfigDocName)
+	if err := c.create(ctx, nil, ref, monitorConfig); err != nil {
+		return fmt.Errorf("create monitor public config: %w", err)
+	}
+	return nil
 }
 
 func (c *FirestoreControllerImplements) ReadLiveChatID(ctx context.Context, tx *firestore.Transaction) (string, error) {
@@ -456,14 +515,14 @@ func (c *FirestoreControllerImplements) UpdateDesiredMemberMaxSeats(ctx context.
 }
 
 func (c *FirestoreControllerImplements) UpdateMaxSeats(ctx context.Context, tx *firestore.Transaction, maxSeats int) error {
-	ref := c.configCollection().Doc(SystemConstantsConfigDocName)
+	ref := c.publicConfigCollection().Doc(MonitorPublicConfigDocName)
 	return c.update(ctx, tx, ref, []firestore.Update{
 		{Path: MaxSeatsDocProperty, Value: maxSeats},
 	})
 }
 
 func (c *FirestoreControllerImplements) UpdateMemberMaxSeats(ctx context.Context, tx *firestore.Transaction, memberMaxSeats int) error {
-	ref := c.configCollection().Doc(SystemConstantsConfigDocName)
+	ref := c.publicConfigCollection().Doc(MonitorPublicConfigDocName)
 	return c.update(ctx, tx, ref, []firestore.Update{
 		{Path: MemberMaxSeatsDocProperty, Value: memberMaxSeats},
 	})

--- a/system/core/repository/firestore_controller_integration_test.go
+++ b/system/core/repository/firestore_controller_integration_test.go
@@ -30,6 +30,135 @@ func runTransaction(t *testing.T, controller *repository.FirestoreControllerImpl
 	require.NoError(t, err)
 }
 
+func legacyConstantsConfig() repository.ConstantsConfigDoc {
+	return repository.ConstantsConfigDoc{
+		MaxWorkTimeMin:           720,
+		MaxSeats:                 100,
+		MemberMaxSeats:           20,
+		DesiredMaxSeats:          110,
+		DesiredMemberMaxSeats:    22,
+		MinVacancyRate:           0.2,
+		YoutubeMembershipEnabled: true,
+		FixedMaxSeatsEnabled:     false,
+	}
+}
+
+func seedLegacyConstantsConfig(t *testing.T, controller *repository.FirestoreControllerImplements, constants repository.ConstantsConfigDoc) {
+	t.Helper()
+	_, err := controller.FirestoreClient().Doc(repository.CONFIG+"/"+repository.SystemConstantsConfigDocName).Set(context.Background(), constants)
+	require.NoError(t, err)
+}
+
+func TestFirestoreRepository_SystemConstantsFallsBackBeforePublicConfigBootstrap(t *testing.T) {
+	integrationtest.ResetFirestore(t)
+	controller := newTestRepository(t)
+	want := legacyConstantsConfig()
+	seedLegacyConstantsConfig(t, controller, want)
+
+	got, err := controller.ReadSystemConstantsConfig(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+
+	var gotInTransaction repository.ConstantsConfigDoc
+	runTransaction(t, controller, func(ctx context.Context, tx *firestore.Transaction) error {
+		var readErr error
+		gotInTransaction, readErr = controller.ReadSystemConstantsConfig(ctx, tx)
+		if readErr != nil {
+			return readErr
+		}
+		return controller.UpdateDesiredMaxSeats(ctx, tx, 111)
+	})
+	assert.Equal(t, want, gotInTransaction)
+	privateSnapshot, err := controller.FirestoreClient().Doc(repository.CONFIG + "/" + repository.SystemConstantsConfigDocName).Get(context.Background())
+	require.NoError(t, err)
+	var updatedPrivate repository.ConstantsConfigDoc
+	require.NoError(t, privateSnapshot.DataTo(&updatedPrivate))
+	assert.Equal(t, 111, updatedPrivate.DesiredMaxSeats)
+}
+
+func TestFirestoreRepository_PublicMonitorConfigIsCanonical(t *testing.T) {
+	integrationtest.ResetFirestore(t)
+	controller := newTestRepository(t)
+	legacy := legacyConstantsConfig()
+	seedLegacyConstantsConfig(t, controller, legacy)
+
+	prepared, err := controller.PrepareMonitorPublicConfigBootstrap(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, repository.MonitorPublicConfigDoc{
+		MaxSeats:                 legacy.MaxSeats,
+		MemberMaxSeats:           legacy.MemberMaxSeats,
+		MinVacancyRate:           legacy.MinVacancyRate,
+		YoutubeMembershipEnabled: legacy.YoutubeMembershipEnabled,
+		FixedMaxSeatsEnabled:     legacy.FixedMaxSeatsEnabled,
+	}, prepared)
+
+	publicConfig := repository.MonitorPublicConfigDoc{
+		MaxSeats:                 80,
+		MemberMaxSeats:           16,
+		MinVacancyRate:           0.35,
+		YoutubeMembershipEnabled: false,
+		FixedMaxSeatsEnabled:     true,
+	}
+	require.NoError(t, controller.CreateMonitorPublicConfig(context.Background(), publicConfig))
+
+	got, err := controller.ReadSystemConstantsConfig(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, legacy.MaxWorkTimeMin, got.MaxWorkTimeMin)
+	assert.Equal(t, legacy.DesiredMaxSeats, got.DesiredMaxSeats)
+	assert.Equal(t, legacy.DesiredMemberMaxSeats, got.DesiredMemberMaxSeats)
+	assert.Equal(t, publicConfig.MaxSeats, got.MaxSeats)
+	assert.Equal(t, publicConfig.MemberMaxSeats, got.MemberMaxSeats)
+	assert.Equal(t, publicConfig.MinVacancyRate, got.MinVacancyRate)
+	assert.Equal(t, publicConfig.YoutubeMembershipEnabled, got.YoutubeMembershipEnabled)
+	assert.Equal(t, publicConfig.FixedMaxSeatsEnabled, got.FixedMaxSeatsEnabled)
+
+	snapshot, err := controller.FirestoreClient().Doc(repository.PublicConfig + "/" + repository.MonitorPublicConfigDocName).Get(context.Background())
+	require.NoError(t, err)
+	data := snapshot.Data()
+	assert.Len(t, data, 5)
+	for _, field := range []string{
+		repository.MaxSeatsDocProperty,
+		repository.MemberMaxSeatsDocProperty,
+		repository.MinVacancyRateDocProperty,
+		repository.YoutubeMembershipEnabledDocProperty,
+		repository.FixedMaxSeatsEnabledDocProperty,
+	} {
+		assert.Contains(t, data, field)
+	}
+}
+
+func TestFirestoreRepository_PublicMonitorConfigUpdatesDoNotDoubleWrite(t *testing.T) {
+	integrationtest.ResetFirestore(t)
+	controller := newTestRepository(t)
+	legacy := legacyConstantsConfig()
+	seedLegacyConstantsConfig(t, controller, legacy)
+	require.NoError(t, controller.CreateMonitorPublicConfig(context.Background(), repository.MonitorPublicConfigDoc{
+		MaxSeats:       80,
+		MemberMaxSeats: 16,
+	}))
+
+	require.NoError(t, controller.UpdateMaxSeats(context.Background(), nil, 90))
+	require.NoError(t, controller.UpdateMemberMaxSeats(context.Background(), nil, 18))
+
+	publicSnapshot, err := controller.FirestoreClient().Doc(repository.PublicConfig + "/" + repository.MonitorPublicConfigDocName).Get(context.Background())
+	require.NoError(t, err)
+	var publicConfig repository.MonitorPublicConfigDoc
+	require.NoError(t, publicSnapshot.DataTo(&publicConfig))
+	assert.Equal(t, 90, publicConfig.MaxSeats)
+	assert.Equal(t, 18, publicConfig.MemberMaxSeats)
+
+	privateSnapshot, err := controller.FirestoreClient().Doc(repository.CONFIG + "/" + repository.SystemConstantsConfigDocName).Get(context.Background())
+	require.NoError(t, err)
+	var privateConfig repository.ConstantsConfigDoc
+	require.NoError(t, privateSnapshot.DataTo(&privateConfig))
+	assert.Equal(t, legacy.MaxSeats, privateConfig.MaxSeats)
+	assert.Equal(t, legacy.MemberMaxSeats, privateConfig.MemberMaxSeats)
+
+	err = controller.CreateMonitorPublicConfig(context.Background(), publicConfig)
+	require.Error(t, err)
+	assert.Equal(t, codes.AlreadyExists, status.Code(err))
+}
+
 func newSeatDoc(seatID int, userID string, sessionID string) repository.SeatDoc {
 	jst := timeutil.JapanLocation()
 	return repository.SeatDoc{

--- a/system/core/repository/models.go
+++ b/system/core/repository/models.go
@@ -63,6 +63,34 @@ type ConstantsConfigDoc struct {
 	FixedMaxSeatsEnabled bool `firestore:"fixed-max-seats-enabled" json:"fixed_max_seats_enabled"`
 }
 
+// MonitorPublicConfigDoc defines the complete public configuration contract for youtube-monitor.
+// Do not add backend-only settings to this document.
+type MonitorPublicConfigDoc struct {
+	MaxSeats                 int     `firestore:"max-seats" json:"max_seats"`
+	MemberMaxSeats           int     `firestore:"member-max-seats" json:"member_max_seats"`
+	MinVacancyRate           float32 `firestore:"min-vacancy-rate" json:"min_vacancy_rate"`
+	YoutubeMembershipEnabled bool    `firestore:"youtube-membership-enabled" json:"youtube_membership_enabled"`
+	FixedMaxSeatsEnabled     bool    `firestore:"fixed-max-seats-enabled" json:"fixed_max_seats_enabled"`
+}
+
+func monitorPublicConfigFromConstants(constants ConstantsConfigDoc) MonitorPublicConfigDoc {
+	return MonitorPublicConfigDoc{
+		MaxSeats:                 constants.MaxSeats,
+		MemberMaxSeats:           constants.MemberMaxSeats,
+		MinVacancyRate:           constants.MinVacancyRate,
+		YoutubeMembershipEnabled: constants.YoutubeMembershipEnabled,
+		FixedMaxSeatsEnabled:     constants.FixedMaxSeatsEnabled,
+	}
+}
+
+func (monitor MonitorPublicConfigDoc) applyTo(constants *ConstantsConfigDoc) {
+	constants.MaxSeats = monitor.MaxSeats
+	constants.MemberMaxSeats = monitor.MemberMaxSeats
+	constants.MinVacancyRate = monitor.MinVacancyRate
+	constants.YoutubeMembershipEnabled = monitor.YoutubeMembershipEnabled
+	constants.FixedMaxSeatsEnabled = monitor.FixedMaxSeatsEnabled
+}
+
 // CredentialsConfigDoc defines credentials for various services.
 type CredentialsConfigDoc struct {
 	DiscordOwnerBotToken         string `firestore:"discord-owner-bot-token"`


### PR DESCRIPTION
## Stack

1. [PR A #976](https://github.com/kani3camp/youtube-study-space/pull/976) — `security/firestore-rules-tests` → `dev`
2. **[PR B #977 (this PR)](https://github.com/kani3camp/youtube-study-space/pull/977)** — `security/public-monitor-config` → `security/firestore-rules-tests`
3. [PR C #978](https://github.com/kani3camp/youtube-study-space/pull/978) — `security/monitor-public-config` → `security/public-monitor-config`
4. [PR D #979](https://github.com/kani3camp/youtube-study-space/pull/979) — `security/close-internal-config` → `security/monitor-public-config`

## Purpose

youtube-monitor向けの公開configを`public-config/monitor`へ分離し、backend専用の`config/constants`と明確なdocument境界を作ります。

## Changes

- 5項目だけを持つGo型`MonitorPublicConfigDoc`を追加
- Repository内部で`config/constants`のbackend設定と`public-config/monitor`を合成し、既存`ConstantsConfigDoc` call siteを維持
- `max-seats`／`member-max-seats`の通常writeを新documentだけへ移行し、二重writeを回避
- productionに新documentがない移行期間だけlegacy値へfallback
- 既存documentを上書きしないpreview／確認付きbootstrap commandを追加
- `public-config/monitor`のanonymous read／client write deny Rulesとテストを追加
- production bootstrap・deploy・rollback手順を文書化

## Tests

- `bash .github/scripts/run-firestore-rules-tests.sh`（12 tests passed）
- `bash .github/scripts/run-firestore-integration-tests.sh`（Repository／WorkspaceApp suite passed）
- `cd system && go test -shuffle=on ./...`
- `cd system && golangci-lint run --timeout=5m --config=.golangci.yml`
- `git diff --check`

## Migration / deploy notes

単独deploy可能ですが、順序が重要です。

1. このPRのFirestore Rulesだけを先にdeploy
2. `go run ./cmd/bootstrap-public-monitor-config --project-id <production-project-id>`でread-only preview
3. 5値を照合後、`--apply`とproject ID再入力で`public-config/monitor`をcreate
4. documentが5フィールドだけであることを確認
5. backendをdeploy

commandはcreate-onlyで既存documentを上書きしません。Codexはproduction dataを変更していません。詳細は`firebase/PUBLIC_CONFIG_MIGRATION.md`を参照してください。

## Following PR

PR Cでyoutube-monitorの購読先と専用type/converterを`public-config/monitor`へ移し、horizontal／vertical双方の回帰テストを追加します。旧buildのmigration windowのため、この段階では`config/constants` public readを維持します。