### PR TITLE
feat: add guarded primary user data deletion operation

### DIFF
--- a/docs/privacy/user-data-deletion-operations.md
+++ b/docs/privacy/user-data-deletion-operations.md
@@ -1,0 +1,102 @@
+# User data deletion operations
+
+## Purpose
+
+This document describes the operator workflow for responding to a verified user request to delete Study Space data associated with a YouTube channel ID.
+
+It is an internal engineering/operations document. The public Privacy Policy must separately explain how users request deletion and what categories of data are affected.
+
+## Commands
+
+### Inspect only
+
+```bash
+cd system
+CREDENTIAL_FILE_LOCATION=/path/to/service-account.json \
+  go run ./cmd/privacy-admin inspect UCxxxxxxxx
+```
+
+This command is read-only. It reports attributable document/row counts from the primary Firestore and BigQuery stores.
+
+### Delete primary stores
+
+```bash
+cd system
+CREDENTIAL_FILE_LOCATION=/path/to/service-account.json \
+  go run ./cmd/privacy-admin delete-primary UCxxxxxxxx --confirm UCxxxxxxxx
+```
+
+`--confirm` must exactly match the target YouTube channel ID. This is intentionally verbose because the operation is destructive.
+
+The command performs:
+
+1. pre-delete inspection;
+2. removal from primary Firestore collections;
+3. removal from primary BigQuery history tables;
+4. post-delete inspection;
+5. a non-zero exit if primary-store data remains.
+
+The command is designed to be idempotent. If a partial failure occurs, inspect and rerun after the underlying problem is fixed.
+
+## Firestore scope
+
+Primary deletion covers data attributable by YouTube channel ID in:
+
+- `users`
+- `seats`
+- `member-seats`
+- `user-activities`
+- `work-segments`
+- `order-history`
+- `seat-limits-black-list`
+- `seat-limits-white-list`
+- `member-seat-limits-black-list`
+- `member-seat-limits-white-list`
+- `live-chat-history`
+- `mypage-youtube-channel-owners`, when present
+- corresponding `mypage-users` document, when present
+
+Active seat documents are removed directly instead of running the normal `!out` path. A privacy deletion should not manufacture a new exit activity or final work segment immediately before deleting the same user's history.
+
+## BigQuery scope
+
+Primary deletion covers attributable rows from:
+
+- `firestore_export.live-chat-history` by `author_channel_id`
+- `firestore_export.user-activity-history` by `user_id`
+- `firestore_export.order-history` by `user_id`
+
+## Important exclusions
+
+`delete-primary` is deliberately not named `delete-all`. It does **not** guarantee erasure from every system.
+
+It does not delete:
+
+- historical Firestore export snapshots in Google Cloud Storage;
+- Firebase Authentication user records;
+- Discord moderation/log messages;
+- data stored by YouTube itself;
+- data outside systems controlled by Study Space.
+
+GCS export retention is tracked separately because snapshots may be disaster-recovery backups containing unrelated collections and must not be rewritten or blindly deleted per user.
+
+## Operator process
+
+Before deletion:
+
+1. verify the requester controls the target YouTube channel;
+2. record the request date and target channel ID in the private operator record;
+3. run `privacy-admin inspect` and save the output privately;
+4. confirm there is no channel-ID mismatch;
+5. run `delete-primary` with the repeated confirmation value.
+
+After deletion:
+
+1. retain the command's post-delete verification output privately as evidence of completion;
+2. complete the GCS/Firebase Auth/Discord steps defined by their respective retention procedures;
+3. confirm to the requester when the applicable deletion process is complete;
+4. do not publish the channel ID, Firebase UID, or deletion inventory in a public GitHub issue.
+
+## Reuse after deletion
+
+A user who posts in the live chat or uses Study Space again after deletion may cause new data to be created. The public Privacy Policy should state this clearly.

--- a/system/cmd/privacy-admin/main.go
+++ b/system/cmd/privacy-admin/main.go
@@ -138,7 +138,13 @@ func runDeletePrimary(
 		},
 	}
 
-	return encodeJSON(output)
+	if err := encodeJSON(output); err != nil {
+		return err
+	}
+	if !primaryInventoryIsEmpty(after) {
+		return errors.New("post-delete verification failed: primary user data still exists")
+	}
+	return nil
 }
 
 func validateDeleteConfirmation(youtubeChannelID string, confirmation string) error {
@@ -152,6 +158,21 @@ func validateDeleteConfirmation(youtubeChannelID string, confirmation string) er
 		return errors.New("deletion confirmation must exactly match the YouTube channel id")
 	}
 	return nil
+}
+
+func primaryInventoryIsEmpty(inventory inspectOutput) bool {
+	for _, count := range inventory.Firestore.Collections {
+		if count != 0 {
+			return false
+		}
+	}
+	if inventory.Firestore.MyPage.ChannelOwnerDocument != 0 ||
+		inventory.Firestore.MyPage.LinkedAccountDocument != 0 {
+		return false
+	}
+	return inventory.BigQuery.LiveChatHistoryRows == 0 &&
+		inventory.BigQuery.UserActivityRows == 0 &&
+		inventory.BigQuery.OrderHistoryRows == 0
 }
 
 func newClients(ctx context.Context) (*clients, error) {
@@ -170,12 +191,12 @@ func newClients(ctx context.Context) (*clients, error) {
 
 	constants, err := repo.ReadSystemConstantsConfig(ctx, nil)
 	if err != nil {
-		_ = repo.FirestoreClient().Close()
+		closeFirestoreAfterInitError(repo)
 		return nil, fmt.Errorf("read system constants: %w", err)
 	}
 	projectID, err := utils.GetGcpProjectID(ctx, clientOption)
 	if err != nil {
-		_ = repo.FirestoreClient().Close()
+		closeFirestoreAfterInitError(repo)
 		return nil, fmt.Errorf("resolve GCP project ID: %w", err)
 	}
 	bqClient, err := mybigquery.NewBigqueryClient(
@@ -185,11 +206,17 @@ func newClients(ctx context.Context) (*clients, error) {
 		constants.GcpRegion,
 	)
 	if err != nil {
-		_ = repo.FirestoreClient().Close()
+		closeFirestoreAfterInitError(repo)
 		return nil, fmt.Errorf("initialize BigQuery: %w", err)
 	}
 
 	return &clients{repository: repo, bigquery: bqClient}, nil
+}
+
+func closeFirestoreAfterInitError(repo *repository.FirestoreControllerImplements) {
+	if err := repo.FirestoreClient().Close(); err != nil {
+		fmt.Fprintln(os.Stderr, "privacy-admin: close Firestore after init error:", err)
+	}
 }
 
 func (c *clients) close() {

--- a/system/cmd/privacy-admin/main.go
+++ b/system/cmd/privacy-admin/main.go
@@ -23,6 +23,19 @@ type inspectOutput struct {
 	Notes            []string                      `json:"notes"`
 }
 
+type deletePrimaryOutput struct {
+	YouTubeChannelID string                           `json:"youtube_channel_id"`
+	Before           inspectOutput                    `json:"before"`
+	FirestoreDeleted privacyops.FirestoreDeleteResult `json:"firestore_deleted"`
+	After            inspectOutput                    `json:"after"`
+	Notes            []string                         `json:"notes"`
+}
+
+type clients struct {
+	repository *repository.FirestoreControllerImplements
+	bigquery   *mybigquery.BigqueryController
+}
+
 func main() {
 	if err := run(context.Background(), os.Args); err != nil {
 		fmt.Fprintln(os.Stderr, "privacy-admin:", err)
@@ -31,44 +44,139 @@ func main() {
 }
 
 func run(ctx context.Context, args []string) error {
-	if len(args) != 3 || args[1] != "inspect" {
-		return errors.New("usage: privacy-admin inspect <youtube-channel-id>")
+	if len(args) < 2 {
+		return usageError()
 	}
-	youtubeChannelID := strings.TrimSpace(args[2])
+
+	switch args[1] {
+	case "inspect":
+		if len(args) != 3 {
+			return usageError()
+		}
+		return runInspect(ctx, strings.TrimSpace(args[2]))
+	case "delete-primary":
+		if len(args) != 5 || args[3] != "--confirm" {
+			return usageError()
+		}
+		return runDeletePrimary(
+			ctx,
+			strings.TrimSpace(args[2]),
+			strings.TrimSpace(args[4]),
+		)
+	default:
+		return usageError()
+	}
+}
+
+func runInspect(ctx context.Context, youtubeChannelID string) error {
 	if youtubeChannelID == "" {
 		return errors.New("youtube channel id is empty")
 	}
 
+	appClients, err := newClients(ctx)
+	if err != nil {
+		return err
+	}
+	defer appClients.close()
+
+	inventory, err := inspect(ctx, appClients, youtubeChannelID)
+	if err != nil {
+		return err
+	}
+	return encodeJSON(inventory)
+}
+
+func runDeletePrimary(
+	ctx context.Context,
+	youtubeChannelID string,
+	confirmation string,
+) error {
+	if err := validateDeleteConfirmation(youtubeChannelID, confirmation); err != nil {
+		return err
+	}
+
+	appClients, err := newClients(ctx)
+	if err != nil {
+		return err
+	}
+	defer appClients.close()
+
+	before, err := inspect(ctx, appClients, youtubeChannelID)
+	if err != nil {
+		return fmt.Errorf("inspect before deletion: %w", err)
+	}
+
+	firestoreDeleted, err := privacyops.DeleteFirestoreUserData(
+		ctx,
+		appClients.repository.FirestoreClient(),
+		youtubeChannelID,
+	)
+	if err != nil {
+		return fmt.Errorf("delete primary Firestore data: %w", err)
+	}
+
+	if err := appClients.bigquery.DeleteUserData(ctx, youtubeChannelID); err != nil {
+		return fmt.Errorf("delete primary BigQuery data: %w", err)
+	}
+
+	after, err := inspect(ctx, appClients, youtubeChannelID)
+	if err != nil {
+		return fmt.Errorf("inspect after deletion: %w", err)
+	}
+
+	output := deletePrimaryOutput{
+		YouTubeChannelID: youtubeChannelID,
+		Before:           before,
+		FirestoreDeleted: firestoreDeleted,
+		After:            after,
+		Notes: []string{
+			"DESTRUCTIVE: primary Firestore and BigQuery data were deleted",
+			"GCS Firestore export snapshots are NOT deleted by this command",
+			"Firebase Authentication user records are NOT deleted by this command",
+			"Discord moderation/log copies are NOT deleted by this command",
+			"using Study Space again after deletion may create new data",
+		},
+	}
+
+	return encodeJSON(output)
+}
+
+func validateDeleteConfirmation(youtubeChannelID string, confirmation string) error {
+	if youtubeChannelID == "" {
+		return errors.New("youtube channel id is empty")
+	}
+	if confirmation == "" {
+		return errors.New("deletion confirmation is empty")
+	}
+	if confirmation != youtubeChannelID {
+		return errors.New("deletion confirmation must exactly match the YouTube channel id")
+	}
+	return nil
+}
+
+func newClients(ctx context.Context) (*clients, error) {
 	utils.LoadEnv(".env")
 	credentialFilePath := strings.TrimSpace(os.Getenv("CREDENTIAL_FILE_LOCATION"))
 	if credentialFilePath == "" {
-		return errors.New("CREDENTIAL_FILE_LOCATION is required")
+		return nil, errors.New("CREDENTIAL_FILE_LOCATION is required")
 	}
 	//nolint:staticcheck // Credential file path is operator-controlled and restricted to the service-account JSON used for this admin command.
 	clientOption := option.WithCredentialsFile(credentialFilePath)
 
 	repo, err := repository.NewFirestoreController(ctx, clientOption)
 	if err != nil {
-		return fmt.Errorf("initialize Firestore: %w", err)
-	}
-	defer func() {
-		if err := repo.FirestoreClient().Close(); err != nil {
-			fmt.Fprintln(os.Stderr, "privacy-admin: close Firestore:", err)
-		}
-	}()
-
-	firestoreInventory, err := privacyops.InspectFirestore(ctx, repo.FirestoreClient(), youtubeChannelID)
-	if err != nil {
-		return fmt.Errorf("inspect Firestore: %w", err)
+		return nil, fmt.Errorf("initialize Firestore: %w", err)
 	}
 
 	constants, err := repo.ReadSystemConstantsConfig(ctx, nil)
 	if err != nil {
-		return fmt.Errorf("read system constants: %w", err)
+		_ = repo.FirestoreClient().Close()
+		return nil, fmt.Errorf("read system constants: %w", err)
 	}
 	projectID, err := utils.GetGcpProjectID(ctx, clientOption)
 	if err != nil {
-		return fmt.Errorf("resolve GCP project ID: %w", err)
+		_ = repo.FirestoreClient().Close()
+		return nil, fmt.Errorf("resolve GCP project ID: %w", err)
 	}
 	bqClient, err := mybigquery.NewBigqueryClient(
 		ctx,
@@ -77,30 +185,62 @@ func run(ctx context.Context, args []string) error {
 		constants.GcpRegion,
 	)
 	if err != nil {
-		return fmt.Errorf("initialize BigQuery: %w", err)
+		_ = repo.FirestoreClient().Close()
+		return nil, fmt.Errorf("initialize BigQuery: %w", err)
 	}
-	defer bqClient.CloseClient()
 
-	bigQueryInventory, err := bqClient.InspectUserData(ctx, youtubeChannelID)
+	return &clients{repository: repo, bigquery: bqClient}, nil
+}
+
+func (c *clients) close() {
+	if err := c.repository.FirestoreClient().Close(); err != nil {
+		fmt.Fprintln(os.Stderr, "privacy-admin: close Firestore:", err)
+	}
+	c.bigquery.CloseClient()
+}
+
+func inspect(
+	ctx context.Context,
+	appClients *clients,
+	youtubeChannelID string,
+) (inspectOutput, error) {
+	firestoreInventory, err := privacyops.InspectFirestore(
+		ctx,
+		appClients.repository.FirestoreClient(),
+		youtubeChannelID,
+	)
 	if err != nil {
-		return fmt.Errorf("inspect BigQuery: %w", err)
+		return inspectOutput{}, fmt.Errorf("inspect Firestore: %w", err)
 	}
 
-	output := inspectOutput{
+	bigQueryInventory, err := appClients.bigquery.InspectUserData(ctx, youtubeChannelID)
+	if err != nil {
+		return inspectOutput{}, fmt.Errorf("inspect BigQuery: %w", err)
+	}
+
+	return inspectOutput{
 		YouTubeChannelID: youtubeChannelID,
 		Firestore:        firestoreInventory,
 		BigQuery:         bigQueryInventory,
 		Notes: []string{
-			"read-only: this command does not delete data",
+			"read-only: this inventory does not delete data",
 			"GCS Firestore export snapshots are not inspectable per user by this command",
 			"Firebase Auth user existence is not checked; firebase_uid is reported when a MyPage mapping exists",
 		},
-	}
+	}, nil
+}
 
+func encodeJSON(value any) error {
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
-	if err := encoder.Encode(output); err != nil {
-		return fmt.Errorf("encode inventory: %w", err)
+	if err := encoder.Encode(value); err != nil {
+		return fmt.Errorf("encode output: %w", err)
 	}
 	return nil
+}
+
+func usageError() error {
+	return errors.New(
+		"usage: privacy-admin inspect <youtube-channel-id> OR privacy-admin delete-primary <youtube-channel-id> --confirm <same-youtube-channel-id>",
+	)
 }

--- a/system/cmd/privacy-admin/main_test.go
+++ b/system/cmd/privacy-admin/main_test.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"testing"
+
+	"app.modules/core/mybigquery"
+	"app.modules/internal/privacyops"
+)
+
+func TestValidateDeleteConfirmation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		channelID    string
+		confirmation string
+		wantErr      bool
+	}{
+		{name: "matching", channelID: "UC123", confirmation: "UC123", wantErr: false},
+		{name: "empty channel", channelID: "", confirmation: "", wantErr: true},
+		{name: "empty confirmation", channelID: "UC123", confirmation: "", wantErr: true},
+		{name: "mismatch", channelID: "UC123", confirmation: "UC456", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateDeleteConfirmation(tt.channelID, tt.confirmation)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("validateDeleteConfirmation() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestPrimaryInventoryIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	empty := inspectOutput{
+		Firestore: privacyops.FirestoreInventory{
+			Collections: map[string]int64{"users": 0, "live-chat-history": 0},
+		},
+		BigQuery: mybigquery.UserDataInventory{},
+	}
+	if !primaryInventoryIsEmpty(empty) {
+		t.Fatal("primaryInventoryIsEmpty() = false for empty inventory")
+	}
+
+	withFirestoreData := empty
+	withFirestoreData.Firestore.Collections = map[string]int64{"users": 1}
+	if primaryInventoryIsEmpty(withFirestoreData) {
+		t.Fatal("primaryInventoryIsEmpty() = true with Firestore data")
+	}
+
+	withMyPageData := empty
+	withMyPageData.Firestore.Collections = map[string]int64{"users": 0}
+	withMyPageData.Firestore.MyPage.ChannelOwnerDocument = 1
+	if primaryInventoryIsEmpty(withMyPageData) {
+		t.Fatal("primaryInventoryIsEmpty() = true with MyPage data")
+	}
+
+	withBigQueryData := empty
+	withBigQueryData.Firestore.Collections = map[string]int64{"users": 0}
+	withBigQueryData.BigQuery.LiveChatHistoryRows = 1
+	if primaryInventoryIsEmpty(withBigQueryData) {
+		t.Fatal("primaryInventoryIsEmpty() = true with BigQuery data")
+	}
+}

--- a/system/core/mybigquery/user_delete.go
+++ b/system/core/mybigquery/user_delete.go
@@ -1,0 +1,75 @@
+package mybigquery
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"cloud.google.com/go/bigquery"
+)
+
+// DeleteUserData removes rows attributable to a YouTube channel ID from the
+// Study Space BigQuery history tables. GCS source snapshots are intentionally
+// out of scope and must be handled by the backup-retention policy separately.
+func (c *BigqueryController) DeleteUserData(ctx context.Context, youtubeChannelID string) error {
+	youtubeChannelID = strings.TrimSpace(youtubeChannelID)
+	if youtubeChannelID == "" {
+		return fmt.Errorf("youtube channel id is empty")
+	}
+
+	deletions := []struct {
+		tableName string
+		fieldName string
+	}{
+		{tableName: LiveChatHistoryMainTableName, fieldName: "author_channel_id"},
+		{tableName: UserActivityHistoryMainTableName, fieldName: "user_id"},
+		{tableName: OrderHistoryMainTableName, fieldName: "user_id"},
+	}
+
+	for _, deletion := range deletions {
+		if err := c.deleteRowsByField(
+			ctx,
+			deletion.tableName,
+			deletion.fieldName,
+			youtubeChannelID,
+		); err != nil {
+			return fmt.Errorf("delete user rows from %s: %w", deletion.tableName, err)
+		}
+	}
+
+	return nil
+}
+
+func (c *BigqueryController) deleteRowsByField(
+	ctx context.Context,
+	tableName string,
+	fieldName string,
+	value string,
+) error {
+	query := c.Client.Query(fmt.Sprintf(
+		"DELETE FROM `%s.%s.%s` WHERE %s = @value",
+		c.Client.Project(),
+		DatasetName,
+		tableName,
+		fieldName,
+	))
+	query.Location = c.WorkingRegion
+	query.Parameters = []bigquery.QueryParameter{{Name: "value", Value: value}}
+
+	job, err := query.Run(ctx)
+	if err != nil {
+		return fmt.Errorf("run delete query: %w", err)
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("wait delete query: %w", err)
+	}
+	if err := status.Err(); err != nil {
+		return fmt.Errorf("delete query failed: %w", err)
+	}
+	if status.State != bigquery.Done {
+		return fmt.Errorf("delete query did not finish: state=%v", status.State)
+	}
+
+	return nil
+}

--- a/system/core/repository/privacy_delete_integration_test.go
+++ b/system/core/repository/privacy_delete_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	"cloud.google.com/go/firestore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"

--- a/system/core/repository/privacy_delete_integration_test.go
+++ b/system/core/repository/privacy_delete_integration_test.go
@@ -1,0 +1,161 @@
+//go:build integration
+
+package repository_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"app.modules/core/repository"
+	"app.modules/internal/integrationtest"
+	"app.modules/internal/privacyops"
+)
+
+func TestPrivacyDeleteFirestoreUserData_DeletesOnlyTargetUser(t *testing.T) {
+	integrationtest.ResetFirestore(t)
+	controller := integrationtest.NewFirestoreController(t)
+	ctx := context.Background()
+	client := controller.FirestoreClient()
+
+	const (
+		targetChannelID = "privacy-delete-target"
+		otherChannelID  = "privacy-delete-other"
+		targetFirebase  = "firebase-target"
+		otherFirebase   = "firebase-other"
+	)
+
+	seedDocument(t, ctx, client.Collection(repository.USERS).Doc(targetChannelID), map[string]any{"marker": "target"})
+	seedDocument(t, ctx, client.Collection(repository.USERS).Doc(otherChannelID), map[string]any{"marker": "other"})
+
+	userIDCollections := []string{
+		repository.SEATS,
+		repository.MemberSeats,
+		repository.UserActivities,
+		repository.WorkSegments,
+		repository.OrderHistory,
+		repository.SeatLimitsBlackList,
+		repository.SeatLimitsWhiteList,
+		repository.MemberSeatLimitsBlackList,
+		repository.MemberSeatLimitsWhiteList,
+	}
+	for index, collection := range userIDCollections {
+		seedDocument(
+			t,
+			ctx,
+			client.Collection(collection).Doc(fmt.Sprintf("target-%02d", index)),
+			map[string]any{repository.UserIDDocProperty: targetChannelID, "marker": "target"},
+		)
+		seedDocument(
+			t,
+			ctx,
+			client.Collection(collection).Doc(fmt.Sprintf("other-%02d", index)),
+			map[string]any{repository.UserIDDocProperty: otherChannelID, "marker": "other"},
+		)
+	}
+
+	seedDocument(
+		t,
+		ctx,
+		client.Collection(repository.LiveChatHistory).Doc("target-message"),
+		map[string]any{"author-channel-id": targetChannelID, "message-text": "target message"},
+	)
+	seedDocument(
+		t,
+		ctx,
+		client.Collection(repository.LiveChatHistory).Doc("other-message"),
+		map[string]any{"author-channel-id": otherChannelID, "message-text": "other message"},
+	)
+
+	seedDocument(
+		t,
+		ctx,
+		client.Collection("mypage-youtube-channel-owners").Doc(targetChannelID),
+		map[string]any{"firebase-uid": targetFirebase},
+	)
+	seedDocument(
+		t,
+		ctx,
+		client.Collection("mypage-users").Doc(targetFirebase),
+		map[string]any{"youtube-channel-id": targetChannelID},
+	)
+	seedDocument(
+		t,
+		ctx,
+		client.Collection("mypage-youtube-channel-owners").Doc(otherChannelID),
+		map[string]any{"firebase-uid": otherFirebase},
+	)
+	seedDocument(
+		t,
+		ctx,
+		client.Collection("mypage-users").Doc(otherFirebase),
+		map[string]any{"youtube-channel-id": otherChannelID},
+	)
+
+	result, err := privacyops.DeleteFirestoreUserData(ctx, client, targetChannelID)
+	require.NoError(t, err)
+	assert.Equal(t, targetFirebase, result.FirebaseUID)
+	assert.Equal(t, 2, result.MyPage)
+
+	assertDocumentMissing(t, ctx, client.Collection(repository.USERS).Doc(targetChannelID))
+	assertDocumentExists(t, ctx, client.Collection(repository.USERS).Doc(otherChannelID))
+
+	for _, collection := range userIDCollections {
+		assertQueryCount(t, ctx, client, collection, repository.UserIDDocProperty, targetChannelID, 0)
+		assertQueryCount(t, ctx, client, collection, repository.UserIDDocProperty, otherChannelID, 1)
+	}
+	assertQueryCount(t, ctx, client, repository.LiveChatHistory, "author-channel-id", targetChannelID, 0)
+	assertQueryCount(t, ctx, client, repository.LiveChatHistory, "author-channel-id", otherChannelID, 1)
+
+	assertDocumentMissing(t, ctx, client.Collection("mypage-youtube-channel-owners").Doc(targetChannelID))
+	assertDocumentMissing(t, ctx, client.Collection("mypage-users").Doc(targetFirebase))
+	assertDocumentExists(t, ctx, client.Collection("mypage-youtube-channel-owners").Doc(otherChannelID))
+	assertDocumentExists(t, ctx, client.Collection("mypage-users").Doc(otherFirebase))
+
+	_, err = privacyops.DeleteFirestoreUserData(ctx, client, targetChannelID)
+	require.NoError(t, err, "privacy deletion must be safe to retry")
+}
+
+func seedDocument(
+	t *testing.T,
+	ctx context.Context,
+	ref *firestore.DocumentRef,
+	data map[string]any,
+) {
+	t.Helper()
+	_, err := ref.Set(ctx, data)
+	require.NoError(t, err)
+}
+
+func assertDocumentMissing(t *testing.T, ctx context.Context, ref *firestore.DocumentRef) {
+	t.Helper()
+	_, err := ref.Get(ctx)
+	require.Error(t, err)
+	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func assertDocumentExists(t *testing.T, ctx context.Context, ref *firestore.DocumentRef) {
+	t.Helper()
+	_, err := ref.Get(ctx)
+	require.NoError(t, err)
+}
+
+func assertQueryCount(
+	t *testing.T,
+	ctx context.Context,
+	client repository.DBClient,
+	collection string,
+	field string,
+	value string,
+	want int,
+) {
+	t.Helper()
+	docs, err := client.Collection(collection).Where(field, "==", value).Documents(ctx).GetAll()
+	require.NoError(t, err)
+	assert.Len(t, docs, want)
+}

--- a/system/internal/privacyops/delete.go
+++ b/system/internal/privacyops/delete.go
@@ -20,6 +20,11 @@ type FirestoreDeleteResult struct {
 	FirebaseUID string         `json:"firebase_uid,omitempty"`
 }
 
+type myPageDeletionTarget struct {
+	ownerExists bool
+	firebaseUID string
+}
+
 var deleteLookups = []collectionLookup{
 	// Active seats are removed first so the seat becomes available even if a
 	// later historical-data deletion fails and the operation has to be retried.
@@ -55,8 +60,16 @@ func DeleteFirestoreUserData(
 		return FirestoreDeleteResult{}, errors.New("firestore client is nil")
 	}
 
+	// Validate any MyPage ownership mapping before making the first write so a
+	// malformed mapping cannot turn a request into an avoidable partial deletion.
+	myPageTarget, err := resolveMyPageDeletionTarget(ctx, client, youtubeChannelID)
+	if err != nil {
+		return FirestoreDeleteResult{}, fmt.Errorf("preflight mypage mapping: %w", err)
+	}
+
 	result := FirestoreDeleteResult{
 		Collections: make(map[string]int, len(deleteLookups)+1),
+		FirebaseUID: myPageTarget.firebaseUID,
 	}
 
 	for _, lookup := range deleteLookups {
@@ -73,12 +86,11 @@ func DeleteFirestoreUserData(
 		result.Collections[lookup.collection] = deleted
 	}
 
-	mypageDeleted, firebaseUID, err := deleteMyPageMappings(ctx, client, youtubeChannelID)
+	mypageDeleted, err := deleteMyPageMappings(ctx, client, youtubeChannelID, myPageTarget)
 	if err != nil {
 		return result, fmt.Errorf("delete mypage mappings: %w", err)
 	}
 	result.MyPage = mypageDeleted
-	result.FirebaseUID = firebaseUID
 
 	userDeleted, err := deleteDocumentIfExists(ctx, client.Collection(repository.USERS).Doc(youtubeChannelID))
 	if err != nil {
@@ -119,49 +131,66 @@ func deleteDocumentsByField(
 	}
 }
 
-func deleteMyPageMappings(
+func resolveMyPageDeletionTarget(
 	ctx context.Context,
 	client repository.DBClient,
 	youtubeChannelID string,
-) (int, string, error) {
+) (myPageDeletionTarget, error) {
 	ownerRef := client.Collection(mypageChannelOwnersCollection).Doc(youtubeChannelID)
 	ownerSnapshot, err := ownerRef.Get(ctx)
 	if status.Code(err) == codes.NotFound {
-		return 0, "", nil
+		return myPageDeletionTarget{}, nil
 	}
 	if err != nil {
-		return 0, "", fmt.Errorf("get mypage channel owner: %w", err)
+		return myPageDeletionTarget{}, fmt.Errorf("get mypage channel owner: %w", err)
 	}
 
 	rawFirebaseUID, ok := ownerSnapshot.Data()[firebaseUIDField]
 	if !ok {
-		return 0, "", errors.New("mypage channel owner is missing firebase uid")
+		return myPageDeletionTarget{}, errors.New("mypage channel owner is missing firebase uid")
 	}
 	firebaseUID, ok := rawFirebaseUID.(string)
 	if !ok {
-		return 0, "", fmt.Errorf("mypage channel owner firebase uid has unexpected type %T", rawFirebaseUID)
+		return myPageDeletionTarget{}, fmt.Errorf(
+			"mypage channel owner firebase uid has unexpected type %T",
+			rawFirebaseUID,
+		)
 	}
 	firebaseUID = strings.TrimSpace(firebaseUID)
 	if firebaseUID == "" {
-		return 0, "", errors.New("mypage channel owner firebase uid is empty")
+		return myPageDeletionTarget{}, errors.New("mypage channel owner firebase uid is empty")
+	}
+
+	return myPageDeletionTarget{ownerExists: true, firebaseUID: firebaseUID}, nil
+}
+
+func deleteMyPageMappings(
+	ctx context.Context,
+	client repository.DBClient,
+	youtubeChannelID string,
+	target myPageDeletionTarget,
+) (int, error) {
+	if !target.ownerExists {
+		return 0, nil
 	}
 
 	deleted := 0
-	accountRef := client.Collection(mypageUsersCollection).Doc(firebaseUID)
+	accountRef := client.Collection(mypageUsersCollection).Doc(target.firebaseUID)
 	accountDeleted, err := deleteDocumentIfExists(ctx, accountRef)
 	if err != nil {
-		return deleted, firebaseUID, fmt.Errorf("delete mypage linked account: %w", err)
+		return deleted, fmt.Errorf("delete mypage linked account: %w", err)
 	}
 	if accountDeleted {
 		deleted++
 	}
 
+	ownerRef := client.Collection(mypageChannelOwnersCollection).Doc(youtubeChannelID)
 	if _, err := ownerRef.Delete(ctx); err != nil {
-		return deleted, firebaseUID, fmt.Errorf("delete mypage channel owner: %w", err)
+		return deleted, fmt.Errorf("delete mypage channel owner: %w", err)
 	}
 	deleted++
 
-	return deleted, firebaseUID, nil
+	return deleted, nil
 }
 
 func deleteDocumentIfExists(ctx context.Context, ref *firestore.DocumentRef) (bool, error) {

--- a/system/internal/privacyops/delete.go
+++ b/system/internal/privacyops/delete.go
@@ -1,0 +1,181 @@
+package privacyops
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"google.golang.org/api/iterator"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"app.modules/core/repository"
+)
+
+type FirestoreDeleteResult struct {
+	Collections map[string]int `json:"collections"`
+	MyPage      int            `json:"mypage_mapping_documents"`
+	FirebaseUID string         `json:"firebase_uid,omitempty"`
+}
+
+var deleteLookups = []collectionLookup{
+	// Active seats are removed first so the seat becomes available even if a
+	// later historical-data deletion fails and the operation has to be retried.
+	{collection: repository.SEATS, field: repository.UserIDDocProperty},
+	{collection: repository.MemberSeats, field: repository.UserIDDocProperty},
+	{collection: repository.UserActivities, field: repository.UserIDDocProperty},
+	{collection: repository.WorkSegments, field: repository.UserIDDocProperty},
+	{collection: repository.OrderHistory, field: repository.UserIDDocProperty},
+	{collection: repository.SeatLimitsBlackList, field: repository.UserIDDocProperty},
+	{collection: repository.SeatLimitsWhiteList, field: repository.UserIDDocProperty},
+	{collection: repository.MemberSeatLimitsBlackList, field: repository.UserIDDocProperty},
+	{collection: repository.MemberSeatLimitsWhiteList, field: repository.UserIDDocProperty},
+	{collection: repository.LiveChatHistory, field: authorChannelIDField},
+}
+
+// DeleteFirestoreUserData deletes primary Firestore documents attributable to a
+// YouTube channel ID. The operation is idempotent and intentionally excludes
+// GCS export snapshots and Firebase Authentication user records.
+//
+// Seat documents are deleted directly instead of executing the ordinary !out
+// flow. A privacy deletion must not create a new exit activity/work segment or
+// preserve the user's accumulated Study Space state merely to close the seat.
+func DeleteFirestoreUserData(
+	ctx context.Context,
+	client repository.DBClient,
+	youtubeChannelID string,
+) (FirestoreDeleteResult, error) {
+	youtubeChannelID = strings.TrimSpace(youtubeChannelID)
+	if youtubeChannelID == "" {
+		return FirestoreDeleteResult{}, errors.New("youtube channel id is empty")
+	}
+	if client == nil {
+		return FirestoreDeleteResult{}, errors.New("firestore client is nil")
+	}
+
+	result := FirestoreDeleteResult{
+		Collections: make(map[string]int, len(deleteLookups)+1),
+	}
+
+	for _, lookup := range deleteLookups {
+		deleted, err := deleteDocumentsByField(
+			ctx,
+			client,
+			lookup.collection,
+			lookup.field,
+			youtubeChannelID,
+		)
+		if err != nil {
+			return result, fmt.Errorf("delete collection %s: %w", lookup.collection, err)
+		}
+		result.Collections[lookup.collection] = deleted
+	}
+
+	mypageDeleted, firebaseUID, err := deleteMyPageMappings(ctx, client, youtubeChannelID)
+	if err != nil {
+		return result, fmt.Errorf("delete mypage mappings: %w", err)
+	}
+	result.MyPage = mypageDeleted
+	result.FirebaseUID = firebaseUID
+
+	userDeleted, err := deleteDocumentIfExists(ctx, client.Collection(repository.USERS).Doc(youtubeChannelID))
+	if err != nil {
+		return result, fmt.Errorf("delete users document: %w", err)
+	}
+	if userDeleted {
+		result.Collections[repository.USERS] = 1
+	} else {
+		result.Collections[repository.USERS] = 0
+	}
+
+	return result, nil
+}
+
+func deleteDocumentsByField(
+	ctx context.Context,
+	client repository.DBClient,
+	collection string,
+	field string,
+	value string,
+) (int, error) {
+	iter := client.Collection(collection).Where(field, "==", value).Documents(ctx)
+	defer iter.Stop()
+
+	deleted := 0
+	for {
+		doc, err := iter.Next()
+		if errors.Is(err, iterator.Done) {
+			return deleted, nil
+		}
+		if err != nil {
+			return deleted, fmt.Errorf("iterate matching documents: %w", err)
+		}
+		if _, err := doc.Ref.Delete(ctx); err != nil {
+			return deleted, fmt.Errorf("delete document %q: %w", doc.Ref.Path, err)
+		}
+		deleted++
+	}
+}
+
+func deleteMyPageMappings(
+	ctx context.Context,
+	client repository.DBClient,
+	youtubeChannelID string,
+) (int, string, error) {
+	ownerRef := client.Collection(mypageChannelOwnersCollection).Doc(youtubeChannelID)
+	ownerSnapshot, err := ownerRef.Get(ctx)
+	if status.Code(err) == codes.NotFound {
+		return 0, "", nil
+	}
+	if err != nil {
+		return 0, "", fmt.Errorf("get mypage channel owner: %w", err)
+	}
+
+	rawFirebaseUID, ok := ownerSnapshot.Data()[firebaseUIDField]
+	if !ok {
+		return 0, "", errors.New("mypage channel owner is missing firebase uid")
+	}
+	firebaseUID, ok := rawFirebaseUID.(string)
+	if !ok {
+		return 0, "", fmt.Errorf("mypage channel owner firebase uid has unexpected type %T", rawFirebaseUID)
+	}
+	firebaseUID = strings.TrimSpace(firebaseUID)
+	if firebaseUID == "" {
+		return 0, "", errors.New("mypage channel owner firebase uid is empty")
+	}
+
+	deleted := 0
+	accountRef := client.Collection(mypageUsersCollection).Doc(firebaseUID)
+	accountDeleted, err := deleteDocumentIfExists(ctx, accountRef)
+	if err != nil {
+		return deleted, firebaseUID, fmt.Errorf("delete mypage linked account: %w", err)
+	}
+	if accountDeleted {
+		deleted++
+	}
+
+	if _, err := ownerRef.Delete(ctx); err != nil {
+		return deleted, firebaseUID, fmt.Errorf("delete mypage channel owner: %w", err)
+	}
+	deleted++
+
+	return deleted, firebaseUID, nil
+}
+
+func deleteDocumentIfExists(ctx context.Context, ref interface {
+	Get(context.Context) (*firestore.DocumentSnapshot, error)
+	Delete(context.Context, ...firestore.Precondition) (*firestore.WriteResult, error)
+}) (bool, error) {
+	_, err := ref.Get(ctx)
+	if status.Code(err) == codes.NotFound {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("get document before delete: %w", err)
+	}
+	if _, err := ref.Delete(ctx); err != nil {
+		return false, fmt.Errorf("delete document: %w", err)
+	}
+	return true, nil
+}

--- a/system/internal/privacyops/delete.go
+++ b/system/internal/privacyops/delete.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"strings"
 
+	"cloud.google.com/go/firestore"
 	"google.golang.org/api/iterator"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -163,10 +164,7 @@ func deleteMyPageMappings(
 	return deleted, firebaseUID, nil
 }
 
-func deleteDocumentIfExists(ctx context.Context, ref interface {
-	Get(context.Context) (*firestore.DocumentSnapshot, error)
-	Delete(context.Context, ...firestore.Precondition) (*firestore.WriteResult, error)
-}) (bool, error) {
+func deleteDocumentIfExists(ctx context.Context, ref *firestore.DocumentRef) (bool, error) {
 	_, err := ref.Get(ctx)
 	if status.Code(err) == codes.NotFound {
 		return false, nil


### PR DESCRIPTION
## Summary

- `privacy-admin delete-primary` を追加し、本人確認済みの削除依頼に対して primary Firestore / BigQuery データを削除できるようにする
- `--confirm <same-channel-id>` を必須化し、対象channel IDのタイプミスによる誤削除を防ぐ
- 実行前後に既存 `inspect` を使って件数を確認し、削除後にprimary dataが残ればエラーにする
- active seat は通常 `!out` を実行せず直接削除し、削除直前に新しいactivity/work-segmentを生成しない
- MyPage mappingが存在する場合はmappingも削除する。ただしFirebase Auth user record自体は対象外
- operator手順を `docs/privacy/user-data-deletion-operations.md` に追加
- Firestore Emulatorで「対象だけ削除・他ユーザー保持・再実行可能」を統合テスト

## Why

Issue #984 の削除依頼フローを、手作業でFirestore各collectionを触る運用にせず、再現可能かつ検証可能な管理operationにします。

初期版では完全自動のユーザー向け削除UIを作らず、本人確認後に管理者がこのoperationを実行する想定です。

## Usage

Read-only inspection:

```bash
cd system
CREDENTIAL_FILE_LOCATION=/path/to/service-account.json \
  go run ./cmd/privacy-admin inspect UCxxxxxxxx
```

Destructive primary deletion:

```bash
cd system
CREDENTIAL_FILE_LOCATION=/path/to/service-account.json \
  go run ./cmd/privacy-admin delete-primary UCxxxxxxxx --confirm UCxxxxxxxx
```

## Primary deletion scope

### Firestore

- `users`
- `seats`, `member-seats`
- `user-activities`
- `work-segments`
- `order-history`
- general/member seat-limit collections
- `live-chat-history`
- MyPage ownership/account mapping when present

### BigQuery

- `firestore_export.live-chat-history`
- `firestore_export.user-activity-history`
- `firestore_export.order-history`

## Explicit exclusions

このPRは「完全削除」を名乗りません。以下は別途対応が必要です。

- GCS Firestore export snapshots: #983
- Firebase Authentication user record
- Discord moderation/log copies: #986
- YouTube本体側のデータ

そのためGCS等の運用が閉じるまではDraftを維持します。

## Safety

- destructive subcommand名を `delete-primary` とし、scopeを明示
- channel IDの再入力を必須化
- pre-delete inspect
- MyPage mappingの整合性をwrite前にpreflight
- deletionはidempotentに再実行可能
- post-delete inspectでprimary storesが0件であることを検証
- GCS/Firebase Auth/Discordが対象外であることをCLI outputと運用docの両方に表示

## Validation

- CI Gate: success
- System Go Test: success
- Go Lint: success
- System Firestore Emulator Test: success
- confirmation / post-delete verification helper tests: success
- privacy-specific Emulator integration test:
  - target userの全対象collectionを削除
  - non-target userのデータは保持
  - MyPage target mappingのみ削除
  - deletion再実行が成功（idempotent）

## Related

- #984 ユーザー本人からのデータ削除依頼フロー
- #983 GCS上のraw YouTubeライブチャット保持期間
- #986 raw YouTubeチャットのログ・Discordコピー
