### PR TITLE
feat: extend raw-data audit with GCS object inventory

### DIFF
--- a/system/cmd/privacy-retention-audit/gcs_inventory.go
+++ b/system/cmd/privacy-retention-audit/gcs_inventory.go
@@ -11,7 +11,10 @@ import (
 	"google.golang.org/api/iterator"
 )
 
-const gcsObjectNameSampleLimit = 20
+const (
+	gcsObjectNameSampleLimit = 20
+	gcsPrefixSampleLimit     = 20
+)
 
 type gcsPrefixSummary struct {
 	Prefix      string `json:"prefix"`
@@ -29,7 +32,7 @@ type gcsObjectInventory struct {
 	OldestSoftDeleteTime        string             `json:"oldest_soft_delete_time,omitempty"`
 	LatestSoftDeleteHardDelete  string             `json:"latest_soft_delete_hard_delete_time,omitempty"`
 	TopLevelPrefixCount         int                `json:"top_level_prefix_count"`
-	TopLevelPrefixes            []gcsPrefixSummary `json:"top_level_prefixes,omitempty"`
+	TopLevelPrefixSamples       []gcsPrefixSummary `json:"top_level_prefix_samples,omitempty"`
 	KnownCollectionObjectCounts map[string]int64   `json:"known_collection_object_counts,omitempty"`
 	SampleLiveObjectNames       []string           `json:"sample_live_object_names,omitempty"`
 	LiveListError               string             `json:"live_list_error,omitempty"`
@@ -158,15 +161,31 @@ func (accumulator *gcsInventoryAccumulator) finalizePrefixes() {
 	sort.Strings(prefixes)
 
 	accumulator.inventory.TopLevelPrefixCount = len(prefixes)
-	for _, prefix := range prefixes {
-		accumulator.inventory.TopLevelPrefixes = append(
-			accumulator.inventory.TopLevelPrefixes,
+	for _, prefix := range sampledPrefixNames(prefixes, gcsPrefixSampleLimit) {
+		accumulator.inventory.TopLevelPrefixSamples = append(
+			accumulator.inventory.TopLevelPrefixSamples,
 			gcsPrefixSummary{
 				Prefix:      prefix,
 				ObjectCount: accumulator.prefixCount[prefix],
 			},
 		)
 	}
+}
+
+func sampledPrefixNames(prefixes []string, limit int) []string {
+	if limit <= 0 || len(prefixes) == 0 {
+		return nil
+	}
+	if len(prefixes) <= limit {
+		return append([]string(nil), prefixes...)
+	}
+
+	frontCount := limit / 2
+	backCount := limit - frontCount
+	samples := make([]string, 0, limit)
+	samples = append(samples, prefixes[:frontCount]...)
+	samples = append(samples, prefixes[len(prefixes)-backCount:]...)
+	return samples
 }
 
 func topLevelPrefix(objectName string) string {

--- a/system/cmd/privacy-retention-audit/gcs_inventory.go
+++ b/system/cmd/privacy-retention-audit/gcs_inventory.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
+)
+
+const gcsObjectNameSampleLimit = 20
+
+type gcsPrefixSummary struct {
+	Prefix      string `json:"prefix"`
+	ObjectCount int64  `json:"object_count"`
+}
+
+type gcsObjectInventory struct {
+	LiveObjectCount             int64              `json:"live_object_count"`
+	LiveBytes                   int64              `json:"live_bytes"`
+	LiveObjectsOlderThanCutoff  int64              `json:"live_objects_older_than_cutoff"`
+	OldestLiveCreatedAt         string             `json:"oldest_live_created_at,omitempty"`
+	NewestLiveCreatedAt         string             `json:"newest_live_created_at,omitempty"`
+	SoftDeletedObjectCount      int64              `json:"soft_deleted_object_count"`
+	SoftDeletedBytes            int64              `json:"soft_deleted_bytes"`
+	OldestSoftDeleteTime        string             `json:"oldest_soft_delete_time,omitempty"`
+	LatestSoftDeleteHardDelete  string             `json:"latest_soft_delete_hard_delete_time,omitempty"`
+	TopLevelPrefixCount         int                `json:"top_level_prefix_count"`
+	TopLevelPrefixes            []gcsPrefixSummary `json:"top_level_prefixes,omitempty"`
+	KnownCollectionObjectCounts map[string]int64   `json:"known_collection_object_counts,omitempty"`
+	SampleLiveObjectNames       []string           `json:"sample_live_object_names,omitempty"`
+	LiveListError               string             `json:"live_list_error,omitempty"`
+	SoftDeletedListError        string             `json:"soft_deleted_list_error,omitempty"`
+}
+
+type gcsInventoryAccumulator struct {
+	inventory   gcsObjectInventory
+	prefixCount map[string]int64
+}
+
+func newGCSInventoryAccumulator(knownCollections []string) *gcsInventoryAccumulator {
+	knownCollectionCounts := make(map[string]int64, len(knownCollections))
+	for _, collection := range knownCollections {
+		knownCollectionCounts[collection] = 0
+	}
+	return &gcsInventoryAccumulator{
+		inventory: gcsObjectInventory{
+			KnownCollectionObjectCounts: knownCollectionCounts,
+		},
+		prefixCount: make(map[string]int64),
+	}
+}
+
+func inspectGCSObjectInventory(
+	ctx context.Context,
+	bucket *storage.BucketHandle,
+	cutoff time.Time,
+	knownCollections []string,
+) gcsObjectInventory {
+	accumulator := newGCSInventoryAccumulator(knownCollections)
+
+	if err := scanGCSObjects(ctx, bucket.Objects(ctx, nil), func(attrs *storage.ObjectAttrs) {
+		accumulator.recordLiveObject(attrs, cutoff)
+	}); err != nil {
+		accumulator.inventory.LiveListError = err.Error()
+	}
+
+	softDeletedQuery := &storage.Query{SoftDeleted: true}
+	if err := scanGCSObjects(ctx, bucket.Objects(ctx, softDeletedQuery), func(attrs *storage.ObjectAttrs) {
+		accumulator.recordSoftDeletedObject(attrs)
+	}); err != nil {
+		accumulator.inventory.SoftDeletedListError = err.Error()
+	}
+
+	accumulator.finalizePrefixes()
+	return accumulator.inventory
+}
+
+func scanGCSObjects(
+	ctx context.Context,
+	objectIterator *storage.ObjectIterator,
+	record func(*storage.ObjectAttrs),
+) error {
+	for {
+		attrs, err := objectIterator.Next()
+		if err == iterator.Done {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("list GCS objects: %w", err)
+		}
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("list GCS objects: %w", err)
+		}
+		record(attrs)
+	}
+}
+
+func (accumulator *gcsInventoryAccumulator) recordLiveObject(attrs *storage.ObjectAttrs, cutoff time.Time) {
+	accumulator.inventory.LiveObjectCount++
+	accumulator.inventory.LiveBytes += attrs.Size
+	if !attrs.Created.IsZero() {
+		if attrs.Created.Before(cutoff) {
+			accumulator.inventory.LiveObjectsOlderThanCutoff++
+		}
+		accumulator.inventory.OldestLiveCreatedAt = earlierTimestamp(
+			accumulator.inventory.OldestLiveCreatedAt,
+			attrs.Created,
+		)
+		accumulator.inventory.NewestLiveCreatedAt = laterTimestamp(
+			accumulator.inventory.NewestLiveCreatedAt,
+			attrs.Created,
+		)
+	}
+
+	prefix := topLevelPrefix(attrs.Name)
+	accumulator.prefixCount[prefix]++
+
+	for collection := range accumulator.inventory.KnownCollectionObjectCounts {
+		if strings.Contains(attrs.Name, collection) {
+			accumulator.inventory.KnownCollectionObjectCounts[collection]++
+		}
+	}
+
+	if len(accumulator.inventory.SampleLiveObjectNames) < gcsObjectNameSampleLimit {
+		accumulator.inventory.SampleLiveObjectNames = append(
+			accumulator.inventory.SampleLiveObjectNames,
+			attrs.Name,
+		)
+	}
+}
+
+func (accumulator *gcsInventoryAccumulator) recordSoftDeletedObject(attrs *storage.ObjectAttrs) {
+	accumulator.inventory.SoftDeletedObjectCount++
+	accumulator.inventory.SoftDeletedBytes += attrs.Size
+	if !attrs.SoftDeleteTime.IsZero() {
+		accumulator.inventory.OldestSoftDeleteTime = earlierTimestamp(
+			accumulator.inventory.OldestSoftDeleteTime,
+			attrs.SoftDeleteTime,
+		)
+	}
+	if !attrs.HardDeleteTime.IsZero() {
+		accumulator.inventory.LatestSoftDeleteHardDelete = laterTimestamp(
+			accumulator.inventory.LatestSoftDeleteHardDelete,
+			attrs.HardDeleteTime,
+		)
+	}
+}
+
+func (accumulator *gcsInventoryAccumulator) finalizePrefixes() {
+	prefixes := make([]string, 0, len(accumulator.prefixCount))
+	for prefix := range accumulator.prefixCount {
+		prefixes = append(prefixes, prefix)
+	}
+	sort.Strings(prefixes)
+
+	accumulator.inventory.TopLevelPrefixCount = len(prefixes)
+	for _, prefix := range prefixes {
+		accumulator.inventory.TopLevelPrefixes = append(
+			accumulator.inventory.TopLevelPrefixes,
+			gcsPrefixSummary{
+				Prefix:      prefix,
+				ObjectCount: accumulator.prefixCount[prefix],
+			},
+		)
+	}
+}
+
+func topLevelPrefix(objectName string) string {
+	index := strings.IndexByte(objectName, '/')
+	if index < 0 {
+		return "(root)"
+	}
+	return objectName[:index+1]
+}
+
+func earlierTimestamp(current string, candidate time.Time) string {
+	if candidate.IsZero() {
+		return current
+	}
+	if current == "" {
+		return candidate.UTC().Format(time.RFC3339)
+	}
+	parsed, err := time.Parse(time.RFC3339, current)
+	if err != nil || candidate.Before(parsed) {
+		return candidate.UTC().Format(time.RFC3339)
+	}
+	return current
+}
+
+func laterTimestamp(current string, candidate time.Time) string {
+	if candidate.IsZero() {
+		return current
+	}
+	if current == "" {
+		return candidate.UTC().Format(time.RFC3339)
+	}
+	parsed, err := time.Parse(time.RFC3339, current)
+	if err != nil || candidate.After(parsed) {
+		return candidate.UTC().Format(time.RFC3339)
+	}
+	return current
+}

--- a/system/cmd/privacy-retention-audit/gcs_inventory_test.go
+++ b/system/cmd/privacy-retention-audit/gcs_inventory_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGCSInventoryAccumulator_RecordLiveObject(t *testing.T) {
+	cutoff := time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC)
+	accumulator := newGCSInventoryAccumulator([]string{"live-chat-history", "users"})
+
+	accumulator.recordLiveObject(&storage.ObjectAttrs{
+		Name:    "2021-11-13/all_namespaces_kind_live-chat-history/output-0",
+		Size:    100,
+		Created: time.Date(2021, 11, 13, 8, 0, 0, 0, time.UTC),
+	}, cutoff)
+	accumulator.recordLiveObject(&storage.ObjectAttrs{
+		Name:    "2026-08-14/all_namespaces_kind_users/output-0",
+		Size:    50,
+		Created: time.Date(2026, 8, 14, 8, 0, 0, 0, time.UTC),
+	}, cutoff)
+	accumulator.finalizePrefixes()
+
+	inventory := accumulator.inventory
+	assert.EqualValues(t, 2, inventory.LiveObjectCount)
+	assert.EqualValues(t, 150, inventory.LiveBytes)
+	assert.EqualValues(t, 1, inventory.LiveObjectsOlderThanCutoff)
+	assert.Equal(t, "2021-11-13T08:00:00Z", inventory.OldestLiveCreatedAt)
+	assert.Equal(t, "2026-08-14T08:00:00Z", inventory.NewestLiveCreatedAt)
+	assert.EqualValues(t, 1, inventory.KnownCollectionObjectCounts["live-chat-history"])
+	assert.EqualValues(t, 1, inventory.KnownCollectionObjectCounts["users"])
+	require.Len(t, inventory.TopLevelPrefixSamples, 2)
+	assert.Equal(t, "2021-11-13/", inventory.TopLevelPrefixSamples[0].Prefix)
+	assert.Equal(t, "2026-08-14/", inventory.TopLevelPrefixSamples[1].Prefix)
+}
+
+func TestGCSInventoryAccumulator_RecordSoftDeletedObject(t *testing.T) {
+	accumulator := newGCSInventoryAccumulator(nil)
+	accumulator.recordSoftDeletedObject(&storage.ObjectAttrs{
+		Size:           42,
+		SoftDeleteTime: time.Date(2026, 8, 14, 1, 0, 0, 0, time.UTC),
+		HardDeleteTime: time.Date(2026, 8, 21, 1, 0, 0, 0, time.UTC),
+	})
+	accumulator.recordSoftDeletedObject(&storage.ObjectAttrs{
+		Size:           8,
+		SoftDeleteTime: time.Date(2026, 8, 13, 1, 0, 0, 0, time.UTC),
+		HardDeleteTime: time.Date(2026, 8, 20, 1, 0, 0, 0, time.UTC),
+	})
+
+	inventory := accumulator.inventory
+	assert.EqualValues(t, 2, inventory.SoftDeletedObjectCount)
+	assert.EqualValues(t, 50, inventory.SoftDeletedBytes)
+	assert.Equal(t, "2026-08-13T01:00:00Z", inventory.OldestSoftDeleteTime)
+	assert.Equal(t, "2026-08-21T01:00:00Z", inventory.LatestSoftDeleteHardDelete)
+}
+
+func TestSampledPrefixNames(t *testing.T) {
+	prefixes := []string{
+		"01/", "02/", "03/", "04/", "05/", "06/",
+		"07/", "08/", "09/", "10/", "11/", "12/",
+	}
+
+	assert.Equal(
+		t,
+		[]string{"01/", "02/", "03/", "10/", "11/", "12/"},
+		sampledPrefixNames(prefixes, 6),
+	)
+	assert.Equal(t, prefixes, sampledPrefixNames(prefixes, 20))
+	assert.Nil(t, sampledPrefixNames(prefixes, 0))
+}
+
+func TestTopLevelPrefix(t *testing.T) {
+	assert.Equal(t, "2026-08-14/", topLevelPrefix("2026-08-14/export/file"))
+	assert.Equal(t, "(root)", topLevelPrefix("root-object"))
+}

--- a/system/cmd/privacy-retention-audit/main.go
+++ b/system/cmd/privacy-retention-audit/main.go
@@ -51,6 +51,7 @@ type gcsAudit struct {
 	RetentionPeriod           string                  `json:"retention_period,omitempty"`
 	RetentionPolicyLocked     bool                    `json:"retention_policy_locked,omitempty"`
 	SoftDeleteRetention       string                  `json:"soft_delete_retention,omitempty"`
+	Objects                   gcsObjectInventory      `json:"objects"`
 	AttributesInspectionError string                  `json:"attributes_inspection_error,omitempty"`
 }
 
@@ -113,7 +114,12 @@ func run(ctx context.Context) error {
 		return fmt.Errorf("inspect BigQuery raw chat age: %w", err)
 	}
 
-	gcs := inspectGCS(ctx, clientOption, constants.GcsFirestoreExportBucketName)
+	gcs := inspectGCS(
+		ctx,
+		clientOption,
+		constants.GcsFirestoreExportBucketName,
+		cutoff,
+	)
 
 	report := report{
 		GeneratedAt: now,
@@ -152,6 +158,30 @@ func run(ctx context.Context) error {
 			"GCS soft delete retains deleted objects beyond their live-object deletion time; include that duration when evaluating effective retention",
 		)
 	}
+	if gcs.Objects.LiveObjectsOlderThanCutoff > 0 {
+		report.Warnings = append(
+			report.Warnings,
+			fmt.Sprintf(
+				"GCS has %d live objects older than the raw YouTube data cutoff",
+				gcs.Objects.LiveObjectsOlderThanCutoff,
+			),
+		)
+	}
+	if gcs.Objects.SoftDeletedObjectCount > 0 {
+		report.Warnings = append(
+			report.Warnings,
+			fmt.Sprintf(
+				"GCS still retains %d soft-deleted objects until their hard-delete times",
+				gcs.Objects.SoftDeletedObjectCount,
+			),
+		)
+	}
+	if gcs.Objects.LiveListError != "" || gcs.Objects.SoftDeletedListError != "" {
+		report.Warnings = append(
+			report.Warnings,
+			"GCS object inventory was only partially available; inspect list errors before changing retention",
+		)
+	}
 
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetIndent("", "  ")
@@ -187,6 +217,7 @@ func inspectGCS(
 	ctx context.Context,
 	clientOption option.ClientOption,
 	bucketName string,
+	cutoff time.Time,
 ) gcsAudit {
 	audit := gcsAudit{BucketName: bucketName}
 	if strings.TrimSpace(bucketName) == "" {
@@ -205,7 +236,8 @@ func inspectGCS(
 		}
 	}()
 
-	attrs, err := client.Bucket(bucketName).Attrs(ctx)
+	bucket := client.Bucket(bucketName)
+	attrs, err := bucket.Attrs(ctx)
 	if err != nil {
 		audit.AttributesInspectionError = fmt.Sprintf("read bucket attributes: %v", err)
 		return audit
@@ -221,5 +253,20 @@ func inspectGCS(
 	if attrs.SoftDeletePolicy != nil {
 		audit.SoftDeleteRetention = attrs.SoftDeletePolicy.RetentionDuration.String()
 	}
+
+	audit.Objects = inspectGCSObjectInventory(
+		ctx,
+		bucket,
+		cutoff,
+		[]string{
+			repository.LiveChatHistory,
+			repository.UserActivities,
+			repository.OrderHistory,
+			repository.USERS,
+			repository.WorkSegments,
+			repository.SEATS,
+			repository.MemberSeats,
+		},
+	)
 	return audit
 }


### PR DESCRIPTION
## Summary

- `privacy-retention-audit` をGCS bucket metadataだけでなくobject inventoryまで拡張
- live object総数 / bytes / 30日cutoff超件数 / 最古・最新作成時刻を出力
- soft-deleted object総数 / bytes / 最古soft-delete / 最終hard-delete予定時刻を出力
- top-level prefixは全件を出さず、件数と先頭/末尾サンプルのみ表示
- Firestore exportで使われる既知collection名がobject pathに何件現れるか集計
- object nameは最大20件だけ構造確認用にサンプル出力
- raw object contentsは一切読まない

## Why

本番監査の結果、bucket `firestore-backup-test-youtube-study-space` は lifecycleなし・soft delete 7日でしたが、bucket内に何年分のsnapshotがあり、raw chat以外のbackupを兼ねているかはmetadataだけでは判断できませんでした。

GCS Lifecycleだけではaction実行が非同期で、condition成立直後の削除時刻を保証できないため、raw chatを30日以内に保つ設計を決める前に実際のobject構造をread-onlyで把握します。

## Safety

- read/list only
- object contentsは読まない
- bucket lifecycle / soft delete / objectを変更しない
- prefix出力は最大20件、object nameサンプルも最大20件に制限
- soft-deleted object listingに権限がなくてもaudit全体は失敗させずエラーをJSONへ記録

## Validation

- pure summarization testsを追加
- Draft CIでGo test / lint / Firestore Emulatorを確認

## Related

- #983 GCS上のraw YouTubeライブチャット保持期間
- #985 Firestore / BigQuery raw live chat 30日cap
