### PR TITLE
Add ChatMessageProcessing target formal specification

### DIFF
--- a/formal-spec/README.md
+++ b/formal-spec/README.md
@@ -25,11 +25,14 @@ CI を緑にすること自体を目的に仕様を弱めてはいけません�
 ## 現在の構成
 
 - `fsl/`: FSL による形式仕様、検証、language-neutral conformance vector / HTML review report の生成
-- `SeatSession`: 座席の Work / Break 状態遷移
-- `SeatAllocation`: 入室・空席衝突・メンバー席アクセス・席移動・退室の安全条件
+- `SeatSession`: 座席の Work / Break 状態遷移。実 `SeatDoc` との conformance 接続済み
+- `SeatAllocation`: 入室・空席衝突・メンバー席アクセス・席移動・退室の高位安全モデル。実装 conformance は未接続
+- `ChatMessageProcessing`: P1 の durable ingest / Inbox / domain transaction / reply outbox の**目標契約**。現行 youtube-bot との conformance は未接続
 - `system/core/repository/seat_formalspec_test.go`: `SeatSession` 用の `formalspec` build tag Go conformance adapter
 
-全 FSL spec は CI で bounded verification されます。`SeatSession` はさらに FSL が生成した conformance vector を oracle として実 `SeatDoc` と照合します。`SeatAllocation` は高位の安全モデルとして導入し、実装 conformance が未接続であることを明示します。
+全 FSL spec は CI で bounded verification されます。実装 conformance が接続済みなのは現時点では `SeatSession` だけです。高位モデル・移行先モデルについては、未接続なのに実装一致を証明したとは扱いません。
+
+`ChatMessageProcessing` は特に、現在の実装を正当化するためではなく、以前のP1設計で決めた「checkpoint は durable ingest 完了を意味する」「messageId を冪等キーにする」「DB effect と reply intent を atomic にする」「poison message は dead-letter して後続を止めない」という移行先の契約を先に固定する目的です。
 
 vector / HTML は一時生成物でコミットせず、通常の `go test ./...` と本番ランタイムは FSL 非依存のまま維持します。
 

--- a/formal-spec/fsl/README.md
+++ b/formal-spec/fsl/README.md
@@ -27,6 +27,7 @@ bash .github/scripts/run-formal-spec-tests.sh
 ```bash
 bash formal-spec/fsl/scripts/report.sh seat_session
 bash formal-spec/fsl/scripts/report.sh seat_allocation
+bash formal-spec/fsl/scripts/report.sh chat_message_processing
 ```
 
 対応している FSL 開発環境は Linux x86_64 / arm64 と macOS Apple Silicon です。`fslc` は `formal-spec/fsl/.tools/` にキャッシュされ、生成した conformance JSON / HTML は `formal-spec/fsl/generated/` に置かれ、どちらもコミットされません。
@@ -42,9 +43,11 @@ bash formal-spec/fsl/scripts/report.sh seat_allocation
 
 ## Requirement traceability
 
-`SeatSession` の `REQ-SEAT-*`、`SeatAllocation` の `REQ-ALLOC-*` は FSL の正準な `@requirement(id, text)` metadata として対象 action / invariant に付与します。これにより verifier の診断や HTML レポートから、どの宣言がどの契約を担うか追跡できます。
+- `SeatSession`: `REQ-SEAT-*`
+- `SeatAllocation`: `REQ-ALLOC-*`
+- `ChatMessageProcessing`: `REQ-CHAT-*`
 
-requirement metadata は検証そのものの代替ではありません。契約の意味は action / invariant の式で検証し、ID と説明はレビュー時のトレーサビリティとして使います。
+これらを FSL の正準な `@requirement(id, text)` metadata として対象 action / invariant に付与します。requirement metadata は検証そのものの代替ではありません。契約の意味は action / invariant の式で検証し、ID と説明はレビュー時のトレーサビリティとして使います。
 
 ## CI gate
 
@@ -57,7 +60,9 @@ SeatSession: fslc conformance --depth 4
 SeatSession: Go conformance adapter (build tag: formalspec)
 ```
 
-`SeatSession` は実 Go adapter まで接続済みです。`SeatAllocation` はまず高位の割当安全条件を独立した有限モデルとして検証し、実装 conformance は Firestore transaction / WorkspaceApp 境界を壊さず接続できる方法を別途設計します。未接続なのに実装との一致を証明したとは扱いません。
+`SeatSession` は実 Go adapter まで接続済みです。`SeatAllocation` は高位の割当安全モデル、`ChatMessageProcessing` はP1移行先の目標契約として検証します。後者2つは現行実装との conformance 未接続であり、FSL検証が通っても「現在のGo/Firestore実装が契約を満たす」とは扱いません。
+
+`ChatMessageProcessing` は、durable ingest と checkpoint、message processor のlease/retry/dead-letter、domain effect と reply outbox intent の atomicity を対象にします。外部 YouTube/Discord 配送の exactly-once は保証対象外です。
 
 Go adapter は FSL の `conformance.v1` JSON を読み、各 reachable state / action instance について `SeatDoc` の実装結果を照合します。`requires_failed` の vector では Go 側も error を返し、`SeatDoc` が変更されないことまで確認します。仕様で新しい outcome が現れた場合は自動で skip せず、分類を要求して失敗します。
 

--- a/formal-spec/fsl/specs/README.md
+++ b/formal-spec/fsl/specs/README.md
@@ -61,3 +61,35 @@
 - activity / work segment ログ
 
 この仕様では「どの席を選ぶか」ではなく、「選んだ席へ遷移してよい条件」と「遷移後も壊れてはいけない安全条件」に焦点を当てます。
+
+## `chat_message_processing.fsl`
+
+P1「YouTubeチャット処理を冪等化・耐障害化」で目標としている、1件の**副作用ありメッセージ**の durable ingest → Inbox processing → domain transaction → reply outbox の契約を有限モデルとして表現します。
+
+これは現行 `youtube-bot` の挙動を写した conformance spec ではありません。現行は `nextPageToken` 保存後に履歴保存・`ProcessMessage` を行い、`live-chat-history` もランダム document ID を使っています。P1 の移行先を先に固定し、実装PRでこの契約へ近づけます。
+
+### v1 でモデル化するもの
+
+- checkpoint/cursor は、メッセージの command 処理完了ではなく Inbox + History へ安全に永続化できたことを意味する
+- Inbox/History/checkpoint は1つの ingest transaction で同時に確定する
+- Pending message を lease 付きで Processing に claim する
+- lease 失効時は未完了 message を Pending に戻して再取得できる
+- 同一 source message の domain effect は論理的に高々1回
+- domain effect と reply outbox intent は処理成功 transaction で同時に確定する
+- 処理失敗は再試行でき、上限到達後は dead-letter にする
+- dead-letter は checkpoint を巻き戻さず、後続 ingest を止めない
+- reply delivery は永続化済み outbox intent がある場合だけ許可する
+
+`FailureCount = 0..2` は bounded model で retry / dead-letter の両経路を検証するための代表値です。本番の最大試行回数を2回に固定する仕様ではありません。
+
+### v1 で意図的にモデル化しないもの
+
+- YouTube API の page token 文字列や polling interval
+- message payload / author / membership / NG word 判定の内容
+- 非コマンドや副作用なしコマンドの細かな分岐
+- Firestore collection 名・field 名・index
+- worker lease の秒数、retry backoff、最大試行回数の具体値
+- outbox の外部配送で起こり得る「送信成功後、Delivered記録前のクラッシュ」による重複配送
+- 複数メッセージ間の順序・並列度
+
+外部 YouTube/Discord 配送まで exactly-once と主張しません。P1 の狙いは、Firestore 内の message ledger / domain side effect / reply intent を冪等に管理し、外部配送は再試行可能な outbox として分離することです。

--- a/formal-spec/fsl/specs/chat_message_processing.fsl
+++ b/formal-spec/fsl/specs/chat_message_processing.fsl
@@ -1,0 +1,149 @@
+// YouTube Live Chat の1件の副作用ありメッセージを、P1の目標アーキテクチャへ射影する。
+// 現行実装との conformance ではなく、Inbox / checkpoint / domain effect / reply outbox の目標契約。
+// FSL の action は RHS を同じ pre-state から読み、更新を同時に commit する。
+spec ChatMessageProcessing {
+  type FailureCount = 0..2
+  type LogicalCount = 0..1
+
+  enum InboxStatus { Absent, Pending, Processing, Processed, DeadLettered }
+  enum OutboxStatus { None, Pending, Delivered }
+
+  state {
+    inbox_status: InboxStatus,
+    history_persisted: Bool,
+    cursor_advanced: Bool,
+    failure_count: FailureCount,
+    domain_apply_count: LogicalCount,
+    reply_intent_count: LogicalCount,
+    outbox_status: OutboxStatus
+  }
+
+  init {
+    inbox_status = Absent
+    history_persisted = false
+    cursor_advanced = false
+    failure_count = 0
+    domain_apply_count = 0
+    reply_intent_count = 0
+    outbox_status = None
+  }
+
+  @requirement("REQ-CHAT-001", "checkpoint は Inbox と History への安全な永続化と同じ ingest transaction で進める")
+  action ingest() {
+    requires inbox_status == Absent
+    inbox_status = Pending
+    history_persisted = true
+    cursor_advanced = true
+  }
+
+  @requirement("REQ-CHAT-005", "Pending message だけを processing lease の対象として claim する")
+  action claim() {
+    requires inbox_status == Pending
+    inbox_status = Processing
+  }
+
+  @requirement("REQ-CHAT-005", "processing lease が失効した未完了 message は Pending に戻して再取得可能にする")
+  action processing_lease_expired() {
+    requires inbox_status == Processing
+    inbox_status = Pending
+  }
+
+  @requirement("REQ-CHAT-002", "同じ source message の domain effect は論理的に高々1回だけ適用する")
+  @requirement("REQ-CHAT-003", "処理成功時は domain effect と reply outbox intent を同じ transaction で確定する")
+  action process_success() {
+    requires inbox_status == Processing
+    inbox_status = Processed
+    domain_apply_count = domain_apply_count + 1
+    reply_intent_count = reply_intent_count + 1
+    outbox_status = Pending
+  }
+
+  // 有限モデルでは「最初の失敗後に1回再試行し、次の失敗でdead-letter」とする。
+  // 本番の最大試行回数そのものを2回に固定する仕様ではない。
+  @requirement("REQ-CHAT-004", "処理失敗は再試行し、上限到達後は dead-letter にして後続 ingest を妨げない")
+  action process_failure_retry() {
+    requires inbox_status == Processing
+    requires failure_count == 0
+    inbox_status = Pending
+    failure_count = failure_count + 1
+  }
+
+  @requirement("REQ-CHAT-004", "処理失敗は再試行し、上限到達後は dead-letter にして後続 ingest を妨げない")
+  action process_failure_dead_letter() {
+    requires inbox_status == Processing
+    requires failure_count == 1
+    inbox_status = DeadLettered
+    failure_count = failure_count + 1
+  }
+
+  @requirement("REQ-CHAT-006", "reply delivery は永続化済み outbox intent に対してだけ行う")
+  action deliver_reply() {
+    requires outbox_status == Pending
+    outbox_status = Delivered
+  }
+
+  @requirement("REQ-CHAT-001", "checkpoint は Inbox と History への安全な永続化と同じ ingest transaction で進める")
+  @kind("safety")
+  invariant CursorRequiresDurableIngest {
+    cursor_advanced => (history_persisted and inbox_status != Absent)
+  }
+
+  @kind("safety")
+  invariant AbsentMessageHasNoDurableState {
+    inbox_status == Absent =>
+      (not history_persisted and
+       not cursor_advanced and
+       domain_apply_count == 0 and
+       reply_intent_count == 0 and
+       outbox_status == None)
+  }
+
+  @requirement("REQ-CHAT-002", "同じ source message の domain effect は論理的に高々1回だけ適用する")
+  @kind("safety")
+  invariant DomainEffectRequiresProcessedMessage {
+    domain_apply_count == 1 => inbox_status == Processed
+  }
+
+  @requirement("REQ-CHAT-003", "処理成功時は domain effect と reply outbox intent を同じ transaction で確定する")
+  @kind("safety")
+  invariant DomainEffectAndReplyIntentStayAtomic {
+    domain_apply_count == reply_intent_count
+  }
+
+  @requirement("REQ-CHAT-003", "処理成功時は domain effect と reply outbox intent を同じ transaction で確定する")
+  @kind("safety")
+  invariant ProcessedMessageHasEffectAndOutboxIntent {
+    inbox_status == Processed =>
+      (domain_apply_count == 1 and
+       reply_intent_count == 1 and
+       outbox_status != None)
+  }
+
+  @requirement("REQ-CHAT-004", "処理失敗は再試行し、上限到達後は dead-letter にして後続 ingest を妨げない")
+  @kind("safety")
+  invariant DeadLetterHasNoPartialDomainEffect {
+    inbox_status == DeadLettered =>
+      (failure_count == 2 and
+       domain_apply_count == 0 and
+       reply_intent_count == 0 and
+       outbox_status == None)
+  }
+
+  @requirement("REQ-CHAT-006", "reply delivery は永続化済み outbox intent に対してだけ行う")
+  @kind("safety")
+  invariant OutboxRequiresPersistedIntent {
+    outbox_status != None => reply_intent_count == 1
+  }
+
+  reachable ProcessedMessageWithPendingReplyIsReachable {
+    inbox_status == Processed and outbox_status == Pending
+  }
+
+  reachable DeadLetterAfterRetryIsReachable {
+    inbox_status == DeadLettered and failure_count == 2
+  }
+
+  reachable DeliveredReplyIsReachable {
+    outbox_status == Delivered
+  }
+}

--- a/formal-spec/fsl/specs/chat_message_processing.fsl
+++ b/formal-spec/fsl/specs/chat_message_processing.fsl
@@ -5,8 +5,14 @@ spec ChatMessageProcessing {
   type FailureCount = 0..2
   type LogicalCount = 0..1
 
-  enum InboxStatus { Absent, Pending, Processing, Processed, DeadLettered }
-  enum OutboxStatus { None, Pending, Delivered }
+  enum InboxStatus {
+    InboxAbsent,
+    InboxPending,
+    InboxProcessing,
+    InboxProcessed,
+    InboxDeadLettered
+  }
+  enum OutboxStatus { OutboxNone, OutboxPending, OutboxDelivered }
 
   state {
     inbox_status: InboxStatus,
@@ -19,89 +25,89 @@ spec ChatMessageProcessing {
   }
 
   init {
-    inbox_status = Absent
+    inbox_status = InboxAbsent
     history_persisted = false
     cursor_advanced = false
     failure_count = 0
     domain_apply_count = 0
     reply_intent_count = 0
-    outbox_status = None
+    outbox_status = OutboxNone
   }
 
   @requirement("REQ-CHAT-001", "checkpoint は Inbox と History への安全な永続化と同じ ingest transaction で進める")
   action ingest() {
-    requires inbox_status == Absent
-    inbox_status = Pending
+    requires inbox_status == InboxAbsent
+    inbox_status = InboxPending
     history_persisted = true
     cursor_advanced = true
   }
 
   @requirement("REQ-CHAT-005", "Pending message だけを processing lease の対象として claim する")
   action claim() {
-    requires inbox_status == Pending
-    inbox_status = Processing
+    requires inbox_status == InboxPending
+    inbox_status = InboxProcessing
   }
 
   @requirement("REQ-CHAT-005", "processing lease が失効した未完了 message は Pending に戻して再取得可能にする")
   action processing_lease_expired() {
-    requires inbox_status == Processing
-    inbox_status = Pending
+    requires inbox_status == InboxProcessing
+    inbox_status = InboxPending
   }
 
   @requirement("REQ-CHAT-002", "同じ source message の domain effect は論理的に高々1回だけ適用する")
   @requirement("REQ-CHAT-003", "処理成功時は domain effect と reply outbox intent を同じ transaction で確定する")
   action process_success() {
-    requires inbox_status == Processing
-    inbox_status = Processed
+    requires inbox_status == InboxProcessing
+    inbox_status = InboxProcessed
     domain_apply_count = domain_apply_count + 1
     reply_intent_count = reply_intent_count + 1
-    outbox_status = Pending
+    outbox_status = OutboxPending
   }
 
   // 有限モデルでは「最初の失敗後に1回再試行し、次の失敗でdead-letter」とする。
   // 本番の最大試行回数そのものを2回に固定する仕様ではない。
   @requirement("REQ-CHAT-004", "処理失敗は再試行し、上限到達後は dead-letter にして後続 ingest を妨げない")
   action process_failure_retry() {
-    requires inbox_status == Processing
+    requires inbox_status == InboxProcessing
     requires failure_count == 0
-    inbox_status = Pending
+    inbox_status = InboxPending
     failure_count = failure_count + 1
   }
 
   @requirement("REQ-CHAT-004", "処理失敗は再試行し、上限到達後は dead-letter にして後続 ingest を妨げない")
   action process_failure_dead_letter() {
-    requires inbox_status == Processing
+    requires inbox_status == InboxProcessing
     requires failure_count == 1
-    inbox_status = DeadLettered
+    inbox_status = InboxDeadLettered
     failure_count = failure_count + 1
   }
 
   @requirement("REQ-CHAT-006", "reply delivery は永続化済み outbox intent に対してだけ行う")
   action deliver_reply() {
-    requires outbox_status == Pending
-    outbox_status = Delivered
+    requires outbox_status == OutboxPending
+    outbox_status = OutboxDelivered
   }
 
   @requirement("REQ-CHAT-001", "checkpoint は Inbox と History への安全な永続化と同じ ingest transaction で進める")
   @kind("safety")
   invariant CursorRequiresDurableIngest {
-    cursor_advanced => (history_persisted and inbox_status != Absent)
+    cursor_advanced => (history_persisted and inbox_status != InboxAbsent)
   }
 
   @kind("safety")
   invariant AbsentMessageHasNoDurableState {
-    inbox_status == Absent =>
+    inbox_status == InboxAbsent =>
       (not history_persisted and
        not cursor_advanced and
        domain_apply_count == 0 and
        reply_intent_count == 0 and
-       outbox_status == None)
+       outbox_status == OutboxNone)
   }
 
   @requirement("REQ-CHAT-002", "同じ source message の domain effect は論理的に高々1回だけ適用する")
   @kind("safety")
   invariant DomainEffectRequiresProcessedMessage {
-    domain_apply_count == 1 => inbox_status == Processed
+    domain_apply_count == 1 => inbox_status == InboxProcessed
   }
 
   @requirement("REQ-CHAT-003", "処理成功時は domain effect と reply outbox intent を同じ transaction で確定する")
@@ -113,37 +119,37 @@ spec ChatMessageProcessing {
   @requirement("REQ-CHAT-003", "処理成功時は domain effect と reply outbox intent を同じ transaction で確定する")
   @kind("safety")
   invariant ProcessedMessageHasEffectAndOutboxIntent {
-    inbox_status == Processed =>
+    inbox_status == InboxProcessed =>
       (domain_apply_count == 1 and
        reply_intent_count == 1 and
-       outbox_status != None)
+       outbox_status != OutboxNone)
   }
 
   @requirement("REQ-CHAT-004", "処理失敗は再試行し、上限到達後は dead-letter にして後続 ingest を妨げない")
   @kind("safety")
   invariant DeadLetterHasNoPartialDomainEffect {
-    inbox_status == DeadLettered =>
+    inbox_status == InboxDeadLettered =>
       (failure_count == 2 and
        domain_apply_count == 0 and
        reply_intent_count == 0 and
-       outbox_status == None)
+       outbox_status == OutboxNone)
   }
 
   @requirement("REQ-CHAT-006", "reply delivery は永続化済み outbox intent に対してだけ行う")
   @kind("safety")
   invariant OutboxRequiresPersistedIntent {
-    outbox_status != None => reply_intent_count == 1
+    outbox_status != OutboxNone => reply_intent_count == 1
   }
 
   reachable ProcessedMessageWithPendingReplyIsReachable {
-    inbox_status == Processed and outbox_status == Pending
+    inbox_status == InboxProcessed and outbox_status == OutboxPending
   }
 
   reachable DeadLetterAfterRetryIsReachable {
-    inbox_status == DeadLettered and failure_count == 2
+    inbox_status == InboxDeadLettered and failure_count == 2
   }
 
   reachable DeliveredReplyIsReachable {
-    outbox_status == Delivered
+    outbox_status == OutboxDelivered
   }
 }


### PR DESCRIPTION
## 概要

P1「YouTubeチャット処理を冪等化・耐障害化」で以前決めた目標アーキテクチャを、実装前の契約として FSL に固定します。

現行 `youtube-bot` の conformance spec ではありません。現状は `nextPageToken` を先に保存してから履歴保存・`ProcessMessage` を実行し、`live-chat-history` も message ID をフィールドに持つ一方で document ID は `NewDoc()` のランダムIDです。このPRでは現状を正当化せず、P1の移行先を検証可能な形にします。

## ChatMessageProcessing v1

1件の副作用あり source message を有限モデルとして扱い、以下を定義します。

- durable ingest で Inbox / History / checkpoint を同時に確定
- checkpoint は「command処理完了」ではなく「安全に永続化済み」を意味する
- Pending → Processing の lease 付き claim
- lease失効時の Processing → Pending 回復
- 同一 source message の domain effect は論理的に高々1回
- 処理成功時、domain effect と reply outbox intent を同じ transaction で確定
- 失敗時は retry、上限到達後は dead-letter
- dead-letter でも ingest済み checkpoint は巻き戻さない
- reply delivery は永続化済み outbox intent がある場合だけ許可

`domain_apply_count` / `reply_intent_count` は `0..1` に制限し、`process_success` で pre-state + 1 することで二重適用を検出可能にします。

## Requirement IDs

- `REQ-CHAT-001`: durable ingest と checkpoint の atomicity
- `REQ-CHAT-002`: domain effect at-most-once
- `REQ-CHAT-003`: domain effect と reply intent の atomicity
- `REQ-CHAT-004`: retry / dead-letter
- `REQ-CHAT-005`: processing lease recovery
- `REQ-CHAT-006`: persisted outbox intent が delivery の前提

## bounded model の注意

`FailureCount = 0..2` は retry → dead-letter の両経路を小さな状態空間で検証する代表値です。本番の最大試行回数を2回に固定する仕様ではありません。

## 意図的にモデル化しないもの

- YouTube page token文字列 / polling interval
- payload / author / membership / NG word内容
- 非コマンド・副作用なしコマンドの細かな分岐
- Firestore collection/field/index名
- lease秒数 / backoff / 本番retry回数
- 外部送信成功後、Delivered記録前に落ちた場合の重複配送
- 複数message間の順序・並列度

YouTube/Discordの外部配送まで exactly-once とは主張しません。

## 境界

- target contract であり、現行実装との conformance 未接続
- production runtimeへFSL依存を追加しない
- 実装PRが進んだ段階で `fslc conformance` を新Inbox processorへ接続する
- mismatchを理由に仕様を弱める既存の禁止ルールを維持

## Acceptance criteria

- pinned FSL v4.2.0 で全specの `check` / `verify --depth 8 --vacuity error` 成功
- 既存 SeatSession conformance → Go adapter 成功
- ChatMessageProcessing HTML report が `fsl-spec-reports` artifact に含まれる
- CI Gate / Formal Spec Report 成功
