### PR TITLE
feat: add guarded one-shot BigQuery raw chat purge

### DIFF
--- a/system/cmd/privacy-retention-admin/main.go
+++ b/system/cmd/privacy-retention-admin/main.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"google.golang.org/api/option"
+
+	"app.modules/core/mybigquery"
+	"app.modules/core/repository"
+	"app.modules/core/utils"
+)
+
+const (
+	previewBigQueryCommand = "preview-bigquery"
+	applyBigQueryCommand   = "apply-bigquery"
+)
+
+type previewOutput struct {
+	Mode                 string                               `json:"mode"`
+	Cutoff               time.Time                            `json:"cutoff"`
+	Audit                mybigquery.RawLiveChatRetentionAudit `json:"audit"`
+	DeleteCandidates     int64                                `json:"delete_candidates"`
+	RequiredConfirmation string                               `json:"required_confirmation"`
+}
+
+type applyOutput struct {
+	Mode             string                               `json:"mode"`
+	Cutoff           time.Time                            `json:"cutoff"`
+	ConfirmedRows    int64                                `json:"confirmed_rows"`
+	Before           mybigquery.RawLiveChatRetentionAudit `json:"before"`
+	After            mybigquery.RawLiveChatRetentionAudit `json:"after"`
+	DeleteCandidates int64                                `json:"delete_candidates"`
+}
+
+func main() {
+	if err := run(context.Background(), os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, "privacy-retention-admin:", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args []string) error {
+	if len(args) < 3 {
+		return usageError()
+	}
+
+	cutoff, err := time.Parse(time.RFC3339, strings.TrimSpace(args[2]))
+	if err != nil {
+		return fmt.Errorf("parse cutoff as RFC3339: %w", err)
+	}
+	cutoff = cutoff.UTC()
+
+	utils.LoadEnv(".env")
+	credentialFilePath := strings.TrimSpace(os.Getenv("CREDENTIAL_FILE_LOCATION"))
+	if credentialFilePath == "" {
+		return errors.New("CREDENTIAL_FILE_LOCATION is required")
+	}
+	//nolint:staticcheck // Credential file path is operator-controlled for this explicit admin operation.
+	clientOption := option.WithCredentialsFile(credentialFilePath)
+
+	repo, err := repository.NewFirestoreController(ctx, clientOption)
+	if err != nil {
+		return fmt.Errorf("initialize Firestore: %w", err)
+	}
+	defer func() {
+		if err := repo.FirestoreClient().Close(); err != nil {
+			fmt.Fprintln(os.Stderr, "privacy-retention-admin: close Firestore:", err)
+		}
+	}()
+
+	constants, err := repo.ReadSystemConstantsConfig(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("read system constants: %w", err)
+	}
+	projectID, err := utils.GetGcpProjectID(ctx, clientOption)
+	if err != nil {
+		return fmt.Errorf("resolve GCP project ID: %w", err)
+	}
+	bqClient, err := mybigquery.NewBigqueryClient(
+		ctx,
+		projectID,
+		clientOption,
+		constants.GcpRegion,
+	)
+	if err != nil {
+		return fmt.Errorf("initialize BigQuery: %w", err)
+	}
+	defer bqClient.CloseClient()
+
+	switch args[1] {
+	case previewBigQueryCommand:
+		if len(args) != 3 {
+			return usageError()
+		}
+		return previewBigQuery(ctx, bqClient, cutoff)
+	case applyBigQueryCommand:
+		if len(args) != 7 || args[3] != "--expected-rows" || args[5] != "--confirm" {
+			return usageError()
+		}
+		expectedRows, err := strconv.ParseInt(args[4], 10, 64)
+		if err != nil || expectedRows <= 0 {
+			return fmt.Errorf("expected rows must be a positive integer: %q", args[4])
+		}
+		return applyBigQuery(ctx, bqClient, cutoff, expectedRows, args[6])
+	default:
+		return usageError()
+	}
+}
+
+func previewBigQuery(
+	ctx context.Context,
+	client *mybigquery.BigqueryController,
+	cutoff time.Time,
+) error {
+	audit, err := client.InspectRawLiveChatRetention(ctx, cutoff)
+	if err != nil {
+		return fmt.Errorf("inspect BigQuery raw chat: %w", err)
+	}
+	candidates := deleteCandidateCount(audit)
+	output := previewOutput{
+		Mode:                 "preview",
+		Cutoff:               cutoff,
+		Audit:                audit,
+		DeleteCandidates:     candidates,
+		RequiredConfirmation: confirmationToken(cutoff, candidates),
+	}
+	return writeJSON(output)
+}
+
+func applyBigQuery(
+	ctx context.Context,
+	client *mybigquery.BigqueryController,
+	cutoff time.Time,
+	expectedRows int64,
+	confirmation string,
+) error {
+	before, err := client.InspectRawLiveChatRetention(ctx, cutoff)
+	if err != nil {
+		return fmt.Errorf("inspect BigQuery raw chat before purge: %w", err)
+	}
+	candidates := deleteCandidateCount(before)
+	if candidates == 0 {
+		return errors.New("there are no raw live chat rows to purge for this cutoff")
+	}
+	if candidates != expectedRows {
+		return fmt.Errorf(
+			"candidate count changed: expected=%d current=%d; rerun preview",
+			expectedRows,
+			candidates,
+		)
+	}
+
+	requiredConfirmation := confirmationToken(cutoff, expectedRows)
+	if confirmation != requiredConfirmation {
+		return fmt.Errorf("confirmation mismatch; required exactly %q", requiredConfirmation)
+	}
+
+	if err := client.PurgeRawLiveChatBefore(ctx, cutoff, expectedRows); err != nil {
+		return fmt.Errorf("purge BigQuery raw chat: %w", err)
+	}
+
+	after, err := client.InspectRawLiveChatRetention(ctx, cutoff)
+	if err != nil {
+		return fmt.Errorf("inspect BigQuery raw chat after purge: %w", err)
+	}
+	if remaining := deleteCandidateCount(after); remaining != 0 {
+		return fmt.Errorf("post-purge verification failed: %d candidate rows remain", remaining)
+	}
+
+	output := applyOutput{
+		Mode:             "applied",
+		Cutoff:           cutoff,
+		ConfirmedRows:    expectedRows,
+		Before:           before,
+		After:            after,
+		DeleteCandidates: candidates,
+	}
+	return writeJSON(output)
+}
+
+func deleteCandidateCount(audit mybigquery.RawLiveChatRetentionAudit) int64 {
+	return audit.RowsOlderThanCutoff + audit.UndatedRows
+}
+
+func confirmationToken(cutoff time.Time, rows int64) string {
+	return fmt.Sprintf(
+		"DELETE %d RAW YOUTUBE LIVE CHAT ROWS BEFORE %s",
+		rows,
+		cutoff.UTC().Format(time.RFC3339),
+	)
+}
+
+func writeJSON(value any) error {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(value); err != nil {
+		return fmt.Errorf("encode output: %w", err)
+	}
+	return nil
+}
+
+func usageError() error {
+	return errors.New(
+		"usage: privacy-retention-admin preview-bigquery <cutoff-rfc3339> OR " +
+			"privacy-retention-admin apply-bigquery <cutoff-rfc3339> " +
+			"--expected-rows <count> --confirm <exact-preview-token>",
+	)
+}

--- a/system/cmd/privacy-retention-admin/main_test.go
+++ b/system/cmd/privacy-retention-admin/main_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"app.modules/core/mybigquery"
+)
+
+func TestDeleteCandidateCount(t *testing.T) {
+	audit := mybigquery.RawLiveChatRetentionAudit{
+		RowsOlderThanCutoff: 47_451,
+		UndatedRows:         3,
+	}
+	assert.EqualValues(t, 47_454, deleteCandidateCount(audit))
+}
+
+func TestConfirmationToken(t *testing.T) {
+	cutoff := time.Date(2026, 7, 15, 13, 52, 23, 0, time.FixedZone("JST-ish", 9*60*60))
+	assert.Equal(
+		t,
+		"DELETE 47451 RAW YOUTUBE LIVE CHAT ROWS BEFORE 2026-07-15T04:52:23Z",
+		confirmationToken(cutoff, 47_451),
+	)
+}

--- a/system/core/mybigquery/retention_purge.go
+++ b/system/core/mybigquery/retention_purge.go
@@ -1,0 +1,69 @@
+package mybigquery
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/bigquery"
+)
+
+// PurgeRawLiveChatBefore deletes raw YouTube live-chat rows before cutoff only
+// when the candidate count still equals expectedRows. The count check and DELETE
+// run in one BigQuery transaction so the operator's preview cannot silently
+// expand to a different snapshot at apply time.
+func (c *BigqueryController) PurgeRawLiveChatBefore(
+	ctx context.Context,
+	cutoff time.Time,
+	expectedRows int64,
+) error {
+	if expectedRows <= 0 {
+		return fmt.Errorf("expected rows must be positive: %d", expectedRows)
+	}
+
+	tableIdentifier := fmt.Sprintf(
+		"`%s.%s.%s`",
+		c.Client.Project(),
+		DatasetName,
+		LiveChatHistoryMainTableName,
+	)
+	query := c.Client.Query(buildRawLiveChatPurgeQuery(tableIdentifier))
+	query.Location = c.WorkingRegion
+	query.Parameters = []bigquery.QueryParameter{
+		{Name: "cutoff", Value: cutoff},
+		{Name: "expected_rows", Value: expectedRows},
+	}
+
+	job, err := query.Run(ctx)
+	if err != nil {
+		return fmt.Errorf("run raw live chat purge transaction: %w", err)
+	}
+	status, err := job.Wait(ctx)
+	if err != nil {
+		return fmt.Errorf("wait raw live chat purge transaction: %w", err)
+	}
+	if err := status.Err(); err != nil {
+		return fmt.Errorf("raw live chat purge transaction failed: %w", err)
+	}
+	if status.State != bigquery.Done {
+		return fmt.Errorf("raw live chat purge transaction did not finish: state=%v", status.State)
+	}
+	return nil
+}
+
+func buildRawLiveChatPurgeQuery(tableIdentifier string) string {
+	return fmt.Sprintf(`
+BEGIN TRANSACTION;
+
+SELECT IF(
+  (SELECT COUNT(*) FROM %s WHERE published_at IS NULL OR published_at < @cutoff) = @expected_rows,
+  TRUE,
+  ERROR('raw live chat purge candidate count changed; rerun preview')
+) AS candidate_count_verified;
+
+DELETE FROM %s
+WHERE published_at IS NULL OR published_at < @cutoff;
+
+COMMIT TRANSACTION;
+`, tableIdentifier, tableIdentifier)
+}

--- a/system/core/mybigquery/retention_purge_test.go
+++ b/system/core/mybigquery/retention_purge_test.go
@@ -1,0 +1,22 @@
+package mybigquery
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildRawLiveChatPurgeQuery(t *testing.T) {
+	const table = "`project.dataset.live-chat-history`"
+	query := buildRawLiveChatPurgeQuery(table)
+
+	assert.Contains(t, query, "BEGIN TRANSACTION;")
+	assert.Contains(t, query, "@expected_rows")
+	assert.Contains(t, query, "@cutoff")
+	assert.Contains(t, query, "ERROR('raw live chat purge candidate count changed; rerun preview')")
+	assert.Contains(t, query, "DELETE FROM "+table)
+	assert.Contains(t, query, "published_at IS NULL OR published_at < @cutoff")
+	assert.Contains(t, query, "COMMIT TRANSACTION;")
+	assert.Equal(t, 2, strings.Count(query, table))
+}


### PR DESCRIPTION
## 概要

- `privacy-retention-admin` を追加し、BigQuery に残る YouTube 生チャットの既存長期データを明示的に整理できるようにする
- `preview-bigquery <cutoff>` は完全な読み取り専用で、削除候補件数と厳密な確認トークンを JSON で出力する
- `apply-bigquery <cutoff> --expected-rows <count> --confirm <token>` だけが DELETE を実行する
- apply 直前に候補件数を再取得し、preview 時の件数と異なる場合は停止する
- BigQuery 側でもトランザクション内で同じ候補件数を再検証してから DELETE する
- DELETE 後に再監査し、cutoff より古い行または timestamp 欠損行が1件でも残れば成功扱いにしない

## 背景となる本番監査結果

2026-08-14 の読み取り専用監査で、本番 `firestore_export.live-chat-history` は以下の状態でした。

- 合計: 47,451 行
- 30日超: 47,451 行
- timestamp 欠損: 0 行
- 最古: 2021-11-13T07:37:55Z
- 最新: 2026-06-23T12:47:09Z

一方、Firestore は `collection-history-retention-days=5` で、30日超のデータは0件でした。

また現行 CDK では daily batch の `transfer-bq` は 00:00 JST で有効ですが、BigQuery の最新行が 6/23 で止まっているため、既存データ整理を次回 daily batch の成功には依存させません。

## 使い方

まず preview のみ実行します。

```bash
cd system
go run ./cmd/privacy-retention-admin preview-bigquery 2026-07-15T13:52:23Z
```

preview が返した `delete_candidates` と `required_confirmation` を確認した場合のみ apply します。

```bash
go run ./cmd/privacy-retention-admin apply-bigquery 2026-07-15T13:52:23Z \
  --expected-rows 47451 \
  --confirm "DELETE 47451 RAW YOUTUBE LIVE CHAT ROWS BEFORE 2026-07-15T13:52:23Z"
```

※上記件数は監査時点の例です。実行時は必ず直前 preview の値を使用します。

## 安全策

- preview は SELECT のみ
- apply には明示的な subcommand、固定 cutoff、期待行数、厳密な確認トークンが必要
- 候補件数が変化した場合は Go 側で停止
- トランザクション内でも snapshot 上の候補件数を SELECT + `ERROR()` で再検証してから DELETE
- `published_at IS NULL` は保存期間を証明できないため削除候補に含める
- BigQuery 以外のデータストアは変更しない
- この PR の CI 実行やマージだけでは本番 DELETE は実行されない

## 検証

- confirmation / candidate helper のテスト
- transaction SQL の形状テスト
- Draft CI で Go test / lint / Firestore Emulator を確認

## 関連

- #985: 今後の Firestore / BigQuery 生チャット30日上限
- この PR: すでに BigQuery へ残っている長期47,451行を、daily batch 復旧に依存せず一度だけ整理する運用操作
- #983: GCS snapshot の扱いは別途 object inventory を確認して決定