### PR TITLE
feat: add read-only raw data retention audit

### DIFF
--- a/system/cmd/privacy-retention-audit/main.go
+++ b/system/cmd/privacy-retention-audit/main.go
@@ -24,13 +24,13 @@ const (
 )
 
 type report struct {
-	GeneratedAt time.Time                           `json:"generated_at"`
-	Cutoff      time.Time                           `json:"cutoff"`
-	Config      configAudit                         `json:"config"`
-	Firestore   firestoreAudit                      `json:"firestore"`
+	GeneratedAt time.Time                            `json:"generated_at"`
+	Cutoff      time.Time                            `json:"cutoff"`
+	Config      configAudit                          `json:"config"`
+	Firestore   firestoreAudit                       `json:"firestore"`
 	BigQuery    mybigquery.RawLiveChatRetentionAudit `json:"bigquery"`
-	GCS         gcsAudit                            `json:"gcs"`
-	Warnings    []string                            `json:"warnings,omitempty"`
+	GCS         gcsAudit                             `json:"gcs"`
+	Warnings    []string                             `json:"warnings,omitempty"`
 }
 
 type configAudit struct {

--- a/system/cmd/privacy-retention-audit/main.go
+++ b/system/cmd/privacy-retention-audit/main.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/firestore/apiv1/firestorepb"
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/option"
+
+	"app.modules/core/mybigquery"
+	"app.modules/core/repository"
+	"app.modules/core/utils"
+)
+
+const (
+	rawYouTubeDataRetentionDays = 30
+	firestoreCountAlias         = "row_count"
+)
+
+type report struct {
+	GeneratedAt time.Time                 `json:"generated_at"`
+	Cutoff      time.Time                 `json:"cutoff"`
+	Config      configAudit               `json:"config"`
+	Firestore   firestoreAudit            `json:"firestore"`
+	BigQuery    mybigquery.RawLiveChatRetentionAudit `json:"bigquery"`
+	GCS         gcsAudit                  `json:"gcs"`
+	Warnings    []string                  `json:"warnings,omitempty"`
+}
+
+type configAudit struct {
+	ConfiguredHistoryRetentionDays int    `json:"configured_history_retention_days"`
+	GCSExportBucketName            string `json:"gcs_export_bucket_name"`
+	GCPRegion                      string `json:"gcp_region"`
+}
+
+type firestoreAudit struct {
+	RawLiveChatRowsOlderThanCutoff int64 `json:"raw_live_chat_rows_older_than_cutoff"`
+}
+
+type gcsAudit struct {
+	BucketName               string                  `json:"bucket_name"`
+	Location                 string                  `json:"location,omitempty"`
+	VersioningEnabled        bool                    `json:"versioning_enabled"`
+	LifecycleRules           []storage.LifecycleRule `json:"lifecycle_rules,omitempty"`
+	RetentionPeriod          string                  `json:"retention_period,omitempty"`
+	RetentionPolicyLocked    bool                    `json:"retention_policy_locked,omitempty"`
+	SoftDeleteRetention      string                  `json:"soft_delete_retention,omitempty"`
+	AttributesInspectionError string                 `json:"attributes_inspection_error,omitempty"`
+}
+
+func main() {
+	if err := run(context.Background()); err != nil {
+		fmt.Fprintln(os.Stderr, "privacy-retention-audit:", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context) error {
+	utils.LoadEnv(".env")
+	credentialFilePath := strings.TrimSpace(os.Getenv("CREDENTIAL_FILE_LOCATION"))
+	if credentialFilePath == "" {
+		return errors.New("CREDENTIAL_FILE_LOCATION is required")
+	}
+	//nolint:staticcheck // Credential file path is operator-controlled for this read-only admin audit.
+	clientOption := option.WithCredentialsFile(credentialFilePath)
+
+	repo, err := repository.NewFirestoreController(ctx, clientOption)
+	if err != nil {
+		return fmt.Errorf("initialize Firestore: %w", err)
+	}
+	defer func() {
+		if err := repo.FirestoreClient().Close(); err != nil {
+			fmt.Fprintln(os.Stderr, "privacy-retention-audit: close Firestore:", err)
+		}
+	}()
+
+	constants, err := repo.ReadSystemConstantsConfig(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("read system constants: %w", err)
+	}
+
+	now := time.Now().UTC()
+	cutoff := now.AddDate(0, 0, -rawYouTubeDataRetentionDays)
+
+	firestoreOlderRows, err := countOldFirestoreRawChat(ctx, repo.FirestoreClient(), cutoff)
+	if err != nil {
+		return fmt.Errorf("inspect Firestore raw chat age: %w", err)
+	}
+
+	projectID, err := utils.GetGcpProjectID(ctx, clientOption)
+	if err != nil {
+		return fmt.Errorf("resolve GCP project ID: %w", err)
+	}
+	bqClient, err := mybigquery.NewBigqueryClient(
+		ctx,
+		projectID,
+		clientOption,
+		constants.GcpRegion,
+	)
+	if err != nil {
+		return fmt.Errorf("initialize BigQuery: %w", err)
+	}
+	defer bqClient.CloseClient()
+
+	bqAudit, err := bqClient.InspectRawLiveChatRetention(ctx, cutoff)
+	if err != nil {
+		return fmt.Errorf("inspect BigQuery raw chat age: %w", err)
+	}
+
+	gcs := inspectGCS(ctx, clientOption, constants.GcsFirestoreExportBucketName)
+
+	report := report{
+		GeneratedAt: now,
+		Cutoff:      cutoff,
+		Config: configAudit{
+			ConfiguredHistoryRetentionDays: constants.CollectionHistoryRetentionDays,
+			GCSExportBucketName:            constants.GcsFirestoreExportBucketName,
+			GCPRegion:                      constants.GcpRegion,
+		},
+		Firestore: firestoreAudit{
+			RawLiveChatRowsOlderThanCutoff: firestoreOlderRows,
+		},
+		BigQuery: bqAudit,
+		GCS:      gcs,
+	}
+
+	if constants.CollectionHistoryRetentionDays > rawYouTubeDataRetentionDays {
+		report.Warnings = append(
+			report.Warnings,
+			fmt.Sprintf(
+				"configured collection-history-retention-days is %d, greater than the raw YouTube data limit of %d days",
+				constants.CollectionHistoryRetentionDays,
+				rawYouTubeDataRetentionDays,
+			),
+		)
+	}
+	if len(gcs.LifecycleRules) == 0 {
+		report.Warnings = append(
+			report.Warnings,
+			"GCS export bucket has no lifecycle rule visible to this audit; historical Firestore exports may remain indefinitely",
+		)
+	}
+	if gcs.SoftDeleteRetention != "" && gcs.SoftDeleteRetention != "0s" {
+		report.Warnings = append(
+			report.Warnings,
+			"GCS soft delete retains deleted objects beyond their live-object deletion time; include that duration when evaluating effective retention",
+		)
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(report); err != nil {
+		return fmt.Errorf("encode report: %w", err)
+	}
+	return nil
+}
+
+func countOldFirestoreRawChat(
+	ctx context.Context,
+	client repository.DBClient,
+	cutoff time.Time,
+) (int64, error) {
+	query := client.Collection(repository.LiveChatHistory).
+		Where(repository.PublishedAtDocProperty, "<", cutoff)
+	result, err := query.NewAggregationQuery().WithCount(firestoreCountAlias).Get(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("run count aggregation: %w", err)
+	}
+	rawCount, ok := result[firestoreCountAlias]
+	if !ok {
+		return 0, fmt.Errorf("count aggregation missing alias %q", firestoreCountAlias)
+	}
+	countValue, ok := rawCount.(*firestorepb.Value)
+	if !ok {
+		return 0, fmt.Errorf("count aggregation has unexpected type %T", rawCount)
+	}
+	return countValue.GetIntegerValue(), nil
+}
+
+func inspectGCS(
+	ctx context.Context,
+	clientOption option.ClientOption,
+	bucketName string,
+) gcsAudit {
+	audit := gcsAudit{BucketName: bucketName}
+	if strings.TrimSpace(bucketName) == "" {
+		audit.AttributesInspectionError = "GCS export bucket name is empty"
+		return audit
+	}
+
+	client, err := storage.NewClient(ctx, clientOption)
+	if err != nil {
+		audit.AttributesInspectionError = fmt.Sprintf("initialize GCS client: %v", err)
+		return audit
+	}
+	defer func() {
+		if err := client.Close(); err != nil && audit.AttributesInspectionError == "" {
+			audit.AttributesInspectionError = fmt.Sprintf("close GCS client: %v", err)
+		}
+	}()
+
+	attrs, err := client.Bucket(bucketName).Attrs(ctx)
+	if err != nil {
+		audit.AttributesInspectionError = fmt.Sprintf("read bucket attributes: %v", err)
+		return audit
+	}
+
+	audit.Location = attrs.Location
+	audit.VersioningEnabled = attrs.VersioningEnabled
+	audit.LifecycleRules = attrs.Lifecycle.Rules
+	if attrs.RetentionPolicy != nil {
+		audit.RetentionPeriod = attrs.RetentionPolicy.RetentionPeriod.String()
+		audit.RetentionPolicyLocked = attrs.RetentionPolicy.IsLocked
+	}
+	if attrs.SoftDeletePolicy != nil {
+		audit.SoftDeleteRetention = attrs.SoftDeletePolicy.RetentionDuration.String()
+	}
+	return audit
+}

--- a/system/cmd/privacy-retention-audit/main.go
+++ b/system/cmd/privacy-retention-audit/main.go
@@ -24,13 +24,13 @@ const (
 )
 
 type report struct {
-	GeneratedAt time.Time                 `json:"generated_at"`
-	Cutoff      time.Time                 `json:"cutoff"`
-	Config      configAudit               `json:"config"`
-	Firestore   firestoreAudit            `json:"firestore"`
+	GeneratedAt time.Time                           `json:"generated_at"`
+	Cutoff      time.Time                           `json:"cutoff"`
+	Config      configAudit                         `json:"config"`
+	Firestore   firestoreAudit                      `json:"firestore"`
 	BigQuery    mybigquery.RawLiveChatRetentionAudit `json:"bigquery"`
-	GCS         gcsAudit                  `json:"gcs"`
-	Warnings    []string                  `json:"warnings,omitempty"`
+	GCS         gcsAudit                            `json:"gcs"`
+	Warnings    []string                            `json:"warnings,omitempty"`
 }
 
 type configAudit struct {
@@ -44,14 +44,14 @@ type firestoreAudit struct {
 }
 
 type gcsAudit struct {
-	BucketName               string                  `json:"bucket_name"`
-	Location                 string                  `json:"location,omitempty"`
-	VersioningEnabled        bool                    `json:"versioning_enabled"`
-	LifecycleRules           []storage.LifecycleRule `json:"lifecycle_rules,omitempty"`
-	RetentionPeriod          string                  `json:"retention_period,omitempty"`
-	RetentionPolicyLocked    bool                    `json:"retention_policy_locked,omitempty"`
-	SoftDeleteRetention      string                  `json:"soft_delete_retention,omitempty"`
-	AttributesInspectionError string                 `json:"attributes_inspection_error,omitempty"`
+	BucketName                string                  `json:"bucket_name"`
+	Location                  string                  `json:"location,omitempty"`
+	VersioningEnabled         bool                    `json:"versioning_enabled"`
+	LifecycleRules            []storage.LifecycleRule `json:"lifecycle_rules,omitempty"`
+	RetentionPeriod           string                  `json:"retention_period,omitempty"`
+	RetentionPolicyLocked     bool                    `json:"retention_policy_locked,omitempty"`
+	SoftDeleteRetention       string                  `json:"soft_delete_retention,omitempty"`
+	AttributesInspectionError string                  `json:"attributes_inspection_error,omitempty"`
 }
 
 func main() {

--- a/system/core/mybigquery/retention_audit.go
+++ b/system/core/mybigquery/retention_audit.go
@@ -1,0 +1,62 @@
+package mybigquery
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+)
+
+type RawLiveChatRetentionAudit struct {
+	TotalRows          int64  `json:"total_rows"`
+	RowsOlderThanCutoff int64  `json:"rows_older_than_cutoff"`
+	UndatedRows        int64  `json:"undated_rows"`
+	OldestPublishedAt  string `json:"oldest_published_at,omitempty"`
+	NewestPublishedAt  string `json:"newest_published_at,omitempty"`
+}
+
+type rawLiveChatRetentionAuditRow struct {
+	TotalRows           int64  `bigquery:"total_rows"`
+	RowsOlderThanCutoff int64  `bigquery:"rows_older_than_cutoff"`
+	UndatedRows         int64  `bigquery:"undated_rows"`
+	OldestPublishedAt   string `bigquery:"oldest_published_at"`
+	NewestPublishedAt   string `bigquery:"newest_published_at"`
+}
+
+// InspectRawLiveChatRetention reports the current age distribution of raw
+// live-chat rows without modifying the table.
+func (c *BigqueryController) InspectRawLiveChatRetention(
+	ctx context.Context,
+	cutoff time.Time,
+) (RawLiveChatRetentionAudit, error) {
+	query := c.Client.Query(fmt.Sprintf(`
+SELECT
+  COUNT(*) AS total_rows,
+  COUNTIF(published_at < @cutoff) AS rows_older_than_cutoff,
+  COUNTIF(published_at IS NULL) AS undated_rows,
+  COALESCE(FORMAT_TIMESTAMP('%%Y-%%m-%%dT%%H:%%M:%%SZ', MIN(published_at)), '') AS oldest_published_at,
+  COALESCE(FORMAT_TIMESTAMP('%%Y-%%m-%%dT%%H:%%M:%%SZ', MAX(published_at)), '') AS newest_published_at
+FROM %s
+`, bqTableIdentifier(c.Client.Project(), DatasetName, LiveChatHistoryMainTableName)))
+	query.Location = c.WorkingRegion
+	query.Parameters = []bigquery.QueryParameter{{Name: "cutoff", Value: cutoff}}
+
+	iterator, err := query.Read(ctx)
+	if err != nil {
+		return RawLiveChatRetentionAudit{}, fmt.Errorf("read raw live chat retention audit: %w", err)
+	}
+
+	var row rawLiveChatRetentionAuditRow
+	if err := iterator.Next(&row); err != nil {
+		return RawLiveChatRetentionAudit{}, fmt.Errorf("read raw live chat retention audit row: %w", err)
+	}
+
+	return RawLiveChatRetentionAudit{
+		TotalRows:           row.TotalRows,
+		RowsOlderThanCutoff: row.RowsOlderThanCutoff,
+		UndatedRows:         row.UndatedRows,
+		OldestPublishedAt:   row.OldestPublishedAt,
+		NewestPublishedAt:   row.NewestPublishedAt,
+	}, nil
+}

--- a/system/core/mybigquery/retention_audit.go
+++ b/system/core/mybigquery/retention_audit.go
@@ -9,11 +9,11 @@ import (
 )
 
 type RawLiveChatRetentionAudit struct {
-	TotalRows          int64  `json:"total_rows"`
+	TotalRows           int64  `json:"total_rows"`
 	RowsOlderThanCutoff int64  `json:"rows_older_than_cutoff"`
-	UndatedRows        int64  `json:"undated_rows"`
-	OldestPublishedAt  string `json:"oldest_published_at,omitempty"`
-	NewestPublishedAt  string `json:"newest_published_at,omitempty"`
+	UndatedRows         int64  `json:"undated_rows"`
+	OldestPublishedAt   string `json:"oldest_published_at,omitempty"`
+	NewestPublishedAt   string `json:"newest_published_at,omitempty"`
 }
 
 type rawLiveChatRetentionAuditRow struct {
@@ -30,6 +30,12 @@ func (c *BigqueryController) InspectRawLiveChatRetention(
 	ctx context.Context,
 	cutoff time.Time,
 ) (RawLiveChatRetentionAudit, error) {
+	tableIdentifier := fmt.Sprintf(
+		"`%s.%s.%s`",
+		c.Client.Project(),
+		DatasetName,
+		LiveChatHistoryMainTableName,
+	)
 	query := c.Client.Query(fmt.Sprintf(`
 SELECT
   COUNT(*) AS total_rows,
@@ -38,7 +44,7 @@ SELECT
   COALESCE(FORMAT_TIMESTAMP('%%Y-%%m-%%dT%%H:%%M:%%SZ', MIN(published_at)), '') AS oldest_published_at,
   COALESCE(FORMAT_TIMESTAMP('%%Y-%%m-%%dT%%H:%%M:%%SZ', MAX(published_at)), '') AS newest_published_at
 FROM %s
-`, bqTableIdentifier(c.Client.Project(), DatasetName, LiveChatHistoryMainTableName)))
+`, tableIdentifier))
 	query.Location = c.WorkingRegion
 	query.Parameters = []bigquery.QueryParameter{{Name: "cutoff", Value: cutoff}}
 

--- a/system/core/mybigquery/retention_audit.go
+++ b/system/core/mybigquery/retention_audit.go
@@ -58,11 +58,5 @@ FROM %s
 		return RawLiveChatRetentionAudit{}, fmt.Errorf("read raw live chat retention audit row: %w", err)
 	}
 
-	return RawLiveChatRetentionAudit{
-		TotalRows:           row.TotalRows,
-		RowsOlderThanCutoff: row.RowsOlderThanCutoff,
-		UndatedRows:         row.UndatedRows,
-		OldestPublishedAt:   row.OldestPublishedAt,
-		NewestPublishedAt:   row.NewestPublishedAt,
-	}, nil
+	return RawLiveChatRetentionAudit(row), nil
 }


### PR DESCRIPTION
## Summary

- 本番raw YouTubeデータ保持状況を1コマンドで確認するread-only auditを追加
- Firestore `live-chat-history` の30日超件数をAggregation COUNTで取得
- BigQuery raw live chatの総件数 / 30日超件数 / timestamp欠損件数 / 最古・最新日時を取得
- Firestore `config/constants` から現在の履歴保持日数・GCS export bucket・regionを取得
- GCS bucketのLifecycle / Versioning / Retention Policy / Soft Delete Policyを取得
- 設定上の注意点をJSON warningsとして表示

## Why

#983 を進めるために必要な本番情報がリポジトリ外にあります。複数のgcloud / Firebase / BigQueryコマンドを人手で実行する代わりに、既存service accountでread-only監査を1回実行すれば必要情報をまとめて取得できるようにします。

## Usage

```bash
cd system
CREDENTIAL_FILE_LOCATION=/path/to/service-account.json \
  go run ./cmd/privacy-retention-audit
```

## Safety

- Firestore: read / aggregation only
- BigQuery: SELECT only
- GCS: bucket attributes read only
- lifecycle / retention / dataを変更しない
- raw object contentsを読み込まない

## Output

- `config.configured_history_retention_days`
- Firestore 30日超raw chat件数
- BigQuery total / >30d / undated / oldest / newest
- GCS lifecycle rules
- Object Versioning status
- bucket retention policy
- soft-delete retention
- warnings

## Validation

- CI Gate: success
- System Go Test: success
- Go Lint: success
- System Firestore Emulator Test: success
- Generated Files Up-to-Date: success

## Related

- #983 GCS上のraw YouTubeライブチャット保持期間を30日以内にする
- #985 raw YouTube live chat 30日cap
