### PR TITLE
refactor: read monitor config from public document

### DIFF
--- a/youtube-monitor/src/components/MainContent.tsx
+++ b/youtube-monitor/src/components/MainContent.tsx
@@ -1,6 +1,5 @@
 import {
 	collection,
-	doc,
 	getFirestore,
 	onSnapshot,
 	query,
@@ -13,11 +12,10 @@ import { useInterval } from '../lib/common'
 import { Constants } from '../lib/constants'
 import fetcher from '../lib/fetcher'
 import {
-	firestoreConstantsConverter,
 	firestoreSeatConverter,
 	firestoreWorkNameTrendConverter,
 	getFirebaseApp,
-	type SystemConstants,
+	subscribeToMonitorPublicConfig,
 } from '../lib/firestore'
 import {
 	buildRoomLayouts,
@@ -174,7 +172,6 @@ const Seats: FC<SeatsProps> = ({ menuItems }) => {
 		const app = getFirebaseApp()
 		const db = getFirestore(app)
 
-		const constantsConverter = firestoreConstantsConverter
 		const seatConverter = firestoreSeatConverter
 		const workNameTrendConverter = firestoreWorkNameTrendConverter
 
@@ -216,23 +213,13 @@ const Seats: FC<SeatsProps> = ({ menuItems }) => {
 			}
 		})
 
-		onSnapshot(
-			doc(db, 'config', 'constants').withConverter(constantsConverter),
-			(doc) => {
-				const generalMaxSeats = (doc.data() as SystemConstants).max_seats
-				const memberMaxSeats = (doc.data() as SystemConstants).member_max_seats
-				const minVacancyRate = (doc.data() as SystemConstants).min_vacancy_rate
-				const youtubeMembershipEnabled = (doc.data() as SystemConstants)
-					.youtube_membership_enabled
-				const fixedMaxSeatsEnabled = (doc.data() as SystemConstants)
-					.fixed_max_seats_enabled
-				setLatestGeneralMaxSeats(generalMaxSeats)
-				setLatestMemberMaxSeats(memberMaxSeats)
-				setLatestMinVacancyRate(minVacancyRate)
-				setLatestYoutubeMembershipEnabled(youtubeMembershipEnabled)
-				setLatestFixedMaxSeatsEnabled(fixedMaxSeatsEnabled)
-			},
-		)
+		subscribeToMonitorPublicConfig(db, (config) => {
+			setLatestGeneralMaxSeats(config.max_seats)
+			setLatestMemberMaxSeats(config.member_max_seats)
+			setLatestMinVacancyRate(config.min_vacancy_rate)
+			setLatestYoutubeMembershipEnabled(config.youtube_membership_enabled)
+			setLatestFixedMaxSeatsEnabled(config.fixed_max_seats_enabled)
+		})
 	}
 
 	/**

--- a/youtube-monitor/src/lib/firestore.test.ts
+++ b/youtube-monitor/src/lib/firestore.test.ts
@@ -1,0 +1,105 @@
+import { doc, onSnapshot } from 'firebase/firestore'
+import {
+	firestoreMonitorPublicConfigConverter,
+	type MonitorPublicConfig,
+	subscribeToMonitorPublicConfig,
+} from './firestore'
+
+jest.mock('firebase/firestore', () => ({
+	doc: jest.fn(),
+	onSnapshot: jest.fn(),
+}))
+
+jest.mock('next/font/google', () => ({
+	M_PLUS_Rounded_1c: jest.fn(() => ({
+		style: { fontFamily: 'M PLUS Rounded 1c' },
+		className: 'mock-font-class',
+	})),
+	Source_Code_Pro: jest.fn(() => ({
+		style: { fontFamily: 'Source Code Pro' },
+		className: 'mock-source-code-pro-class',
+	})),
+}))
+
+const mockedDoc = jest.mocked(doc)
+const mockedOnSnapshot = jest.mocked(onSnapshot)
+
+const firstConfig: MonitorPublicConfig = {
+	max_seats: 100,
+	member_max_seats: 20,
+	min_vacancy_rate: 0.25,
+	youtube_membership_enabled: true,
+	fixed_max_seats_enabled: false,
+}
+
+beforeEach(() => {
+	jest.clearAllMocks()
+})
+
+test('monitor config converter maps exactly the five public fields', () => {
+	expect(
+		firestoreMonitorPublicConfigConverter.toFirestore(firstConfig),
+	).toEqual({
+		'max-seats': 100,
+		'member-max-seats': 20,
+		'min-vacancy-rate': 0.25,
+		'youtube-membership-enabled': true,
+		'fixed-max-seats-enabled': false,
+	})
+
+	const fromFirestore = firestoreMonitorPublicConfigConverter.fromFirestore(
+		{
+			data: () => ({
+				'max-seats': 90,
+				'member-max-seats': 18,
+				'min-vacancy-rate': 0.3,
+				'youtube-membership-enabled': false,
+				'fixed-max-seats-enabled': true,
+			}),
+		} as never,
+		{},
+	)
+	expect(fromFirestore).toEqual({
+		max_seats: 90,
+		member_max_seats: 18,
+		min_vacancy_rate: 0.3,
+		youtube_membership_enabled: false,
+		fixed_max_seats_enabled: true,
+	})
+})
+
+test('shared monitor subscription uses public-config/monitor and forwards realtime updates', () => {
+	const convertedReference = { path: 'public-config/monitor' }
+	const withConverter = jest.fn(() => convertedReference)
+	mockedDoc.mockReturnValue({ withConverter } as never)
+	let snapshotHandler:
+		| ((snapshot: { data: () => MonitorPublicConfig }) => void)
+		| undefined
+	const unsubscribe = jest.fn()
+	mockedOnSnapshot.mockImplementation(((_reference, onNext) => {
+		snapshotHandler = onNext as typeof snapshotHandler
+		return unsubscribe
+	}) as never)
+	const onConfig = jest.fn()
+	const db = {} as never
+
+	const returnedUnsubscribe = subscribeToMonitorPublicConfig(db, onConfig)
+
+	expect(mockedDoc).toHaveBeenCalledWith(db, 'public-config', 'monitor')
+	expect(withConverter).toHaveBeenCalledWith(
+		firestoreMonitorPublicConfigConverter,
+	)
+	expect(mockedOnSnapshot).toHaveBeenCalledWith(
+		convertedReference,
+		expect.any(Function),
+		undefined,
+	)
+	expect(returnedUnsubscribe).toBe(unsubscribe)
+
+	snapshotHandler?.({ data: () => firstConfig })
+	const updatedConfig = { ...firstConfig, max_seats: 120, member_max_seats: 24 }
+	snapshotHandler?.({ data: () => updatedConfig })
+
+	expect(onConfig).toHaveBeenNthCalledWith(1, firstConfig)
+	expect(onConfig).toHaveBeenNthCalledWith(2, updatedConfig)
+})

--- a/youtube-monitor/src/lib/firestore.ts
+++ b/youtube-monitor/src/lib/firestore.ts
@@ -5,11 +5,16 @@ import {
 	getApps,
 	initializeApp,
 } from 'firebase/app'
-import type {
-	DocumentData,
-	FirestoreDataConverter,
-	QueryDocumentSnapshot,
-	SnapshotOptions,
+import {
+	type DocumentData,
+	doc,
+	type Firestore,
+	type FirestoreDataConverter,
+	type FirestoreError,
+	onSnapshot,
+	type QueryDocumentSnapshot,
+	type SnapshotOptions,
+	type Unsubscribe,
 } from 'firebase/firestore'
 import type { Menu, Seat, WorkNameTrend } from '../types/api'
 import { validateString } from './common'
@@ -31,7 +36,7 @@ export const getFirebaseApp = (): FirebaseApp => {
 	return getApps().length === 0 ? initializeApp(getFirebaseConfig()) : getApp()
 }
 
-export type SystemConstants = {
+export type MonitorPublicConfig = {
 	max_seats: number
 	member_max_seats: number
 	min_vacancy_rate: number
@@ -39,21 +44,21 @@ export type SystemConstants = {
 	fixed_max_seats_enabled: boolean
 }
 
-export const firestoreConstantsConverter: FirestoreDataConverter<SystemConstants> =
+export const firestoreMonitorPublicConfigConverter: FirestoreDataConverter<MonitorPublicConfig> =
 	{
-		toFirestore(constants: SystemConstants): DocumentData {
+		toFirestore(config: MonitorPublicConfig): DocumentData {
 			return {
-				'max-seats': constants.max_seats,
-				'member-max-seats': constants.member_max_seats,
-				'min-vacancy-rate': constants.min_vacancy_rate,
-				'youtube-membership-enabled': constants.youtube_membership_enabled,
-				'fixed-max-seats-enabled': constants.fixed_max_seats_enabled,
+				'max-seats': config.max_seats,
+				'member-max-seats': config.member_max_seats,
+				'min-vacancy-rate': config.min_vacancy_rate,
+				'youtube-membership-enabled': config.youtube_membership_enabled,
+				'fixed-max-seats-enabled': config.fixed_max_seats_enabled,
 			}
 		},
 		fromFirestore(
 			snapshot: QueryDocumentSnapshot,
 			options: SnapshotOptions,
-		): SystemConstants {
+		): MonitorPublicConfig {
 			const data = snapshot.data(options)
 			return {
 				max_seats: data['max-seats'],
@@ -64,6 +69,24 @@ export const firestoreConstantsConverter: FirestoreDataConverter<SystemConstants
 			}
 		},
 	}
+
+export const subscribeToMonitorPublicConfig = (
+	db: Firestore,
+	onConfig: (config: MonitorPublicConfig) => void,
+	onError?: (error: FirestoreError) => void,
+): Unsubscribe =>
+	onSnapshot(
+		doc(db, 'public-config', 'monitor').withConverter(
+			firestoreMonitorPublicConfigConverter,
+		),
+		(snapshot) => {
+			const config = snapshot.data()
+			if (config !== undefined) {
+				onConfig(config)
+			}
+		},
+		onError,
+	)
 
 export const firestoreSeatConverter: FirestoreDataConverter<Seat> = {
 	toFirestore(seat: Seat): DocumentData {


### PR DESCRIPTION
## Stack

1. [PR A #976](https://github.com/kani3camp/youtube-study-space/pull/976) — `security/firestore-rules-tests` → `dev`
2. [PR B #977](https://github.com/kani3camp/youtube-study-space/pull/977) — `security/public-monitor-config` → `security/firestore-rules-tests`
3. **[PR C #978 (this PR)](https://github.com/kani3camp/youtube-study-space/pull/978)** — `security/monitor-public-config` → `security/public-monitor-config`
4. [PR D #979](https://github.com/kani3camp/youtube-study-space/pull/979) — `security/close-internal-config` → `security/monitor-public-config`

## Purpose

youtube-monitorのFirestore購読をprivateな`config/constants`から、5項目だけの`public-config/monitor`へ移行します。

## Changes

- `SystemConstants`を公開契約に即した`MonitorPublicConfig`へ改名
- 専用`firestoreMonitorPublicConfigConverter`を追加
- orientationに依存しない`subscribeToMonitorPublicConfig`へdocument pathとrealtime購読を集約
- 現行horizontal monitorの購読先を`public-config/monitor`へ変更
- converterが5項目だけを扱うこと、正しいpathを読むこと、連続snapshotを転送することをテスト
- `youtube-monitor/src`から`config/constants`参照を除去

## Tests

- `cd youtube-monitor && pnpm test`（8 suites / 160 tests passed）
- `cd youtube-monitor && pnpm exec biome check .`
- CI相当envで`cd youtube-monitor && pnpm build`
- `rg`でyoutube-monitor内に旧`config/constants`／`SystemConstants`／旧converter参照がないことを確認
- `git diff --check`

既存`max-seats.test.ts`がseat capacity、membership enabled/disabled、fixed capacity、temporary room expansionを継続検証します。公開configのrealtime更新は新しいsubscription testで検証します。

## Horizontal / vertical

現行`dev`にはhorizontal実装だけがあり、vertical実装は別Draft PR #972上です。このPRでは両variantから再利用できるorientation-independent subscription境界として実装しています。

#972 branchへこのPRの変更を一時適用し、`useMonitorData`、`useRoomPages`、`useSeatCapacityController`の型／購読を`MonitorPublicConfig`へ合わせた互換worktreeで次を確認しました（検証用変更はpushしていません）。

- `pnpm test`: 15 suites / 182 tests passed
- `pnpm exec biome check .`: passed
- production build: `/`と`/vertical`の両route passed
- #972既存の`MonitorVariants.test.tsx`、seat capacity、membership、paging testsを含む

#972が先にmergeされた場合は、上記4ファイルの旧`SystemConstants`／`config/constants`参照をこの共有subscriptionへ合わせてからPR Cをmergeします。

## Migration / deploy notes

PR Bの手順で`public-config/monitor`をbootstrapしてからこのPRをdeployします。旧monitor buildとのmigration windowのため、このPRでも`config/constants` public readは維持します。

## Following PR

PR Dで`config/constants` public readを削除し、Client SDKから`config/*`を完全非公開化します。