### PR TITLE
Codex向けAGENTSを意思決定ルールへ圧縮

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Goal
+
+<!-- ユーザー/システムから見て何ができれば完了か -->
+
+## Invariants / Non-goals
+
+<!-- 変更後も守るbehavior/data/security/UX契約と、今回あえて変更しない範囲 -->
+
+## 変更概要
+
+## Stack / Migration / Deploy
+
+<!-- stacked PR、data migration、deploy順、rollback条件がある場合に記載。なければ「なし」。 -->
+
+## Verification
+
+<!-- 実際に実行したcheckだけを書く。ローカル未実施なら、理由とCIで確認するjobを明記。 -->
+
+## 再発防止 / Quality ownership
+
+<!-- review起点の修正や再現可能な問題なら、test / rules・constraint / lint / CI / architecture / AGENTSのどこへ再発防止を置いたか。 -->
+
+## レビューで重点確認してほしい点

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ golangci-lint run --timeout=5m --config=.golangci.yml
 I18N_BASELINE=ja go generate ./...
 ```
 
-After generation, verify there is no unintended generated diff. For Firestore repository/application behavior that depends on Emulator semantics, run the repository's emulator script when applicable:
+After generation, verify there is no unintended generated diff. For Firestore repository/application behavior that depends on Emulator semantics, run the repository's emulator script when applicable **from the repository root**:
 
 ```sh
 bash .github/scripts/run-firestore-integration-tests.sh
@@ -126,6 +126,7 @@ A new file/path that should trigger existing validation must be classified by CI
 ## Pull Requests
 
 - Normal development PRs target `dev`, not `main`, unless the user explicitly requests another base.
+- When using `gh pr create` for a normal development PR, pass `--base dev` explicitly rather than relying on the repository default.
 - Keep commits and PRs coherent. Split independent concerns rather than creating a review mega-bundle.
 - PR descriptions should state the goal, key invariants/non-goals, migration/deploy ordering when relevant, and the checks actually run.
 - Never claim a check ran locally when it only ran in GitHub Actions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,267 +1,133 @@
 # AGENTS.md
 
-This file provides guidance to Codex (Codex.ai/code) when working with code in this repository.
+This file is the repository-wide operating contract for coding agents. Keep it focused on decisions an agent must make repeatedly. Put product/user documentation in the relevant README or docs, and keep tool/runtime versions in their canonical config files instead of duplicating them here.
 
-## Custom Instructions
+## Communication and Safety
 
-### Communication
-- **Primary Language**: 日本語でのやりとりを基本とする (Use Japanese as the primary communication language)
+- Use Japanese as the primary language for user-facing communication and pull request discussion unless asked otherwise.
+- Before changing external content or production state through MCP/API/deploy tools, obtain explicit user authorization for that external mutation.
+- Do not expose, log, copy, or move credentials/secrets into client-readable locations.
+- Preserve important `NOTE` comments. Temporary review-only explanations may use `[NOTE FOR REVIEW]` and should not become permanent clutter.
 
-### External Content Management
-- **MCP Server Changes**: MCPサーバーで外部コンテンツに変更を加える時は、必ず事前に確認をとること (Always seek confirmation before making changes to external content via MCP servers)
+## Start Every Task
 
-### Git Commit Guidelines
-- **Commit Granularity**: gitコミットは適切な粒度にわけて簡潔なコミットメッセージにより行うこと (Make git commits with appropriate granularity and concise commit messages)
+1. Read `README.md`, this file, and only the task-relevant package/docs files.
+2. Start normal development work from the latest `dev` on a **fresh branch for that PR**. Never reuse the head branch of a merged or closed PR for new work.
+3. An intentionally stacked PR is allowed when the dependency is real. In that case, base it on the immediate predecessor and document the stack/order in every affected PR. Do not accidentally carry unrelated history forward.
+4. Before substantial implementation, establish a task contract in working notes:
+   - **Goal**: observable outcome.
+   - **Invariants**: behavior/data/security/UX that must stay true.
+   - **Non-goals**: nearby work intentionally excluded.
+   - **Acceptance criteria**: externally observable completion conditions.
+   - **Verification**: deterministic checks proving those conditions.
+5. Resolve ambiguity from current code, tests, docs, and existing contracts first. Ask for user judgment only when materially different product semantics remain possible.
 
-### Pull Requests（ベースブランチ）
-- **既定のマージ先**: 通常の開発用 PR は **`dev`** をベースにする（`main` は本番相当のため、ここへ向けない）。ユーザーが別ブランチを明示したときのみ従う。
-- **`gh pr create`**: ベース未指定だとリポジトリ既定（多くの場合 `main`）になりやすいので、**必ず** `--base dev` を付ける（または GitHub 上でベースを `dev` に変更する）。
+## Canonical Sources
 
-### Communication Style
-- **Ask Questions**: 指示が曖昧だったり、不明点・懸念点があれば遠慮なく質問・確認すること (Don't hesitate to ask questions or seek clarification when instructions are ambiguous or when there are unclear points or concerns)
+Do not hard-code volatile versions or duplicate package metadata in this file.
 
-## Project Overview
+- Node.js version: root `.node-version` / `.nvmrc` and each package's `engines`.
+- pnpm version: each package's `packageManager`.
+- Go version/dependencies: `system/go.mod` and tool-specific `go.mod` files.
+- CI behavior and path routing: `.github/workflows/` and `.github/scripts/detect-ci-paths.sh`.
+- Firestore rules/configuration: `firebase/`.
+- User-facing commands and behavior: implementation/tests plus the maintained docs site.
 
-YouTube Study Space is a 24/7 automated online study room livestreamed on YouTube. Users can join and leave virtual study sessions through YouTube live chat commands. The system supports both general seats and member-exclusive seats, tracks work time, and provides moderation and automation features.
+Major areas:
 
-## Development Commands
+- `system/`: Go backend, repository/application logic, batch/Lambda entrypoints.
+- `youtube-monitor/`: Next.js livestream UI.
+- `firebase/`: Firestore rules and emulator configuration.
+- `aws-cdk/`: AWS infrastructure.
+- `docs-site/`: Docusaurus documentation.
+- `tools/`: standalone operational/development tools.
 
-### Go Backend (`system/`)
-```bash
-# Run the main bot locally
-go run ./cmd/youtube-bot
+Prefer the closest package README/config and the closest nested `AGENTS.md` if one is added later.
 
-# Run all tests with randomization
-go test -shuffle=on -v ./...
+## Quality Ownership
 
-# Run tests for a specific package
-go test ./core/youtubebot/...
+Generation may be probabilistic; acceptance must be deterministic whenever practical.
 
-# Generate repository mocks
-mockgen -source ./core/repository/interface.go -destination ./core/repository/mocks/interface.go -package mock_repository
+When implementation or review reveals a repeatable failure mode, fix the instance and then choose the cheapest reliable prevention layer:
 
-# Update dependencies
-go mod tidy
+1. regression/integration/contract test for observable behavior;
+2. security rule, schema, or data constraint for access/data invariants;
+3. formatter/linter/static analysis for mechanical rules;
+4. CI/path-routing check for workflow invariants;
+5. `AGENTS.md` for agent decisions that cannot be encoded reliably elsewhere;
+6. architecture boundary when the invalid state should be impossible by construction.
 
-# Regenerate typed i18n wrappers
-go generate ./...
+Do not rely on self-review alone for a repeatable problem that a machine can reject. Avoid tests coupled to implementation trivia; prefer one named externally observable contract per test and semantic assertions over weak existence/truthiness checks.
+
+## Validation by Area
+
+Run the smallest set that fully covers the changed contract, then let GitHub Actions remain the final repository gate.
+
+### Go backend (`system/`)
+
+```sh
+cd system
+go test -shuffle=on ./...
+golangci-lint run --timeout=5m --config=.golangci.yml
+I18N_BASELINE=ja go generate ./...
 ```
 
-### Frontend (`youtube-monitor/`)
-```bash
-# Install dependencies
-pnpm install
+After generation, verify there is no unintended generated diff. For Firestore repository/application behavior that depends on Emulator semantics, run the repository's emulator script when applicable:
 
-# Development server
-pnpm dev
+```sh
+bash .github/scripts/run-firestore-integration-tests.sh
+```
 
-# Production build
+For transactional behavior, verify both commit and rollback/atomicity where failure can leave partial state. Preserve error identity with wrapping that still supports `errors.Is` when callers depend on it.
+
+### YouTube monitor (`youtube-monitor/`)
+
+```sh
+cd youtube-monitor
+pnpm check
+pnpm test --runInBand
 pnpm build
+```
 
-# Production server
-pnpm start
+Keep horizontal/vertical or other variants sharing domain/data behavior unless the requirement is intentionally variant-specific. When shared behavior changes, cover the relevant variants rather than assuming one rendering path represents all of them.
 
-# Run tests
+### AWS CDK (`aws-cdk/`)
+
+```sh
+cd aws-cdk
 pnpm test
-
-# Linting and formatting (using Biome)
-pnpm format
-pnpm lint
-pnpm lint:fix
-pnpm format:fix
-
-# Storybook for component development
-pnpm storybook
-pnpm build-storybook
+pnpm cdk:synth
 ```
 
-### AWS Infrastructure (`aws-cdk/`)
-```bash
-# Install dependencies
-pnpm install
+Do not deploy infrastructure without explicit authorization.
 
-# Preview infrastructure changes
-pnpm cdk:diff
+### Documentation (`docs-site/`)
 
-# Deploy infrastructure
-pnpm cdk:deploy
+Use the package scripts defined in `docs-site/package.json` for lint/typecheck/build. Be careful: some format/check scripts write files; inspect the script before running a command whose name is ambiguous.
 
-# Build CDK code
-pnpm build
+### CI and path routing
 
-# Run CDK tests
-pnpm test
+When changing `.github/workflows/**`, `.github/actions/**`, or CI path detection, test the routing contract as well as syntax:
+
+```sh
+bash .github/scripts/test-detect-ci-paths.sh
 ```
 
-### Documentation Site (`docs-site/`)
-```bash
-# Install dependencies
-pnpm install
+A new file/path that should trigger existing validation must be classified by CI. Do not let a new area silently bypass its deterministic checks.
 
-# Local development server
-pnpm start
+## Implementation Rules That Matter Across the Repository
 
-# Build static site
-pnpm build
+- Include useful context when returning external/dependency errors; preserve unwrap/error identity when required.
+- Use Firestore transactions where a business invariant spans multiple reads/writes or collections.
+- Keep server-only configuration and credentials behind server authorization boundaries. A public client contract should expose only the minimum explicit fields it needs.
+- When changing i18n source/locales/generation, regenerate typed artifacts and verify the generated diff.
+- Avoid unrelated refactors in a behavioral/security fix unless they are required to make the invariant enforceable.
 
-# Formatting and linting
-pnpm format
-pnpm lint
-```
+## Pull Requests
 
-- **Note**: In `docs-site/`, `pnpm format` runs `biome format --write .` (writes files), while `youtube-monitor/` uses separate `format` vs `format:fix` scripts. `docs-site` `pnpm check` runs `biome check --apply .`.
-
-- `youtube-monitor/`, `aws-cdk/`, and `docs-site/` use `pnpm` (`packageManager: pnpm@10.4.0`).
-- Do not use `npm` or `yarn` for these directories unless explicitly required.
-
-## Architecture
-
-### High-Level Structure
-- **`system/`** - Go backend, scheduled jobs, and AWS Lambda entrypoints
-- **`youtube-monitor/`** - Next.js frontend for the study room interface
-- **`aws-cdk/`** - AWS infrastructure as code
-- **`docs-site/`** - Docusaurus documentation site with i18n support
-- **`firebase/`** - Firestore configuration
-
-### Core Architecture Patterns
-
-**Event-Driven Serverless**:
-- **Every 1 minute**: `youtube_organize_database` + `check_live_stream_status`
-- **Every 15 minutes**: `update_work_name_trend`
-- **Daily at 00:00 JST**: EventBridge Scheduler invokes `start_daily_batch`, which starts Step Functions; after a built-in **15-second wait** (date-boundary safeguard in CDK), the state machine runs the sequential ECS Fargate daily batch (`reset-daily-total` → `update-rp` → `transfer-bq`)
-
-**Multi-Database Strategy**:
-- **Firestore**: Real-time user sessions, room state, chat history, configuration
-- **DynamoDB**: Configuration and secret lookup for Lambda-side operations
-- **BigQuery**: Historical analytics and archival processing
-- **Cloud Storage**: Transfer source for BigQuery import jobs
-
-**Command Processing Flow**:
-1. YouTube Live Chat API retrieves messages
-2. Commands are parsed and validated
-3. `workspaceapp` processes seat, break, user, and moderation behavior
-4. Firestore transactions persist state changes
-5. Replies and notifications are posted to YouTube Live Chat and Discord when needed
-
-### Key Components
-
-**Backend (`system/core/`)**:
-- `workspaceapp/` - Main application layer for command handling, presenters, validation, and batch jobs
-- `youtubebot/` - YouTube Live Chat API integration
-- `repository/` - Firestore data access layer
-- `guardians/` - Live stream monitoring and guard logic
-- `moderatorbot/` - Moderation and Discord notification integrations
-- `mybigquery/` - BigQuery transfer logic
-- `i18n/` - Locales and typed translation wrappers
-
-**Backend Entrypoints (`system/`)**:
-- `cmd/youtube-bot/` - Local live chat bot runner
-- `cmd/batch/` - Daily batch executable for Fargate
-- `cmd/lambda/` - Lambda handlers such as `youtube_organize_database`, `check_live_stream_status`, `start_daily_batch`, `set_desired_max_seats`, and `update_work_name_trend`
-
-**Frontend Architecture**:
-- **Next.js** with TypeScript
-- **Redux Toolkit** for state management
-- **Emotion** for CSS-in-JS styling
-- **SWR** for data fetching
-- **Framer Motion** for animations
-- **next-i18next** for localization
-
-## Data Models
-
-### Core Entities
-- **SeatDoc**: Seat information such as user ID, entry time, and work content
-- **UserDoc**: User profiles and accumulated activity
-- **ConstantsConfigDoc**: Runtime constants such as seat counts and polling settings
-- **CredentialsConfigDoc**: Authentication and configuration references
-
-### State Management
-- Firestore transactions ensure atomicity for seat assignment and updates
-- User sessions persist across reconnections
-- Frontend consumes real-time data via Firebase and SWR-based flows
-
-## Testing Strategy
-
-### Go Backend
-- Standard Go testing with `testify`
-- Mock generation using `go.uber.org/mock`
-- Package-level tests around command parsing, repository behavior, and workspace flows
-
-### Frontend
-- **Jest** with **React Testing Library**
-- **ts-jest** for TypeScript support
-- **jsdom** environment for DOM testing
-- Component development and verification with **Storybook**
-
-### Infrastructure
-- CDK unit tests for schedule and infrastructure invariants
-- GitHub Actions CI/CD pipeline
-
-## Code Guidelines
-
-### Important Conventions
-- **Preserve `NOTE` comments**: These contain important implementation details and should not be removed
-- **Add review comments**: Use `[NOTE FOR REVIEW]` prefix for temporary explanatory comments
-- **Error handling**: Include contextual information in error messages
-- **Transaction safety**: Use Firestore transactions for data consistency
-
-### Command System
-Representative chat commands (full strings and member variants live in `system/core/utils/constants.go`):
-- `!in` - General seat entry
-- `/in` - Member seat entry
-- `!out` - Exit seat
-- `!break` / `!rest` / `!chill` - Start break
-- `!resume` - End break
-- `!my` - Show personal stats or update personal settings
-- `!rank` - Display rankings
-- `!more` / `!okawari` - Extend work time
-- Moderation: `!kick`, `!check`, `!block` (member-prefixed variants such as `/kick` are defined alongside)
-
-### Internationalization
-- Support for English, Japanese, and Korean locale files
-- Message templates live under `system/core/i18n/`
-- `system/core/i18n/generate.go` wires `//go:generate go run app.modules/cmd/i18n-gen`; run `go generate ./...` from `system/` to regenerate typed wrappers (and any other `go:generate` targets such as repository mocks)
-- Frontend uses `next-i18next`
-
-## Development Environment
-
-### Required Setup
-1. Go 1.25.0+ for backend development
-2. Node.js **>=20.19.0** (see `youtube-monitor/package.json` `engines`) and `pnpm` for frontend and TypeScript-based subprojects
-3. Google Cloud credentials for Firestore, Cloud Storage, and BigQuery access
-4. AWS credentials for Lambda, Step Functions, Scheduler, and CDK operations
-5. YouTube Data API credentials
-
-### Local Development
-- `system/cmd/youtube-bot` runs the live chat bot locally
-- Install frontend dependencies with `pnpm install` in `youtube-monitor/`
-- Start the frontend dev server with `pnpm dev` in `youtube-monitor/`
-- Start the frontend production server with `pnpm start` in `youtube-monitor/` on port `18080`
-- Storybook runs on port `6006`
-- Use `.env` files for local configuration
-
-### Deployment
-- AWS Lambda functions are containerized with `system/Dockerfile.lambda`
-- Daily batch jobs run on ECS Fargate via `system/Dockerfile.fargate`
-- Daily orchestration is driven by EventBridge Scheduler and Step Functions
-- Infrastructure changes are managed through `aws-cdk/`
-
-## External Integrations
-
-### Google Services
-- **YouTube Data API v3**: Live chat message retrieval and posting
-- **Firestore**: Primary real-time datastore
-- **BigQuery**: Analytics and history transfer target
-- **Cloud Storage**: Export and transfer staging
-
-### AWS Services
-- **Lambda**: Scheduled and on-demand compute
-- **EventBridge / EventBridge Scheduler**: Periodic execution and daily scheduling
-- **Step Functions**: Daily batch orchestration
-- **ECS Fargate**: Daily batch runtime
-- **DynamoDB**: Configuration storage for Lambda functions
-- **API Gateway**: Authenticated REST API
-
-### Third-Party
-- **Discord**: Notification webhooks for moderation and failures
-- **OpenAI API**: Work name trend generation
+- Normal development PRs target `dev`, not `main`, unless the user explicitly requests another base.
+- Keep commits and PRs coherent. Split independent concerns rather than creating a review mega-bundle.
+- PR descriptions should state the goal, key invariants/non-goals, migration/deploy ordering when relevant, and the checks actually run.
+- Never claim a check ran locally when it only ran in GitHub Actions.
+- For stacked PRs, show the stack and base relationship clearly. Before merging/rebasing, re-check that each PR contains only its intended delta.
+- If review uncovers a repeatable defect, include the prevention-layer decision (test/lint/CI/rules/architecture/instruction) as part of completing the fix.


### PR DESCRIPTION
## 概要

`AGENTS.md`がプロジェクト説明・バージョン情報・運用ルールを広く抱え、既にNode要件などで正本とのドリフトが発生していました。Codexが毎タスク必要とする判断だけへ圧縮し、変わりやすい情報は正本ファイルを参照する構成へ整理します。併せてPRテンプレートで作業契約をレビュー工程へ引き継ぎます。

## 変更内容

- Node/pnpm/Go等のバージョンを`AGENTS.md`へ重複記載せず、`.node-version`、package manifest、`go.mod`を正本として参照
- 通常PRは最新`dev`からfresh branchを作り、merged/closed PRのhead branchを再利用しないルールを追加
- `gh pr create`では通常PRの`--base dev`を明示し、repository defaultへの誤作成を防ぐルールを維持
- 意図的なstacked PRは許可し、直前PRをbaseにしてstack/deploy順を明示するルールを追加
- substantial taskでGoal / Invariants / Non-goals / Acceptance criteria / Verificationを先に定める作業契約を追加
- reviewで再現可能な問題をtest / rules・constraint / lint / CI / AGENTS / architectureへ還元する品質ループを追加
- system、youtube-monitor、AWS CDK、CI path routingの代表的な決定論的検証入口を整理
- Firestore Emulator scriptはrepository rootから実行することを明示し、作業directory起因の誤実行を防止
- Firestore transactionのcommit/rollback、`errors.Is`、client/server config境界など、直近のレビューで重要だった横断不変条件を短く残す
- PRテンプレートへGoal / Invariants・Non-goals / Stack・Migration・Deploy / Verification / 再発防止を追加
- 長いアーキテクチャ説明・コマンド一覧・変わりやすい依存情報を削除

## 背景

PR #973ではmerged済みPRのbranch再利用により古い差分が再混入し、人間レビューでbranch整理が必要になりました。一方、現在のsecurity migrationのような意図的stackは正当なので、両者を区別できるルールにしています。

また、PR #965のように繰り返しreview指摘をlintへ移す運用を、個別対応ではなくrepository-wideの品質原則として明文化します。

## 検証

ローカルcloneは実行環境のネットワーク制約で行えなかったため、PR Actionsを正とします。最新headのCIは成功しています。
