### PR TITLE
feat: add read-only user data inventory command

### DIFF
--- a/system/cmd/privacy-admin/main.go
+++ b/system/cmd/privacy-admin/main.go
@@ -16,10 +16,10 @@ import (
 )
 
 type inspectOutput struct {
-	YouTubeChannelID string                       `json:"youtube_channel_id"`
+	YouTubeChannelID string                        `json:"youtube_channel_id"`
 	Firestore        privacyops.FirestoreInventory `json:"firestore"`
-	BigQuery         mybigquery.UserDataInventory `json:"bigquery"`
-	Notes            []string                     `json:"notes"`
+	BigQuery         mybigquery.UserDataInventory  `json:"bigquery"`
+	Notes            []string                      `json:"notes"`
 }
 
 func main() {
@@ -58,11 +58,20 @@ func run(ctx context.Context, args []string) error {
 		return fmt.Errorf("inspect Firestore: %w", err)
 	}
 
+	constants, err := repo.ReadSystemConstantsConfig(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("read system constants: %w", err)
+	}
 	projectID, err := utils.GetGcpProjectID(ctx, clientOption)
 	if err != nil {
 		return fmt.Errorf("resolve GCP project ID: %w", err)
 	}
-	bqClient, err := mybigquery.NewBigqueryClient(ctx, projectID, clientOption, "US")
+	bqClient, err := mybigquery.NewBigqueryClient(
+		ctx,
+		projectID,
+		clientOption,
+		constants.GcpRegion,
+	)
 	if err != nil {
 		return fmt.Errorf("initialize BigQuery: %w", err)
 	}

--- a/system/cmd/privacy-admin/main.go
+++ b/system/cmd/privacy-admin/main.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"app.modules/core/mybigquery"
+	"app.modules/core/repository"
+	"app.modules/core/utils"
+	"app.modules/internal/privacyops"
+	"google.golang.org/api/option"
+)
+
+type inspectOutput struct {
+	YouTubeChannelID string                       `json:"youtube_channel_id"`
+	Firestore        privacyops.FirestoreInventory `json:"firestore"`
+	BigQuery         mybigquery.UserDataInventory `json:"bigquery"`
+	Notes            []string                     `json:"notes"`
+}
+
+func main() {
+	if err := run(context.Background(), os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, "privacy-admin:", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args []string) error {
+	if len(args) != 3 || args[1] != "inspect" {
+		return errors.New("usage: privacy-admin inspect <youtube-channel-id>")
+	}
+	youtubeChannelID := strings.TrimSpace(args[2])
+	if youtubeChannelID == "" {
+		return errors.New("youtube channel id is empty")
+	}
+
+	utils.LoadEnv(".env")
+	credentialFilePath := strings.TrimSpace(os.Getenv("CREDENTIAL_FILE_LOCATION"))
+	if credentialFilePath == "" {
+		return errors.New("CREDENTIAL_FILE_LOCATION is required")
+	}
+	clientOption := option.WithCredentialsFile(credentialFilePath)
+
+	repo, err := repository.NewFirestoreController(ctx, clientOption)
+	if err != nil {
+		return fmt.Errorf("initialize Firestore: %w", err)
+	}
+	defer func() {
+		_ = repo.FirestoreClient().Close()
+	}()
+
+	firestoreInventory, err := privacyops.InspectFirestore(ctx, repo.FirestoreClient(), youtubeChannelID)
+	if err != nil {
+		return fmt.Errorf("inspect Firestore: %w", err)
+	}
+
+	projectID, err := utils.GetGcpProjectID(ctx, clientOption)
+	if err != nil {
+		return fmt.Errorf("resolve GCP project ID: %w", err)
+	}
+	bqClient, err := mybigquery.NewBigqueryClient(ctx, projectID, clientOption, "US")
+	if err != nil {
+		return fmt.Errorf("initialize BigQuery: %w", err)
+	}
+	defer bqClient.CloseClient()
+
+	bigQueryInventory, err := bqClient.InspectUserData(ctx, youtubeChannelID)
+	if err != nil {
+		return fmt.Errorf("inspect BigQuery: %w", err)
+	}
+
+	output := inspectOutput{
+		YouTubeChannelID: youtubeChannelID,
+		Firestore:        firestoreInventory,
+		BigQuery:         bigQueryInventory,
+		Notes: []string{
+			"read-only: this command does not delete data",
+			"GCS Firestore export snapshots are not inspectable per user by this command",
+			"Firebase Auth user existence is not checked; firebase_uid is reported when a MyPage mapping exists",
+		},
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(output); err != nil {
+		return fmt.Errorf("encode inventory: %w", err)
+	}
+	return nil
+}

--- a/system/cmd/privacy-admin/main.go
+++ b/system/cmd/privacy-admin/main.go
@@ -8,18 +8,19 @@ import (
 	"os"
 	"strings"
 
+	"google.golang.org/api/option"
+
 	"app.modules/core/mybigquery"
 	"app.modules/core/repository"
 	"app.modules/core/utils"
 	"app.modules/internal/privacyops"
-	"google.golang.org/api/option"
 )
 
 type inspectOutput struct {
-	YouTubeChannelID string                        `json:"youtube_channel_id"`
-	Firestore        privacyops.FirestoreInventory `json:"firestore"`
-	BigQuery         mybigquery.UserDataInventory  `json:"bigquery"`
-	Notes            []string                      `json:"notes"`
+	YouTubeChannelID string                         `json:"youtube_channel_id"`
+	Firestore        privacyops.FirestoreInventory  `json:"firestore"`
+	BigQuery         mybigquery.UserDataInventory   `json:"bigquery"`
+	Notes            []string                       `json:"notes"`
 }
 
 func main() {

--- a/system/cmd/privacy-admin/main.go
+++ b/system/cmd/privacy-admin/main.go
@@ -17,10 +17,10 @@ import (
 )
 
 type inspectOutput struct {
-	YouTubeChannelID string                         `json:"youtube_channel_id"`
-	Firestore        privacyops.FirestoreInventory  `json:"firestore"`
-	BigQuery         mybigquery.UserDataInventory   `json:"bigquery"`
-	Notes            []string                       `json:"notes"`
+	YouTubeChannelID string                        `json:"youtube_channel_id"`
+	Firestore        privacyops.FirestoreInventory `json:"firestore"`
+	BigQuery         mybigquery.UserDataInventory  `json:"bigquery"`
+	Notes            []string                      `json:"notes"`
 }
 
 func main() {
@@ -44,6 +44,7 @@ func run(ctx context.Context, args []string) error {
 	if credentialFilePath == "" {
 		return errors.New("CREDENTIAL_FILE_LOCATION is required")
 	}
+	//nolint:staticcheck // Credential file path is operator-controlled and restricted to the service-account JSON used for this admin command.
 	clientOption := option.WithCredentialsFile(credentialFilePath)
 
 	repo, err := repository.NewFirestoreController(ctx, clientOption)
@@ -51,7 +52,9 @@ func run(ctx context.Context, args []string) error {
 		return fmt.Errorf("initialize Firestore: %w", err)
 	}
 	defer func() {
-		_ = repo.FirestoreClient().Close()
+		if err := repo.FirestoreClient().Close(); err != nil {
+			fmt.Fprintln(os.Stderr, "privacy-admin: close Firestore:", err)
+		}
 	}()
 
 	firestoreInventory, err := privacyops.InspectFirestore(ctx, repo.FirestoreClient(), youtubeChannelID)

--- a/system/core/mybigquery/user_inventory.go
+++ b/system/core/mybigquery/user_inventory.go
@@ -1,0 +1,95 @@
+package mybigquery
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"cloud.google.com/go/bigquery"
+)
+
+type UserDataInventory struct {
+	LiveChatHistoryRows   int64 `json:"live_chat_history_rows"`
+	UserActivityRows      int64 `json:"user_activity_rows"`
+	OrderHistoryRows      int64 `json:"order_history_rows"`
+}
+
+type countRow struct {
+	RowCount int64 `bigquery:"row_count"`
+}
+
+// InspectUserData returns counts of BigQuery rows attributable to a YouTube
+// channel ID. It does not modify any table.
+func (c *BigqueryController) InspectUserData(
+	ctx context.Context,
+	youtubeChannelID string,
+) (UserDataInventory, error) {
+	youtubeChannelID = strings.TrimSpace(youtubeChannelID)
+	if youtubeChannelID == "" {
+		return UserDataInventory{}, fmt.Errorf("youtube channel id is empty")
+	}
+
+	liveChatRows, err := c.countRowsByField(
+		ctx,
+		LiveChatHistoryMainTableName,
+		"author_channel_id",
+		youtubeChannelID,
+	)
+	if err != nil {
+		return UserDataInventory{}, fmt.Errorf("count live chat history rows: %w", err)
+	}
+
+	userActivityRows, err := c.countRowsByField(
+		ctx,
+		UserActivityHistoryMainTableName,
+		"user_id",
+		youtubeChannelID,
+	)
+	if err != nil {
+		return UserDataInventory{}, fmt.Errorf("count user activity rows: %w", err)
+	}
+
+	orderHistoryRows, err := c.countRowsByField(
+		ctx,
+		OrderHistoryMainTableName,
+		"user_id",
+		youtubeChannelID,
+	)
+	if err != nil {
+		return UserDataInventory{}, fmt.Errorf("count order history rows: %w", err)
+	}
+
+	return UserDataInventory{
+		LiveChatHistoryRows: liveChatRows,
+		UserActivityRows:    userActivityRows,
+		OrderHistoryRows:    orderHistoryRows,
+	}, nil
+}
+
+func (c *BigqueryController) countRowsByField(
+	ctx context.Context,
+	tableName string,
+	fieldName string,
+	value string,
+) (int64, error) {
+	query := c.Client.Query(fmt.Sprintf(
+		"SELECT COUNT(*) AS row_count FROM `%s.%s.%s` WHERE %s = @value",
+		c.Client.Project(),
+		DatasetName,
+		tableName,
+		fieldName,
+	))
+	query.Location = c.WorkingRegion
+	query.Parameters = []bigquery.QueryParameter{{Name: "value", Value: value}}
+
+	iterator, err := query.Read(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	var row countRow
+	if err := iterator.Next(&row); err != nil {
+		return 0, err
+	}
+	return row.RowCount, nil
+}

--- a/system/core/mybigquery/user_inventory.go
+++ b/system/core/mybigquery/user_inventory.go
@@ -9,9 +9,9 @@ import (
 )
 
 type UserDataInventory struct {
-	LiveChatHistoryRows   int64 `json:"live_chat_history_rows"`
-	UserActivityRows      int64 `json:"user_activity_rows"`
-	OrderHistoryRows      int64 `json:"order_history_rows"`
+	LiveChatHistoryRows int64 `json:"live_chat_history_rows"`
+	UserActivityRows    int64 `json:"user_activity_rows"`
+	OrderHistoryRows    int64 `json:"order_history_rows"`
 }
 
 type countRow struct {
@@ -84,12 +84,12 @@ func (c *BigqueryController) countRowsByField(
 
 	iterator, err := query.Read(ctx)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("read count query: %w", err)
 	}
 
 	var row countRow
 	if err := iterator.Next(&row); err != nil {
-		return 0, err
+		return 0, fmt.Errorf("read count query row: %w", err)
 	}
 	return row.RowCount, nil
 }

--- a/system/internal/privacyops/inventory.go
+++ b/system/internal/privacyops/inventory.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"strings"
 
-	"app.modules/core/repository"
 	"cloud.google.com/go/firestore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"app.modules/core/repository"
 )
 
 const (

--- a/system/internal/privacyops/inventory.go
+++ b/system/internal/privacyops/inventory.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/firestore"
+	"cloud.google.com/go/firestore/apiv1/firestorepb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -18,10 +19,11 @@ const (
 	mypageChannelOwnersCollection = "mypage-youtube-channel-owners"
 	authorChannelIDField          = "author-channel-id"
 	firebaseUIDField              = "firebase-uid"
+	countAlias                    = "row_count"
 )
 
 type FirestoreInventory struct {
-	Collections map[string]int         `json:"collections"`
+	Collections map[string]int64       `json:"collections"`
 	MyPage      MyPageMappingInventory `json:"mypage"`
 }
 
@@ -66,7 +68,7 @@ func InspectFirestore(
 	}
 
 	inventory := FirestoreInventory{
-		Collections: make(map[string]int, len(userIDCollectionLookups)+1),
+		Collections: make(map[string]int64, len(userIDCollectionLookups)+1),
 	}
 
 	userExists, err := documentExists(ctx, client.Collection(repository.USERS).Doc(youtubeChannelID))
@@ -102,16 +104,26 @@ func countDocumentsByField(
 	collection string,
 	field string,
 	value string,
-) (int, error) {
-	docs, err := client.Collection(collection).
+) (int64, error) {
+	result, err := client.Collection(collection).
 		Where(field, "==", value).
-		Select().
-		Documents(ctx).
-		GetAll()
+		NewAggregationQuery().
+		WithCount(countAlias).
+		Get(ctx)
 	if err != nil {
-		return 0, fmt.Errorf("query matching documents: %w", err)
+		return 0, fmt.Errorf("run count aggregation: %w", err)
 	}
-	return len(docs), nil
+
+	rawCount, ok := result[countAlias]
+	if !ok {
+		return 0, fmt.Errorf("count aggregation result missing alias %q", countAlias)
+	}
+	countValue, ok := rawCount.(*firestorepb.Value)
+	if !ok {
+		return 0, fmt.Errorf("count aggregation result has unexpected type %T", rawCount)
+	}
+
+	return countValue.GetIntegerValue(), nil
 }
 
 func inspectMyPageMappings(

--- a/system/internal/privacyops/inventory.go
+++ b/system/internal/privacyops/inventory.go
@@ -105,8 +105,8 @@ func countDocumentsByField(
 	field string,
 	value string,
 ) (int64, error) {
-	result, err := client.Collection(collection).
-		Where(field, "==", value).
+	query := client.Collection(collection).Where(field, "==", value)
+	result, err := query.
 		NewAggregationQuery().
 		WithCount(countAlias).
 		Get(ctx)

--- a/system/internal/privacyops/inventory.go
+++ b/system/internal/privacyops/inventory.go
@@ -2,10 +2,12 @@ package privacyops
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
 	"app.modules/core/repository"
+	"cloud.google.com/go/firestore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -18,13 +20,13 @@ const (
 )
 
 type FirestoreInventory struct {
-	Collections map[string]int        `json:"collections"`
+	Collections map[string]int         `json:"collections"`
 	MyPage      MyPageMappingInventory `json:"mypage"`
 }
 
 type MyPageMappingInventory struct {
-	ChannelOwnerDocument int    `json:"channel_owner_document"`
-	LinkedAccountDocument int   `json:"linked_account_document"`
+	ChannelOwnerDocument  int    `json:"channel_owner_document"`
+	LinkedAccountDocument int    `json:"linked_account_document"`
 	FirebaseUID           string `json:"firebase_uid,omitempty"`
 }
 
@@ -56,10 +58,10 @@ func InspectFirestore(
 ) (FirestoreInventory, error) {
 	youtubeChannelID = strings.TrimSpace(youtubeChannelID)
 	if youtubeChannelID == "" {
-		return FirestoreInventory{}, errorsNewEmptyChannelID()
+		return FirestoreInventory{}, errors.New("youtube channel id is empty")
 	}
 	if client == nil {
-		return FirestoreInventory{}, fmt.Errorf("firestore client is nil")
+		return FirestoreInventory{}, errors.New("firestore client is nil")
 	}
 
 	inventory := FirestoreInventory{
@@ -144,7 +146,7 @@ func inspectMyPageMappings(
 	return inventory, nil
 }
 
-func documentExists(ctx context.Context, ref interface{ Get(context.Context) (*firestore.DocumentSnapshot, error) }) (bool, error) {
+func documentExists(ctx context.Context, ref *firestore.DocumentRef) (bool, error) {
 	_, err := ref.Get(ctx)
 	if status.Code(err) == codes.NotFound {
 		return false, nil
@@ -153,8 +155,4 @@ func documentExists(ctx context.Context, ref interface{ Get(context.Context) (*f
 		return false, err
 	}
 	return true, nil
-}
-
-func errorsNewEmptyChannelID() error {
-	return fmt.Errorf("youtube channel id is empty")
 }

--- a/system/internal/privacyops/inventory.go
+++ b/system/internal/privacyops/inventory.go
@@ -1,0 +1,160 @@
+package privacyops
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"app.modules/core/repository"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	mypageUsersCollection         = "mypage-users"
+	mypageChannelOwnersCollection = "mypage-youtube-channel-owners"
+	authorChannelIDField          = "author-channel-id"
+	firebaseUIDField              = "firebase-uid"
+)
+
+type FirestoreInventory struct {
+	Collections map[string]int        `json:"collections"`
+	MyPage      MyPageMappingInventory `json:"mypage"`
+}
+
+type MyPageMappingInventory struct {
+	ChannelOwnerDocument int    `json:"channel_owner_document"`
+	LinkedAccountDocument int   `json:"linked_account_document"`
+	FirebaseUID           string `json:"firebase_uid,omitempty"`
+}
+
+type collectionLookup struct {
+	collection string
+	field      string
+}
+
+var userIDCollectionLookups = []collectionLookup{
+	{collection: repository.SEATS, field: repository.UserIDDocProperty},
+	{collection: repository.MemberSeats, field: repository.UserIDDocProperty},
+	{collection: repository.UserActivities, field: repository.UserIDDocProperty},
+	{collection: repository.WorkSegments, field: repository.UserIDDocProperty},
+	{collection: repository.OrderHistory, field: repository.UserIDDocProperty},
+	{collection: repository.SeatLimitsBlackList, field: repository.UserIDDocProperty},
+	{collection: repository.SeatLimitsWhiteList, field: repository.UserIDDocProperty},
+	{collection: repository.MemberSeatLimitsBlackList, field: repository.UserIDDocProperty},
+	{collection: repository.MemberSeatLimitsWhiteList, field: repository.UserIDDocProperty},
+	{collection: repository.LiveChatHistory, field: authorChannelIDField},
+}
+
+// InspectFirestore returns counts of documents directly attributable to a
+// YouTube channel ID. It is deliberately read-only and is intended to be run
+// before any user-data deletion operation.
+func InspectFirestore(
+	ctx context.Context,
+	client repository.DBClient,
+	youtubeChannelID string,
+) (FirestoreInventory, error) {
+	youtubeChannelID = strings.TrimSpace(youtubeChannelID)
+	if youtubeChannelID == "" {
+		return FirestoreInventory{}, errorsNewEmptyChannelID()
+	}
+	if client == nil {
+		return FirestoreInventory{}, fmt.Errorf("firestore client is nil")
+	}
+
+	inventory := FirestoreInventory{
+		Collections: make(map[string]int, len(userIDCollectionLookups)+1),
+	}
+
+	userExists, err := documentExists(ctx, client.Collection(repository.USERS).Doc(youtubeChannelID))
+	if err != nil {
+		return FirestoreInventory{}, fmt.Errorf("inspect users document: %w", err)
+	}
+	if userExists {
+		inventory.Collections[repository.USERS] = 1
+	} else {
+		inventory.Collections[repository.USERS] = 0
+	}
+
+	for _, lookup := range userIDCollectionLookups {
+		count, err := countDocumentsByField(ctx, client, lookup.collection, lookup.field, youtubeChannelID)
+		if err != nil {
+			return FirestoreInventory{}, fmt.Errorf("inspect collection %s: %w", lookup.collection, err)
+		}
+		inventory.Collections[lookup.collection] = count
+	}
+
+	mypageInventory, err := inspectMyPageMappings(ctx, client, youtubeChannelID)
+	if err != nil {
+		return FirestoreInventory{}, fmt.Errorf("inspect mypage mappings: %w", err)
+	}
+	inventory.MyPage = mypageInventory
+
+	return inventory, nil
+}
+
+func countDocumentsByField(
+	ctx context.Context,
+	client repository.DBClient,
+	collection string,
+	field string,
+	value string,
+) (int, error) {
+	docs, err := client.Collection(collection).
+		Where(field, "==", value).
+		Select().
+		Documents(ctx).
+		GetAll()
+	if err != nil {
+		return 0, err
+	}
+	return len(docs), nil
+}
+
+func inspectMyPageMappings(
+	ctx context.Context,
+	client repository.DBClient,
+	youtubeChannelID string,
+) (MyPageMappingInventory, error) {
+	ownerRef := client.Collection(mypageChannelOwnersCollection).Doc(youtubeChannelID)
+	ownerSnapshot, err := ownerRef.Get(ctx)
+	if status.Code(err) == codes.NotFound {
+		return MyPageMappingInventory{}, nil
+	}
+	if err != nil {
+		return MyPageMappingInventory{}, err
+	}
+
+	inventory := MyPageMappingInventory{ChannelOwnerDocument: 1}
+	firebaseUID, _ := ownerSnapshot.Data()[firebaseUIDField].(string)
+	firebaseUID = strings.TrimSpace(firebaseUID)
+	if firebaseUID == "" {
+		return inventory, nil
+	}
+	inventory.FirebaseUID = firebaseUID
+
+	accountExists, err := documentExists(ctx, client.Collection(mypageUsersCollection).Doc(firebaseUID))
+	if err != nil {
+		return MyPageMappingInventory{}, err
+	}
+	if accountExists {
+		inventory.LinkedAccountDocument = 1
+	}
+
+	return inventory, nil
+}
+
+func documentExists(ctx context.Context, ref interface{ Get(context.Context) (*firestore.DocumentSnapshot, error) }) (bool, error) {
+	_, err := ref.Get(ctx)
+	if status.Code(err) == codes.NotFound {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func errorsNewEmptyChannelID() error {
+	return fmt.Errorf("youtube channel id is empty")
+}

--- a/system/internal/privacyops/inventory.go
+++ b/system/internal/privacyops/inventory.go
@@ -109,7 +109,7 @@ func countDocumentsByField(
 		Documents(ctx).
 		GetAll()
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("query matching documents: %w", err)
 	}
 	return len(docs), nil
 }
@@ -125,11 +125,21 @@ func inspectMyPageMappings(
 		return MyPageMappingInventory{}, nil
 	}
 	if err != nil {
-		return MyPageMappingInventory{}, err
+		return MyPageMappingInventory{}, fmt.Errorf("get mypage channel owner: %w", err)
 	}
 
 	inventory := MyPageMappingInventory{ChannelOwnerDocument: 1}
-	firebaseUID, _ := ownerSnapshot.Data()[firebaseUIDField].(string)
+	rawFirebaseUID, ok := ownerSnapshot.Data()[firebaseUIDField]
+	if !ok {
+		return inventory, nil
+	}
+	firebaseUID, ok := rawFirebaseUID.(string)
+	if !ok {
+		return MyPageMappingInventory{}, fmt.Errorf(
+			"mypage channel owner firebase uid has unexpected type %T",
+			rawFirebaseUID,
+		)
+	}
 	firebaseUID = strings.TrimSpace(firebaseUID)
 	if firebaseUID == "" {
 		return inventory, nil
@@ -153,7 +163,7 @@ func documentExists(ctx context.Context, ref *firestore.DocumentRef) (bool, erro
 		return false, nil
 	}
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("get document %q: %w", ref.Path, err)
 	}
 	return true, nil
 }

--- a/system/internal/privacyops/inventory_test.go
+++ b/system/internal/privacyops/inventory_test.go
@@ -1,0 +1,15 @@
+package privacyops
+
+import (
+	"context"
+	"testing"
+)
+
+func TestInspectFirestoreRejectsEmptyChannelID(t *testing.T) {
+	t.Parallel()
+
+	_, err := InspectFirestore(context.Background(), nil, "   ")
+	if err == nil {
+		t.Fatal("InspectFirestore() error = nil, want error")
+	}
+}


### PR DESCRIPTION
## Summary

- YouTube channel ID に紐づくユーザーデータ件数を確認する read-only admin command を追加
- Firestore の主要collectionを横断して件数を表示
- Firestore件数取得はAggregation COUNTを使い、該当ドキュメント本文を全件読み込まない
- BigQuery の live chat / user activity / order history を横断して件数を表示
- `feature/mypage` 導入後の `mypage-users` / `mypage-youtube-channel-owners` も存在すれば検出可能
- 削除操作は一切実装しない

## Why

Issue #984 のユーザーデータ削除フローを安全に実装するため、いきなり破壊操作を追加せず、まず「対象channel IDのデータがどのstoreに何件あるか」を確認できるdry-run相当のinspection基盤を作ります。

## Usage

```bash
cd system
CREDENTIAL_FILE_LOCATION=/path/to/service-account.json \
  go run ./cmd/privacy-admin inspect UCxxxxxxxx
```

JSONで以下を出力します。

- Firestore
  - `users`
  - `seats` / `member-seats`
  - `user-activities`
  - `work-segments`
  - `order-history`
  - general/member seat limit collections
  - `live-chat-history`
  - optional MyPage ownership/link mapping
- BigQuery
  - `firestore_export.live-chat-history`
  - `firestore_export.user-activity-history`
  - `firestore_export.order-history`

## Safety

- command はread-only
- delete/update APIは持たない
- Firestoreの履歴件数はserver-side aggregationで数え、内容を一括取得しない
- GCS snapshot はper-userに安全にinspectできないため対象外として明示
- Firebase Auth user自体の存在確認/削除はまだ行わない

## Validation

- CI: success
- System Go Test: success
- Go Lint: success
- System Firestore Emulator Test: success
- Generated Files Up-to-Date: success
- input validation unit testを追加

## Follow-up

- #984 本人からのデータ削除依頼フロー
- #983 GCS raw live chat retention
- #986 raw chat logging / Discord retention
