### PR TITLE
Connect FSL conformance vectors to SeatDoc

### DIFF
--- a/.github/scripts/detect-ci-paths.sh
+++ b/.github/scripts/detect-ci-paths.sh
@@ -82,7 +82,7 @@ classify_path() {
 				aws_cdk=true
 			fi
 			case "$path" in
-				system/core/repository/seat.go|system/core/repository/models.go|system/core/timeutil/*)
+				system/core/repository/seat.go|system/core/repository/models.go|system/core/repository/seat_formalspec_test.go|system/core/timeutil/*)
 					formal_spec=true
 					;;
 			esac

--- a/.github/scripts/run-formal-spec-tests.sh
+++ b/.github/scripts/run-formal-spec-tests.sh
@@ -11,3 +11,12 @@ FSLC="$("$fsl_root/scripts/install.sh")"
 export FSLC
 
 bash "$fsl_root/scripts/verify.sh"
+
+vectors_dir="${FSL_GENERATED_DIR:-$fsl_root/generated}"
+vectors="$vectors_dir/seat_session.conformance.json"
+bash "$fsl_root/scripts/conformance.sh" "$vectors" >/dev/null
+
+(
+	cd "$repo_root/system"
+	FSL_SEAT_CONFORMANCE_FILE="$vectors" go test -count=1 -tags=formalspec -run '^TestSeatFSLConformance$' ./core/repository
+)

--- a/.github/scripts/test-detect-ci-paths.sh
+++ b/.github/scripts/test-detect-ci-paths.sh
@@ -39,6 +39,7 @@ assert_exact_groups "system firestore_integration" system/core/repository/firest
 assert_exact_groups "system firestore_integration" system/core/workspaceapp/workspace_app_private_test.go
 assert_exact_groups "system firestore_integration formal_spec" system/core/repository/seat.go
 assert_exact_groups "system firestore_integration formal_spec" system/core/repository/models.go
+assert_exact_groups "system firestore_integration formal_spec" system/core/repository/seat_formalspec_test.go
 assert_exact_groups "system firestore_integration formal_spec" system/core/timeutil/time.go
 assert_exact_groups "system firestore_integration aws_cdk" system/Dockerfile.lambda
 assert_exact_groups "system firestore_integration aws_cdk" system/.dockerignore

--- a/formal-spec/README.md
+++ b/formal-spec/README.md
@@ -24,7 +24,10 @@ CI を緑にすること自体を目的に仕様を弱めてはいけません�
 
 ## 現在の構成
 
-- `fsl/`: FSL による形式仕様と検証スクリプト
+- `fsl/`: FSL による形式仕様、検証、language-neutral conformance vector の生成
+- `system/core/repository/seat_formalspec_test.go`: `formalspec` build tag のときだけ有効になる Go conformance adapter
 - 最初の対象: `SeatSession`（座席の Work / Break 状態遷移）
 
-次段階では FSL の conformance vector と Go 実装を接続しますが、通常の Go テストや本番ランタイムは FSL 非依存のまま維持します。
+CI では FSL が生成した conformance vector を oracle として `SeatDoc` の実装を照合します。vector は一時生成物でコミットせず、通常の `go test ./...` と本番ランタイムは FSL 非依存のまま維持します。
+
+将来 FSL を置き換える場合は、`formal-spec/fsl/` と build tag 付き adapter / 専用 CI の入力部分だけを交換し、本番コードや Firestore schema には波及させません。

--- a/formal-spec/fsl/README.md
+++ b/formal-spec/fsl/README.md
@@ -10,29 +10,43 @@ FSL の更新は通常の依存更新として、バージョン・checksum・�
 
 ## ローカル検証
 
+FSL 仕様だけを検証する場合:
+
 ```bash
 bash formal-spec/fsl/scripts/verify.sh
 ```
 
-対応している開発環境は Linux x86_64 / arm64 と macOS Apple Silicon です。`fslc` は `formal-spec/fsl/.tools/` にキャッシュされ、コミットされません。
+`SeatSession` の conformance vector 生成から Go 実装との照合まで含めた CI 相当の検証:
+
+```bash
+bash .github/scripts/run-formal-spec-tests.sh
+```
+
+対応している FSL 開発環境は Linux x86_64 / arm64 と macOS Apple Silicon です。`fslc` は `formal-spec/fsl/.tools/` にキャッシュされ、生成した conformance JSON は `formal-spec/fsl/generated/` に置かれ、どちらもコミットされません。
 
 環境変数:
 
 - `FSLC`: 既存の `fslc` 実行ファイルを明示する
 - `FSL_TOOL_DIR`: ダウンロード先を変更する
 - `FSL_VERIFY_DEPTH`: BMC の depth を変更する（既定 8）
+- `FSL_CONFORMANCE_DEPTH`: conformance vector の探索 depth を変更する（既定 4）
+- `FSL_GENERATED_DIR`: conformance JSON の生成先を変更する
 
 ## CI gate
 
-PR では各 `.fsl` に対して以下を実行します。
+PR の形式仕様 job では以下を実行します。
 
 ```text
 fslc check
 fslc verify --depth 8 --vacuity error
+fslc conformance seat_session.fsl --depth 4
+Go conformance adapter (build tag: formalspec)
 ```
+
+Go adapter は FSL の `conformance.v1` JSON を読み、各 reachable state / action instance について `SeatDoc` の実装結果を照合します。`requires_failed` の vector では Go 側も error を返し、`SeatDoc` が変更されないことまで確認します。仕様で新しい outcome が現れた場合は自動で skip せず、分類を要求して失敗します。
 
 Linux バイナリは Ubuntu 24.04 ABI を前提としているため、専用 CI job は `ubuntu-24.04` を使います。
 
 ## 境界
 
-FSL は本番依存ではありません。Go / Firestore / Lambda / ECS から FSL を呼び出さず、形式仕様の導入・撤去が本番成果物に波及しない状態を維持します。
+FSL は本番依存ではありません。Go / Firestore / Lambda / ECS から FSL を呼び出さず、形式仕様の導入・撤去が本番成果物に波及しない状態を維持します。Go conformance adapter も `formalspec` build tag のテスト専用コードであり、通常ビルドには含まれません。

--- a/formal-spec/fsl/scripts/conformance.sh
+++ b/formal-spec/fsl/scripts/conformance.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+fsl_root="$(cd -- "$script_dir/.." && pwd)"
+fslc="${FSLC:-$("$script_dir/install.sh")}"
+depth="${FSL_CONFORMANCE_DEPTH:-4}"
+output="${1:-$fsl_root/generated/seat_session.conformance.json}"
+
+mkdir -p "$(dirname -- "$output")"
+tmp_output="${output}.tmp.$$"
+trap 'rm -f "$tmp_output"' EXIT
+
+"$fslc" conformance "$fsl_root/specs/seat_session.fsl" --depth "$depth" >"$tmp_output"
+mv "$tmp_output" "$output"
+trap - EXIT
+
+printf '%s\n' "$output"

--- a/system/core/repository/seat_formalspec_test.go
+++ b/system/core/repository/seat_formalspec_test.go
@@ -1,0 +1,275 @@
+//go:build formalspec
+
+package repository
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	seatConformanceFileEnv = "FSL_SEAT_CONFORMANCE_FILE"
+	seatModelClockMax      = 4
+)
+
+var seatModelEpoch = time.Date(2026, 1, 1, 12, 0, 0, 0, time.FixedZone("JST", 9*60*60))
+
+type seatConformanceDocument struct {
+	SchemaVersion       string                 `json:"schema_version"`
+	KernelSchemaVersion string                 `json:"kernel_schema_version"`
+	Result              string                 `json:"result"`
+	Spec                string                 `json:"spec"`
+	States              []seatConformanceState `json:"states"`
+	Vectors             []seatConformanceVector `json:"vectors"`
+}
+
+type seatConformanceState struct {
+	ID    string       `json:"id"`
+	State seatFSLState `json:"state"`
+}
+
+type seatConformanceVector struct {
+	State   string                 `json:"state"`
+	Action  seatConformanceAction  `json:"action"`
+	Outcome seatConformanceOutcome `json:"outcome"`
+}
+
+type seatConformanceAction struct {
+	Name   string         `json:"name"`
+	Params map[string]int `json:"params"`
+}
+
+type seatConformanceOutcome struct {
+	Kind         string       `json:"kind"`
+	StateChanged bool         `json:"state_changed"`
+	State        seatFSLState `json:"state"`
+}
+
+type seatFSLState struct {
+	Mode                    string `json:"mode"`
+	Now                     int    `json:"now"`
+	Until                   int    `json:"until"`
+	CurrentStateStartedAt   int    `json:"current_state_started_at"`
+	CurrentStateUntil       int    `json:"current_state_until"`
+	CurrentSegmentStartedAt int    `json:"current_segment_started_at"`
+	CumulativeWork          int    `json:"cumulative_work"`
+}
+
+func TestSeatFSLConformance(t *testing.T) {
+	vectorPath := os.Getenv(seatConformanceFileEnv)
+	if vectorPath == "" {
+		t.Fatalf("%s is required when running formalspec tests", seatConformanceFileEnv)
+	}
+
+	data, err := os.ReadFile(vectorPath)
+	if err != nil {
+		t.Fatalf("read conformance vectors: %v", err)
+	}
+
+	var doc seatConformanceDocument
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("decode conformance vectors: %v", err)
+	}
+	if !strings.HasPrefix(doc.SchemaVersion, "1.") {
+		t.Fatalf("unsupported conformance schema version: %q", doc.SchemaVersion)
+	}
+	if !strings.HasPrefix(doc.KernelSchemaVersion, "1.") {
+		t.Fatalf("unsupported kernel schema version: %q", doc.KernelSchemaVersion)
+	}
+	if doc.Result != "conformance" {
+		t.Fatalf("unexpected conformance result: %q", doc.Result)
+	}
+	if doc.Spec != "SeatSession" {
+		t.Fatalf("unexpected spec: %q", doc.Spec)
+	}
+	if len(doc.Vectors) == 0 {
+		t.Fatal("conformance vector set is empty")
+	}
+
+	states := make(map[string]seatFSLState, len(doc.States))
+	for _, state := range doc.States {
+		if _, exists := states[state.ID]; exists {
+			t.Fatalf("duplicate conformance state id: %s", state.ID)
+		}
+		states[state.ID] = state.State
+	}
+
+	coverage := map[string]map[string]int{}
+	for i, vector := range doc.Vectors {
+		input, ok := states[vector.State]
+		if !ok {
+			t.Fatalf("vector %d references unknown state %q", i, vector.State)
+		}
+		if coverage[vector.Action.Name] == nil {
+			coverage[vector.Action.Name] = map[string]int{}
+		}
+		coverage[vector.Action.Name][vector.Outcome.Kind]++
+
+		name := fmt.Sprintf("%04d_%s_%s", i, vector.Action.Name, vector.Outcome.Kind)
+		t.Run(name, func(t *testing.T) {
+			seat, logicalNow := seatDocFromFSLState(t, input)
+			beforeSeat := seat
+			beforeNow := logicalNow
+
+			err := applySeatConformanceAction(&seat, &logicalNow, vector.Action)
+			switch vector.Outcome.Kind {
+			case "ok":
+				if err != nil {
+					t.Fatalf("Go implementation rejected FSL-enabled action: %v", err)
+				}
+			case "requires_failed":
+				if err == nil {
+					t.Fatal("Go implementation accepted an FSL-disabled action")
+				}
+				if !reflect.DeepEqual(seat, beforeSeat) || logicalNow != beforeNow {
+					t.Fatalf("disabled action mutated state: before=%+v/%d after=%+v/%d", beforeSeat, beforeNow, seat, logicalNow)
+				}
+			default:
+				t.Fatalf("unsupported FSL outcome %q; classify the mismatch instead of skipping the vector", vector.Outcome.Kind)
+			}
+
+			got := projectSeatToFSLState(seat, logicalNow)
+			if got != vector.Outcome.State {
+				t.Fatalf("state mismatch\ninput:    %+v\naction:   %+v\nexpected: %+v\ngot:      %+v", input, vector.Action, vector.Outcome.State, got)
+			}
+			if changed := got != input; changed != vector.Outcome.StateChanged {
+				t.Fatalf("state_changed mismatch: expected=%v got=%v", vector.Outcome.StateChanged, changed)
+			}
+		})
+	}
+
+	for _, action := range []string{
+		"start_break",
+		"resume_work",
+		"set_work_duration",
+		"extend_work_duration",
+		"extend_break_duration",
+	} {
+		if coverage[action]["ok"] == 0 {
+			t.Errorf("conformance corpus has no successful vector for %s", action)
+		}
+		if coverage[action]["requires_failed"] == 0 {
+			t.Errorf("conformance corpus has no disabled vector for %s", action)
+		}
+	}
+}
+
+func seatDocFromFSLState(t *testing.T, state seatFSLState) (SeatDoc, int) {
+	t.Helper()
+
+	var mode SeatState
+	switch state.Mode {
+	case "Work":
+		mode = WorkState
+	case "Break":
+		mode = BreakState
+	default:
+		t.Fatalf("unknown FSL mode: %q", state.Mode)
+	}
+
+	return SeatDoc{
+		SeatID:                  1,
+		UserID:                  "formalspec-user",
+		SessionID:               "formalspec-session",
+		State:                   mode,
+		EnteredAt:               seatModelEpoch,
+		Until:                   seatModelTime(state.Until),
+		CurrentStateStartedAt:   seatModelTime(state.CurrentStateStartedAt),
+		CurrentStateUntil:       seatModelTime(state.CurrentStateUntil),
+		CurrentSegmentStartedAt: seatModelTime(state.CurrentSegmentStartedAt),
+		CumulativeWorkSec:       state.CumulativeWork * 60,
+	}, state.Now
+}
+
+func applySeatConformanceAction(seat *SeatDoc, logicalNow *int, action seatConformanceAction) error {
+	now := seatModelTime(*logicalNow)
+
+	switch action.Name {
+	case "tick":
+		if *logicalNow >= seatModelClockMax {
+			return errors.New("model clock upper bound reached")
+		}
+		*logicalNow++
+		return nil
+	case "start_break":
+		duration, err := seatConformanceParam(action, "duration")
+		if err != nil {
+			return err
+		}
+		return seat.StartBreak(now, "formalspec-break", duration)
+	case "resume_work":
+		return seat.ResumeWork(now, "formalspec-work")
+	case "set_work_duration":
+		duration, err := seatConformanceParam(action, "duration")
+		if err != nil {
+			return err
+		}
+		return seat.SetWorkDuration(now.Add(time.Duration(duration) * time.Minute))
+	case "extend_work_duration":
+		add, err := seatConformanceParam(action, "add")
+		if err != nil {
+			return err
+		}
+		maxRemaining, err := seatConformanceParam(action, "max_remaining")
+		if err != nil {
+			return err
+		}
+		_, _, err = seat.ExtendWorkDuration(now, add, maxRemaining)
+		return err
+	case "extend_break_duration":
+		add, err := seatConformanceParam(action, "add")
+		if err != nil {
+			return err
+		}
+		maxBreakDuration, err := seatConformanceParam(action, "max_break_duration")
+		if err != nil {
+			return err
+		}
+		_, _, _, err = seat.ExtendBreakDuration(now, add, maxBreakDuration)
+		return err
+	default:
+		return fmt.Errorf("unsupported SeatSession action: %s", action.Name)
+	}
+}
+
+func seatConformanceParam(action seatConformanceAction, name string) (int, error) {
+	value, ok := action.Params[name]
+	if !ok {
+		return 0, fmt.Errorf("action %s is missing parameter %s", action.Name, name)
+	}
+	return value, nil
+}
+
+func projectSeatToFSLState(seat SeatDoc, logicalNow int) seatFSLState {
+	mode := string(seat.State)
+	switch seat.State {
+	case WorkState:
+		mode = "Work"
+	case BreakState:
+		mode = "Break"
+	}
+
+	return seatFSLState{
+		Mode:                    mode,
+		Now:                     logicalNow,
+		Until:                   seatModelMinute(seat.Until),
+		CurrentStateStartedAt:   seatModelMinute(seat.CurrentStateStartedAt),
+		CurrentStateUntil:       seatModelMinute(seat.CurrentStateUntil),
+		CurrentSegmentStartedAt: seatModelMinute(seat.CurrentSegmentStartedAt),
+		CumulativeWork:          seat.CumulativeWorkSec / 60,
+	}
+}
+
+func seatModelTime(minute int) time.Time {
+	return seatModelEpoch.Add(time.Duration(minute) * time.Minute)
+}
+
+func seatModelMinute(value time.Time) int {
+	return int(value.Sub(seatModelEpoch) / time.Minute)
+}

--- a/system/core/repository/seat_formalspec_test.go
+++ b/system/core/repository/seat_formalspec_test.go
@@ -21,12 +21,12 @@ const (
 var seatModelEpoch = time.Date(2026, 1, 1, 12, 0, 0, 0, time.FixedZone("JST", 9*60*60))
 
 type seatConformanceDocument struct {
-	SchemaVersion       string                 `json:"schema_version"`
-	KernelSchemaVersion string                 `json:"kernel_schema_version"`
-	Result              string                 `json:"result"`
-	Spec                string                 `json:"spec"`
-	States              []seatConformanceState `json:"states"`
-	Vectors             []seatConformanceVector `json:"vectors"`
+	SchemaVersion        string                  `json:"schema_version"`
+	KernelSchemaVersion  string                  `json:"kernel_schema_version"`
+	Result               string                  `json:"result"`
+	Spec                 string                  `json:"spec"`
+	States               []seatConformanceState  `json:"states"`
+	Vectors              []seatConformanceVector `json:"vectors"`
 }
 
 type seatConformanceState struct {
@@ -195,7 +195,7 @@ func applySeatConformanceAction(seat *SeatDoc, logicalNow *int, action seatConfo
 		if *logicalNow >= seatModelClockMax {
 			return errors.New("model clock upper bound reached")
 		}
-		*logicalNow++
+		(*logicalNow)++
 		return nil
 	case "start_break":
 		duration, err := seatConformanceParam(action, "duration")


### PR DESCRIPTION
## 概要

FSL `SeatSession` を仕様の検証だけで終わらせず、`fslc conformance` が生成する language-neutral JSON vector を Go の `SeatDoc` 実装へ接続し、仕様と実装の振る舞いを CI で照合します。

## 変更内容

- `formal-spec/fsl/scripts/conformance.sh` を追加
  - pinned `fslc` で `SeatSession` の `conformance.v1` JSON を depth 4 で生成
  - 生成物は `formal-spec/fsl/generated/` 配下の一時ファイルで、コミットしない
- `system/core/repository/seat_formalspec_test.go` を追加
  - `//go:build formalspec` で通常の Go test / production build から隔離
  - FSL state を固定 JST epoch の `SeatDoc` へ射影
  - `StartBreak` / `ResumeWork` / `SetWorkDuration` / `ExtendWorkDuration` / `ExtendBreakDuration` を実行
  - `ok` vector は FSL expected state と modeled fields を比較
  - `requires_failed` vector は Go 側も error になり、SeatDoc 全体が不変であることを検証
  - 未対応 outcome は skip せず fail して分類を要求
  - 各 domain action に success / disabled の両 vector が存在することを保証
  - `tick` は Go domain method ではなく検証 harness の clock としてのみ扱う
- `.github/scripts/run-formal-spec-tests.sh` を拡張し、verify → conformance生成 → Go adapter test を一連で実行
- path detector に build-tag test を formal-spec 対象として追加
- formal-spec README を現行構成に更新

## 設計上の境界

- FSL は production runtime から呼ばない
- conformance JSON はリポジトリにコミットしない
- 通常の `go test ./...` は FSL / vector ファイル不要
- FSL を将来置き換える場合は generator + build-tag adapter の境界を交換し、本番 Go / Firestore schema には波及させない
- mismatch 時に仕様を弱める、depthを下げる、vectorをskipすることでCIを緑にすることは禁止する既存方針を維持

## Acceptance criteria

GitHub Actions の `Formal Spec (FSL)` job 上で pinned FSL v4.2.0 を使い、以下が一続きで成功すること:

1. `fslc check`
2. `fslc verify --depth 8 --vacuity error`
3. `fslc conformance ... --depth 4`
4. `go test -tags=formalspec` による SeatDoc conformance test
5. 既存 CI Gate 全体が成功
