### PR TITLE
security: close internal Firestore config

### DIFF
--- a/firebase/PUBLIC_CONFIG_MIGRATION.md
+++ b/firebase/PUBLIC_CONFIG_MIGRATION.md
@@ -43,6 +43,8 @@
 7. PR Cのyoutube-monitorをdeployし、horizontal／vertical双方の表示とrealtime updateを確認します。
 8. 旧monitor buildが残っていないことを確認してからPR DのRulesをdeployし、`config/*`を完全非公開化します。
 
+PR Dのbackendはlegacy fallbackを削除するため、`public-config/monitor`が存在しない環境では起動時のconfig readが失敗します。PR D deploy前にbootstrap済みであることを必ず確認してください。PR D deploy後は、anonymous／authenticated Client SDKの両方で`config/constants`、`config/credentials`、`config/unknown`のGETとconfig collection listが拒否され、`public-config/monitor`のGETだけが成功することをRules testと同じ条件で確認します。
+
 ## Rollback
 
 PR BまたはPR Cまでのrollbackでは`config/constants`のpublic readを維持しているため、旧monitor buildへ戻せます。`public-config/monitor`は削除せず、新backendをrollbackした場合は必要に応じて5値を`config/constants`へ手動で戻します。PR Dをdeployした後に旧monitorへrollbackする場合は、先にPR DのRulesをrollbackしないと旧buildがconfigを読めません。

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -15,11 +15,6 @@ service cloud.firestore {
     	allow write: if false;
     }
     
-    match /config/constants {
-    	allow read: if true;
-      allow write: if false;
-    }
-
     match /config/{doc} {
     	allow read, write: if false;
     }

--- a/firebase/firestore.rules.test.mjs
+++ b/firebase/firestore.rules.test.mjs
@@ -3,7 +3,7 @@ import {
 	assertSucceeds,
 	initializeTestEnvironment,
 } from '@firebase/rules-unit-testing'
-import { doc, getDoc, setDoc } from 'firebase/firestore'
+import { collection, doc, getDoc, getDocs, setDoc } from 'firebase/firestore'
 import { after, before, beforeEach, describe, test } from 'node:test'
 import { readFile } from 'node:fs/promises'
 
@@ -29,7 +29,9 @@ beforeEach(async () => {
 		for (const path of [
 			'config/constants',
 			'config/credentials',
+			'config/unknown',
 			'public-config/monitor',
+			'public-config/unknown',
 			'seats/1',
 			'member-seats/1',
 			'menu/default',
@@ -53,7 +55,6 @@ const anonymousFirestore = () =>
 
 describe('public documents', () => {
 	for (const path of [
-		'config/constants',
 		'public-config/monitor',
 		'seats/1',
 		'member-seats/1',
@@ -71,7 +72,10 @@ describe('public documents', () => {
 
 describe('private documents', () => {
 	for (const path of [
+		'config/constants',
 		'config/credentials',
+		'config/unknown',
+		'public-config/unknown',
 		'users/private-user',
 		'live-chat-history/private-message',
 		'work-segments/private-segment',
@@ -85,13 +89,24 @@ describe('private documents', () => {
 		})
 	}
 
-	test('arbitrary authentication does not grant access to private config', async () => {
+	test('config collection cannot be listed by an anonymous client', async () => {
+		await assertFails(getDocs(collection(anonymousFirestore(), 'config')))
+	})
+
+	test('arbitrary authentication does not grant access to any config document', async () => {
 		const authenticatedFirestore = testEnvironment
 			.authenticatedContext('arbitrary-user')
 			.firestore()
-		const reference = doc(authenticatedFirestore, 'config/credentials')
+		for (const path of [
+			'config/constants',
+			'config/credentials',
+			'config/unknown',
+		]) {
+			const reference = doc(authenticatedFirestore, path)
 
-		await assertFails(getDoc(reference))
-		await assertFails(setDoc(reference, { clientWrite: true }))
+			await assertFails(getDoc(reference))
+			await assertFails(setDoc(reference, { clientWrite: true }))
+		}
+		await assertFails(getDocs(collection(authenticatedFirestore, 'config')))
 	})
 })

--- a/system/core/repository/firestore_controller.go
+++ b/system/core/repository/firestore_controller.go
@@ -206,11 +206,6 @@ func (c *FirestoreControllerImplements) ReadSystemConstantsConfig(ctx context.Co
 
 	monitorConfig, err := c.readMonitorPublicConfig(ctx, tx)
 	if err != nil {
-		// Temporary migration fallback: production initially has only config/constants.
-		// Remove this after public-config/monitor has been bootstrapped everywhere.
-		if status.Code(err) == codes.NotFound {
-			return constantsConfig, nil
-		}
 		return ConstantsConfigDoc{}, fmt.Errorf("read monitor public config: %w", err)
 	}
 	monitorConfig.applyTo(&constantsConfig)

--- a/system/core/repository/firestore_controller_integration_test.go
+++ b/system/core/repository/firestore_controller_integration_test.go
@@ -49,31 +49,14 @@ func seedLegacyConstantsConfig(t *testing.T, controller *repository.FirestoreCon
 	require.NoError(t, err)
 }
 
-func TestFirestoreRepository_SystemConstantsFallsBackBeforePublicConfigBootstrap(t *testing.T) {
+func TestFirestoreRepository_SystemConstantsRequiresPublicConfigAfterMigration(t *testing.T) {
 	integrationtest.ResetFirestore(t)
 	controller := newTestRepository(t)
-	want := legacyConstantsConfig()
-	seedLegacyConstantsConfig(t, controller, want)
+	seedLegacyConstantsConfig(t, controller, legacyConstantsConfig())
 
-	got, err := controller.ReadSystemConstantsConfig(context.Background(), nil)
-	require.NoError(t, err)
-	assert.Equal(t, want, got)
-
-	var gotInTransaction repository.ConstantsConfigDoc
-	runTransaction(t, controller, func(ctx context.Context, tx *firestore.Transaction) error {
-		var readErr error
-		gotInTransaction, readErr = controller.ReadSystemConstantsConfig(ctx, tx)
-		if readErr != nil {
-			return readErr
-		}
-		return controller.UpdateDesiredMaxSeats(ctx, tx, 111)
-	})
-	assert.Equal(t, want, gotInTransaction)
-	privateSnapshot, err := controller.FirestoreClient().Doc(repository.CONFIG + "/" + repository.SystemConstantsConfigDocName).Get(context.Background())
-	require.NoError(t, err)
-	var updatedPrivate repository.ConstantsConfigDoc
-	require.NoError(t, privateSnapshot.DataTo(&updatedPrivate))
-	assert.Equal(t, 111, updatedPrivate.DesiredMaxSeats)
+	_, err := controller.ReadSystemConstantsConfig(context.Background(), nil)
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
 }
 
 func TestFirestoreRepository_PublicMonitorConfigIsCanonical(t *testing.T) {


### PR DESCRIPTION
## Stack

1. [PR A #976](https://github.com/kani3camp/youtube-study-space/pull/976) — `security/firestore-rules-tests` → `dev`
2. [PR B #977](https://github.com/kani3camp/youtube-study-space/pull/977) — `security/public-monitor-config` → `security/firestore-rules-tests`
3. [PR C #978](https://github.com/kani3camp/youtube-study-space/pull/978) — `security/monitor-public-config` → `security/public-monitor-config`
4. **[PR D #979 (this PR)](https://github.com/kani3camp/youtube-study-space/pull/979)** — `security/close-internal-config` → `security/monitor-public-config`

## Purpose

migration windowを閉じ、Client SDKから`config/*`をread/writeできない最終Security Rules契約へ移行します。

## Changes

- `config/constants`のpublic read allowを削除
- default deny + 明示したpublic pathだけallowする構成を維持
- `config/constants`、`config/credentials`、`config/unknown`のGET／write denyを保証
- anonymous／arbitrary authenticated client双方のconfig collection list denyを保証
- `public-config/monitor` GET allow／client write denyを保証
- `public-config/unknown` denyで公開範囲をdocument単位に固定
- backendのlegacy fallbackを削除し、bootstrapped `public-config/monitor`を正本として必須化
- migration文書へPR D前後の検証手順を追記

## Tests

- `bash .github/scripts/run-firestore-rules-tests.sh`（15 tests passed）
- `bash .github/scripts/run-firestore-integration-tests.sh`（Repository／WorkspaceApp suite passed）
- `cd system && go test -shuffle=on ./core/repository/... ./core/workspaceapp/...`
- `cd system && golangci-lint run --timeout=5m --config=.golangci.yml`
- `bash .github/scripts/test-detect-ci-paths.sh`
- `node --check firebase/firestore.rules.test.mjs`
- `git diff --check`

## Migration / deploy notes

このPRをdeployする前に、以下をすべて満たす必要があります。

1. PR Bの手順でproductionの`public-config/monitor`をbootstrap済み
2. documentが公開5フィールドだけを持つことを確認済み
3. PR Cのyoutube-monitorがdeploy済み
4. horizontal／verticalを含む稼働中buildが旧`config/constants`を参照しないことを確認済み
5. old monitor buildのmigration windowを終了可能

Rulesを閉じた後に旧monitorへrollbackする場合は、先にこのPRのRulesをrollbackする必要があります。Codexはproduction deploy／data変更を行っていません。

## Final contract

- Client SDK: `config/*` read/write/list deny
- Client SDK: `public-config/monitor` read allow、write deny
- server client: internal `config/constants`／`config/credentials`を引き続き利用
- monitor: 公開5項目だけをrealtime購読