### PR TITLE
fix: stop logging Discord message bodies

### DIFF
--- a/system/core/moderatorbot/discord.go
+++ b/system/core/moderatorbot/discord.go
@@ -39,7 +39,9 @@ func NewDiscordBot(token string, textChannelID string) (*DiscordBot, error) {
 }
 
 func (bot *DiscordBot) SendMessage(ctx context.Context, message string) error {
-	slog.InfoContext(ctx, "sending a message to Discord.", "message", message)
+	// Message bodies may contain raw YouTube chat/user data. Log only the
+	// delivery event so process logs do not become a second long-lived copy.
+	slog.InfoContext(ctx, "sending a message to Discord")
 	_, err := bot.session.ChannelMessageSend(bot.textChannelID, message)
 	if err != nil {
 		return fmt.Errorf("in bot.session.ChannelMessageSend: %w", err)


### PR DESCRIPTION
## Summary

- `moderatorbot.DiscordBot.SendMessage` のprocess logからDiscord送信本文を除去
- Discordへの送信内容・送信先・エラー処理は変更しない

## Why

Discord送信本文にはNGワード検知時のYouTube channel情報・チャット本文や、fan funding eventのraw payload等が含まれることがあります。

`SendMessage` が本文を `slog` に出すと、Discordに必要な通知とは別にprocess logへraw user dataを複製してしまいます。送信イベント自体はログに残しつつ、本文だけを除外します。

## Scope

```go
slog.InfoContext(ctx, "sending a message to Discord.", "message", message)
```

を本文なしのdelivery event logへ変更するだけです。

## Validation

- CI Gate: success
- System Go Test: success
- Go Lint: success
- System Firestore Emulator Test: success
- Generated Files Up-to-Date: success

## Related

- #986 raw YouTubeチャットのログ・Discordコピーの保持を見直す
- #988 通常ライブチャットのprocess log複製停止（merged）
