### PR TITLE
fix: stop logging raw YouTube chat messages

### DIFF
--- a/system/cmd/youtube-bot/main.go
+++ b/system/cmd/youtube-bot/main.go
@@ -198,7 +198,6 @@ func Bot(ctx context.Context, clientOption option.ClientOption) {
 			isModerator := youtubebot.IsChatMessageByModerator(chatMessage)
 			isOwner := youtubebot.IsChatMessageByOwner(chatMessage)
 			isMember := isOwner || youtubebot.IsChatMessageByMember(chatMessage)
-			slog.Info(chatMessage.AuthorDetails.ChannelId + " (" + chatMessage.AuthorDetails.DisplayName + "): " + message)
 			if err := app.ProcessMessage(ctx, ngWordConfig, message, channelID, displayName, profileImageURL, isModerator, isOwner, isMember); err != nil {
 				app.MessageToOwnerWithError(ctx, "error in ProcessMessage()", err)
 			}


### PR DESCRIPTION
## Summary

- YouTube Bot の通常process logから、ライブチャット本文・channel ID・display nameの出力を削除
- コマンド処理、Firestore `live-chat-history` 保存、NGワード検知、エラー/運用ログは変更しない

## Why

通常のライブチャットは既に `live-chat-history` として管理されており、さらにprocess logへ全文を複製する必要性がありませんでした。

raw YouTube API data の保存経路を減らし、ログ保存先のretentionに依存してチャット本文が長期残存する経路を1つ閉じます。

Related: #986

## Scope

1行のraw chat `slog.Info(...)` を削除するだけの小さい変更です。

このPRでは以下は変更しません。

- Firestore / BigQuery raw chat retention: #985
- GCS export retention: #983
- Discord moderation copies / fan funding event retention: #986
- user-requested deletion flow: #984

## Validation

- CI: success
- System Go Test: success
- Go Lint: success
- System Firestore Emulator Test: success
- Generated Files Up-to-Date: success
