### PR TITLE
fix: stop long-term BigQuery raw live chat archive

### DIFF
--- a/system/core/mybigquery/archive_policy_test.go
+++ b/system/core/mybigquery/archive_policy_test.go
@@ -1,0 +1,42 @@
+package mybigquery
+
+import (
+	"testing"
+
+	"app.modules/core/repository"
+)
+
+func TestShouldArchiveCollectionToBigQuery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		collection string
+		want       bool
+	}{
+		{
+			name:       "raw live chat is never archived",
+			collection: repository.LiveChatHistory,
+			want:       false,
+		},
+		{
+			name:       "user activities remain archived",
+			collection: repository.UserActivities,
+			want:       true,
+		},
+		{
+			name:       "order history remains archived",
+			collection: repository.OrderHistory,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := shouldArchiveCollectionToBigQuery(tt.collection); got != tt.want {
+				t.Fatalf("shouldArchiveCollectionToBigQuery(%q) = %t, want %t", tt.collection, got, tt.want)
+			}
+		})
+	}
+}

--- a/system/core/mybigquery/bigquery_controller.go
+++ b/system/core/mybigquery/bigquery_controller.go
@@ -43,11 +43,23 @@ func (c *BigqueryController) CloseClient() {
 	}
 }
 
+func shouldArchiveCollectionToBigQuery(collectionName string) bool {
+	// Raw YouTube live chat is intentionally not a long-term analytics/archive
+	// dataset. Firestore keeps it only for its short operational retention, and
+	// historical BigQuery rows are cleaned up by the privacy retention operation.
+	return collectionName != repository.LiveChatHistory
+}
+
 func (c *BigqueryController) ReadCollectionsFromGcs(ctx context.Context,
 	gcsFolderName string, bucketName string,
 	collections []string,
 ) error {
 	for _, collectionName := range collections {
+		if !shouldArchiveCollectionToBigQuery(collectionName) {
+			slog.Info("skipping raw YouTube live chat BigQuery archive", "collection", collectionName)
+			continue
+		}
+
 		// GCSからbigqueryの一時テーブルにデータをバッチ読込
 		gcsRef := bigquery.NewGCSReference("gs://" + bucketName + "/" + gcsFolderName + "/all_namespaces/kind_" +
 			"" + collectionName + "/all_namespaces_kind_" + collectionName + ".export_metadata")


### PR DESCRIPTION
## 概要

- `ReadCollectionsFromGcs` に BigQuery アーカイブ対象の境界を追加する
- `live-chat-history` は呼び出し側が collection list に渡しても BigQuery へ load / append しない
- `user-activities` / `order-history` は従来どおりアーカイブ対象とする
- policy helper の unit test で raw live chat の再追加を防止する

## 背景

2026-08-14 の本番監査では以下を確認しました。

- BigQuery `firestore_export.live-chat-history`: 47,451 行
- 全件30日超
- 最新行: 2026-06-23
- リポジトリ内に raw live-chat BigQuery table をサービス機能から読む consumer は見つからない
- Firestore 側の raw chat はすでに5日 retention で、30日超は0件

さらに GCS 監査では、古い snapshot に `kind_live-chat-history` が存在する一方、最近の snapshot は object 構成が減少しており、BigQuery 停止日と近い時期に GCS export から raw chat が外れた可能性が高い状態でした。

現行 `BackupCollectionHistoryFromGcsToBigquery` は呼び出し側の list 先頭で `live-chat-history` を要求するため、GCS metadata が存在しない場合はそこで失敗し、後続の `user-activities` / `order-history` まで転送されません。

raw chat の長期アーカイブ自体に利用価値が見つからないため、missing raw-chat export を復旧させるのではなく、BigQuery 層で恒久的にアーカイブ対象外とします。

## 重要な境界

- 既存47,451行はこの PR では削除しない。マージ済み #997 の guarded one-shot purge で別途整理する
- Firestore `live-chat-history` の短期 operational retention は変更しない
- GCS の混在 historical snapshot は #1001 / #983 で別途整理する
- `user-activities` / `order-history` の transfer は維持する

## 回帰防止

`shouldArchiveCollectionToBigQuery` のテストで以下を固定します。

- `live-chat-history` => false
- `user-activities` => true
- `order-history` => true

## 検証

Draft CI で System Go Test / Go Lint / Firestore Emulator / CI Gate を確認します。

## 関連

- #999 raw live chat BigQuery archive retirement
- #998 production daily batch drift
- #997 guarded existing BigQuery purge（マージ済み）
- #1001 guarded GCS mixed snapshot cleanup