### PR TITLE
Add FSL requirement traceability and review reports

### DIFF
--- a/.github/scripts/run-formal-spec-tests.sh
+++ b/.github/scripts/run-formal-spec-tests.sh
@@ -12,14 +12,11 @@ export FSLC
 
 bash "$fsl_root/scripts/verify.sh"
 
-generated_dir="${FSL_GENERATED_DIR:-$fsl_root/generated}"
-vectors="$generated_dir/seat_session.conformance.json"
-report="$generated_dir/seat_session.html"
+vectors_dir="${FSL_GENERATED_DIR:-$fsl_root/generated}"
+vectors="$vectors_dir/seat_session.conformance.json"
 bash "$fsl_root/scripts/conformance.sh" "$vectors" >/dev/null
 
 (
 	cd "$repo_root/system"
 	FSL_SEAT_CONFORMANCE_FILE="$vectors" go test -count=1 -tags=formalspec -run '^TestSeatFSLConformance$' ./core/repository
 )
-
-bash "$fsl_root/scripts/report.sh" "$report" >/dev/null

--- a/.github/scripts/run-formal-spec-tests.sh
+++ b/.github/scripts/run-formal-spec-tests.sh
@@ -12,11 +12,14 @@ export FSLC
 
 bash "$fsl_root/scripts/verify.sh"
 
-vectors_dir="${FSL_GENERATED_DIR:-$fsl_root/generated}"
-vectors="$vectors_dir/seat_session.conformance.json"
+generated_dir="${FSL_GENERATED_DIR:-$fsl_root/generated}"
+vectors="$generated_dir/seat_session.conformance.json"
+report="$generated_dir/seat_session.html"
 bash "$fsl_root/scripts/conformance.sh" "$vectors" >/dev/null
 
 (
 	cd "$repo_root/system"
 	FSL_SEAT_CONFORMANCE_FILE="$vectors" go test -count=1 -tags=formalspec -run '^TestSeatFSLConformance$' ./core/repository
 )
+
+bash "$fsl_root/scripts/report.sh" "$report" >/dev/null

--- a/.github/workflows/formal-spec-report.yml
+++ b/.github/workflows/formal-spec-report.yml
@@ -1,0 +1,41 @@
+name: Formal Spec Report
+
+on:
+  pull_request:
+    paths:
+      - "formal-spec/**"
+      - ".github/workflows/formal-spec-report.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    name: SeatSession HTML Report
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Cache pinned FSL tool
+        uses: actions/cache@v5
+        with:
+          path: formal-spec/fsl/.tools
+          key: ${{ runner.os }}-fsl-${{ hashFiles('formal-spec/fsl/VERSION', 'formal-spec/fsl/SHA256SUMS') }}
+
+      - name: Generate self-contained HTML report
+        run: bash formal-spec/fsl/scripts/report.sh
+
+      - name: Upload HTML review report
+        uses: actions/upload-artifact@v7
+        with:
+          name: seat-session-fsl-report
+          path: formal-spec/fsl/generated/seat_session.html
+          if-no-files-found: error
+          retention-days: 14

--- a/formal-spec/fsl/README.md
+++ b/formal-spec/fsl/README.md
@@ -47,19 +47,22 @@ requirement metadata は検証そのものの代替ではありません。契�
 
 ## CI gate
 
-PR の形式仕様 job では以下を実行します。
+PR の `Formal Spec (FSL)` job では以下を実行します。
 
 ```text
 fslc check
 fslc verify --depth 8 --vacuity error
 fslc conformance seat_session.fsl --depth 4
 Go conformance adapter (build tag: formalspec)
-fslc html --depth 8
 ```
 
 Go adapter は FSL の `conformance.v1` JSON を読み、各 reachable state / action instance について `SeatDoc` の実装結果を照合します。`requires_failed` の vector では Go 側も error を返し、`SeatDoc` が変更されないことまで確認します。仕様で新しい outcome が現れた場合は自動で skip せず、分類を要求して失敗します。
 
-`Formal Spec Report` workflow は形式仕様が変わった PR で `seat_session.html` を生成し、GitHub Actions artifact `seat-session-fsl-report` として 14 日間保持します。レポートは自己完結 HTML で、state / action / property、requirement metadata、検証結果、witness などを CLI なしでレビューするための補助資料です。
+## Review report
+
+`Formal Spec Report` workflow は形式仕様が変わった PR で `fslc html --depth 8` を1回だけ実行し、`seat_session.html` を GitHub Actions artifact `seat-session-fsl-report` として 14 日間保持します。main formal gate と分離することで、検証・conformance の gate にレポート生成コストを重複させません。
+
+レポートは自己完結 HTML で、state / action / property、requirement metadata、検証結果、witness などを CLI なしでレビューするための補助資料です。HTML 生成に失敗した場合は `Formal Spec Report` workflow 自体が失敗します。
 
 Linux バイナリは Ubuntu 24.04 ABI を前提としているため、専用 CI job は `ubuntu-24.04` を使います。
 

--- a/formal-spec/fsl/README.md
+++ b/formal-spec/fsl/README.md
@@ -22,7 +22,13 @@ bash formal-spec/fsl/scripts/verify.sh
 bash .github/scripts/run-formal-spec-tests.sh
 ```
 
-対応している FSL 開発環境は Linux x86_64 / arm64 と macOS Apple Silicon です。`fslc` は `formal-spec/fsl/.tools/` にキャッシュされ、生成した conformance JSON は `formal-spec/fsl/generated/` に置かれ、どちらもコミットされません。
+人間向けの自己完結 HTML レポートだけを生成する場合:
+
+```bash
+bash formal-spec/fsl/scripts/report.sh
+```
+
+対応している FSL 開発環境は Linux x86_64 / arm64 と macOS Apple Silicon です。`fslc` は `formal-spec/fsl/.tools/` にキャッシュされ、生成した conformance JSON / HTML は `formal-spec/fsl/generated/` に置かれ、どちらもコミットされません。
 
 環境変数:
 
@@ -30,7 +36,14 @@ bash .github/scripts/run-formal-spec-tests.sh
 - `FSL_TOOL_DIR`: ダウンロード先を変更する
 - `FSL_VERIFY_DEPTH`: BMC の depth を変更する（既定 8）
 - `FSL_CONFORMANCE_DEPTH`: conformance vector の探索 depth を変更する（既定 4）
-- `FSL_GENERATED_DIR`: conformance JSON の生成先を変更する
+- `FSL_REPORT_DEPTH`: HTML レポートの検証 depth を変更する（既定 8）
+- `FSL_GENERATED_DIR`: conformance JSON / HTML の生成先を変更する
+
+## Requirement traceability
+
+`SeatSession` の既存契約 ID `REQ-SEAT-001` 〜 `REQ-SEAT-005` はコメントではなく、FSL の正準な `@requirement(id, text)` metadata として対象 action / invariant に付与します。これにより verifier の診断や HTML レポートから、どの宣言がどの契約を担うか追跡できます。
+
+requirement metadata は検証そのものの代替ではありません。契約の意味は action / invariant の式で検証し、ID と説明はレビュー時のトレーサビリティとして使います。
 
 ## CI gate
 
@@ -41,9 +54,12 @@ fslc check
 fslc verify --depth 8 --vacuity error
 fslc conformance seat_session.fsl --depth 4
 Go conformance adapter (build tag: formalspec)
+fslc html --depth 8
 ```
 
 Go adapter は FSL の `conformance.v1` JSON を読み、各 reachable state / action instance について `SeatDoc` の実装結果を照合します。`requires_failed` の vector では Go 側も error を返し、`SeatDoc` が変更されないことまで確認します。仕様で新しい outcome が現れた場合は自動で skip せず、分類を要求して失敗します。
+
+`Formal Spec Report` workflow は形式仕様が変わった PR で `seat_session.html` を生成し、GitHub Actions artifact `seat-session-fsl-report` として 14 日間保持します。レポートは自己完結 HTML で、state / action / property、requirement metadata、検証結果、witness などを CLI なしでレビューするための補助資料です。
 
 Linux バイナリは Ubuntu 24.04 ABI を前提としているため、専用 CI job は `ubuntu-24.04` を使います。
 

--- a/formal-spec/fsl/scripts/report.sh
+++ b/formal-spec/fsl/scripts/report.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+fsl_root="$(cd -- "$script_dir/.." && pwd)"
+fslc="${FSLC:-$("$script_dir/install.sh")}"
+depth="${FSL_REPORT_DEPTH:-8}"
+output="${1:-$fsl_root/generated/seat_session.html}"
+
+mkdir -p "$(dirname -- "$output")"
+tmp_output="${output}.tmp.$$"
+trap 'rm -f "$tmp_output"' EXIT
+
+"$fslc" html "$fsl_root/specs/seat_session.fsl" --depth "$depth" -o "$tmp_output"
+mv "$tmp_output" "$output"
+trap - EXIT
+
+printf '%s\n' "$output"

--- a/formal-spec/fsl/specs/seat_session.fsl
+++ b/formal-spec/fsl/specs/seat_session.fsl
@@ -91,13 +91,13 @@ spec SeatSession {
     }
   }
 
-  @requirement("REQ-SEAT-005", "休憩終了時刻は自動退室時刻を超えない")
+  @requirement("REQ-SEAT-005", "Break 延長は休憩開始からの上限を守り、必要なら自動退室時刻も延長する")
   @kind("safety")
   invariant BreakEndsBeforeExit {
     current_state_until <= until
   }
 
-  @requirement("REQ-SEAT-003", "Work 中は状態終了時刻と自動退室時刻が一致する")
+  @requirement("REQ-SEAT-003", "Work 中の作業時間変更では自動退室時刻と状態終了時刻を同期する")
   @kind("safety")
   invariant WorkDeadlineMatchesExit {
     mode == Work => current_state_until == until

--- a/formal-spec/fsl/specs/seat_session.fsl
+++ b/formal-spec/fsl/specs/seat_session.fsl
@@ -34,7 +34,7 @@ spec SeatSession {
     now = now + 1
   }
 
-  // REQ-SEAT-001: 休憩開始は Work 中だけ許可する。
+  @requirement("REQ-SEAT-001", "休憩開始は Work 中だけ許可する")
   action start_break(duration: Duration) {
     requires mode == Work
     cumulative_work = cumulative_work + (now - current_state_started_at)
@@ -47,7 +47,7 @@ spec SeatSession {
     }
   }
 
-  // REQ-SEAT-002: 作業再開は Break 中だけ許可する。
+  @requirement("REQ-SEAT-002", "作業再開は Break 中だけ許可する")
   action resume_work() {
     requires mode == Break
     mode = Work
@@ -56,15 +56,14 @@ spec SeatSession {
     current_segment_started_at = now
   }
 
-  // REQ-SEAT-003: Work 中の終了時刻変更は現在時刻からの duration で指定し、
-  // Until と状態終了時刻を同期する。
+  @requirement("REQ-SEAT-003", "Work 中の作業時間変更では自動退室時刻と状態終了時刻を同期する")
   action set_work_duration(duration: Duration) {
     requires mode == Work
     until = now + duration
     current_state_until = now + duration
   }
 
-  // REQ-SEAT-004: Work 延長は現在時刻からの最大残り時間を超えない。
+  @requirement("REQ-SEAT-004", "Work 延長は現在時刻からの最大残り時間を超えない")
   action extend_work_duration(add: Duration, max_remaining: MaxDuration) {
     requires mode == Work
     if until + add - now > max_remaining {
@@ -76,7 +75,7 @@ spec SeatSession {
     }
   }
 
-  // REQ-SEAT-005: Break 延長は休憩開始からの上限を守り、必要なら Until も延長する。
+  @requirement("REQ-SEAT-005", "Break 延長は休憩開始からの上限を守り、必要なら自動退室時刻も延長する")
   action extend_break_duration(add: Duration, max_break_duration: MaxDuration) {
     requires mode == Break
     if current_state_until + add - current_state_started_at > max_break_duration {
@@ -92,22 +91,29 @@ spec SeatSession {
     }
   }
 
+  @requirement("REQ-SEAT-005", "休憩終了時刻は自動退室時刻を超えない")
+  @kind("safety")
   invariant BreakEndsBeforeExit {
     current_state_until <= until
   }
 
+  @requirement("REQ-SEAT-003", "Work 中は状態終了時刻と自動退室時刻が一致する")
+  @kind("safety")
   invariant WorkDeadlineMatchesExit {
     mode == Work => current_state_until == until
   }
 
+  @kind("safety")
   invariant StateStartNotInFuture {
     current_state_started_at <= now
   }
 
+  @kind("safety")
   invariant SegmentStartNotInFuture {
     current_segment_started_at <= now
   }
 
+  @kind("safety")
   invariant CumulativeWorkNeverNegative {
     cumulative_work >= 0
   }


### PR DESCRIPTION
## 概要

形式仕様を verifier / conformance CI だけでなく、人間がレビューしやすい形へ拡張します。既存の `REQ-SEAT-001` 〜 `REQ-SEAT-005` を FSL の正準な typed requirement metadata に昇格し、自己完結 HTML レポートを GitHub Actions artifact として生成します。

## 変更内容

- `SeatSession` の既存 `REQ-SEAT-*` を `@requirement(id, text)` で action / 関連 invariant に紐付け
- safety invariant に `@kind("safety")` metadata を追加
- 同一 requirement ID は同一の正準テキストを共有
- `formal-spec/fsl/scripts/report.sh` を追加
  - pinned `fslc` の `fslc html --depth 8` を使用
  - self-contained HTML を `generated/seat_session.html` に生成
  - 一時ファイル → rename で不完全な出力を残さない
- `Formal Spec Report` workflow を追加
  - FSL 関連 PR で HTML を1回だけ生成
  - `actions/upload-artifact@v7`
  - artifact名 `seat-session-fsl-report`
  - 14日保持
- main `Formal Spec (FSL)` job は verify / conformance / Go adapter に専念し、HTML生成コストを重複させない
- README に requirement traceability / report運用を追記

## 境界

- requirement metadata は verification の代替ではなく、action / invariant と契約IDのレビュー用トレーサビリティ
- HTML は生成物でありコミットしない
- production Go / Firestore / deploy artifact には影響なし
- FSL は引き続き交換可能な sidecar として維持

## Acceptance criteria

- 既存 `check` / `verify` / conformance / Go adapter がすべて成功
- `Formal Spec Report` workflow で pinned v4.2.0 の `fslc html --depth 8` が成功
- HTML artifact `seat-session-fsl-report` が実際に生成・uploadされる
- artifact内で `REQ-SEAT-001`〜`005` と関連 action / invariant が確認できる
- CI Gate が成功
