### PR TITLE
Add live chat inbox processing lease foundation

### DIFF
--- a/firebase/firestore.indexes.json
+++ b/firebase/firestore.indexes.json
@@ -43,6 +43,46 @@
       ]
     },
     {
+      "collectionGroup": "live-chat-inbox",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "`live-chat-id`",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "sequence",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
+      "collectionGroup": "live-chat-inbox",
+      "queryScope": "COLLECTION",
+      "fields": [
+        {
+          "fieldPath": "`live-chat-id`",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "status",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "`lease-until`",
+          "order": "ASCENDING"
+        },
+        {
+          "fieldPath": "sequence",
+          "order": "ASCENDING"
+        }
+      ]
+    },
+    {
       "collectionGroup": "member-seats",
       "queryScope": "COLLECTION",
       "fields": [

--- a/system/core/repository/live_chat_inbox_concurrency_integration_test.go
+++ b/system/core/repository/live_chat_inbox_concurrency_integration_test.go
@@ -1,0 +1,79 @@
+//go:build integration
+
+package repository_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"app.modules/core/repository"
+	"app.modules/internal/integrationtest"
+)
+
+func TestFirestoreRepository_LiveChatInboxConcurrentClaimHasSingleWinner(t *testing.T) {
+	integrationtest.ResetFirestore(t)
+	controller := integrationtest.NewFirestoreController(t)
+	ctx := context.Background()
+	liveChatID := "live-chat-concurrent-claim"
+	ingestedAt := time.Date(2026, 8, 15, 1, 0, 0, 0, time.UTC)
+	message := liveChatHistoryDoc(liveChatID, "message-1", "author-1", "!in", ingestedAt)
+	require.NoError(t, controller.IngestLiveChatPage(ctx, liveChatID, "", "cursor-1", []repository.LiveChatHistoryDoc{message}, ingestedAt))
+
+	claimAt := ingestedAt.Add(time.Minute)
+	workers := []string{"worker-a", "worker-b"}
+	type claimResult struct {
+		worker  string
+		message repository.LiveChatInboxDoc
+		err     error
+	}
+	results := make(chan claimResult, len(workers))
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for _, worker := range workers {
+		worker := worker
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			claimed, err := controller.ClaimLiveChatInboxMessage(
+				ctx,
+				liveChatID,
+				message.ID,
+				worker,
+				claimAt,
+				time.Minute,
+				3,
+			)
+			results <- claimResult{worker: worker, message: claimed, err: err}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	var successes []claimResult
+	var rejected []claimResult
+	for result := range results {
+		if result.err == nil {
+			successes = append(successes, result)
+			continue
+		}
+		if assert.ErrorIs(t, result.err, repository.ErrLiveChatInboxNotClaimable) {
+			rejected = append(rejected, result)
+		}
+	}
+
+	require.Len(t, successes, 1)
+	require.Len(t, rejected, 1)
+	assert.Equal(t, repository.LiveChatInboxProcessing, successes[0].message.Status)
+	assert.Equal(t, 1, successes[0].message.AttemptCount)
+
+	stored := readInboxMessage(t, controller, liveChatID, message.ID)
+	assert.Equal(t, successes[0].worker, stored.LeaseOwner)
+	assert.Equal(t, 1, stored.AttemptCount)
+}

--- a/system/core/repository/live_chat_inbox_processing.go
+++ b/system/core/repository/live_chat_inbox_processing.go
@@ -97,12 +97,12 @@ func (c *FirestoreControllerImplements) listExpiredLiveChatInboxMessages(
 }
 
 func readLiveChatInboxQuery(ctx context.Context, query firestore.Query) ([]LiveChatInboxDoc, error) {
-	iterator := query.Documents(ctx)
-	defer iterator.Stop()
+	iter := query.Documents(ctx)
+	defer iter.Stop()
 
 	var messages []LiveChatInboxDoc
 	for {
-		doc, err := iterator.Next()
+		doc, err := iter.Next()
 		if err == iterator.Done {
 			break
 		}

--- a/system/core/repository/live_chat_inbox_processing.go
+++ b/system/core/repository/live_chat_inbox_processing.go
@@ -1,0 +1,359 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/firestore"
+	"google.golang.org/api/iterator"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	LiveChatInboxProcessing   LiveChatInboxStatus = "processing"
+	LiveChatInboxProcessed    LiveChatInboxStatus = "processed"
+	LiveChatInboxDeadLettered LiveChatInboxStatus = "dead-lettered"
+)
+
+var (
+	ErrLiveChatInboxNotClaimable   = errors.New("live chat inbox message is not claimable")
+	ErrLiveChatInboxLeaseLost      = errors.New("live chat inbox processing lease is not owned or has expired")
+	ErrLiveChatInboxRetryExhausted = errors.New("live chat inbox processing retry limit exhausted")
+	ErrLiveChatInboxCorruptState   = errors.New("live chat inbox message has inconsistent processing state")
+)
+
+// ListClaimableLiveChatInboxMessages returns pending messages and processing
+// messages whose leases have expired. Results are merged by durable sequence so
+// workers preserve source ordering as far as the current bounded batch allows.
+// ClaimLiveChatInboxMessage remains the authority: listing is only advisory and
+// concurrent workers must still claim each message transactionally.
+func (c *FirestoreControllerImplements) ListClaimableLiveChatInboxMessages(
+	ctx context.Context,
+	liveChatID string,
+	now time.Time,
+	limit int,
+) ([]LiveChatInboxDoc, error) {
+	if strings.TrimSpace(liveChatID) == "" {
+		return nil, errors.New("live chat id is empty")
+	}
+	if now.IsZero() {
+		return nil, errors.New("now is zero")
+	}
+	if limit <= 0 {
+		return nil, fmt.Errorf("limit must be positive: %d", limit)
+	}
+
+	pending, err := c.listPendingLiveChatInboxMessages(ctx, liveChatID, limit)
+	if err != nil {
+		return nil, err
+	}
+	expired, err := c.listExpiredLiveChatInboxMessages(ctx, liveChatID, now, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	messages := append(pending, expired...)
+	sort.SliceStable(messages, func(i, j int) bool {
+		return messages[i].Sequence < messages[j].Sequence
+	})
+	if len(messages) > limit {
+		messages = messages[:limit]
+	}
+	return messages, nil
+}
+
+func (c *FirestoreControllerImplements) listPendingLiveChatInboxMessages(
+	ctx context.Context,
+	liveChatID string,
+	limit int,
+) ([]LiveChatInboxDoc, error) {
+	query := c.liveChatInboxCollection().
+		Where("live-chat-id", "==", liveChatID).
+		Where("status", "==", LiveChatInboxPending).
+		OrderBy("sequence", firestore.Asc).
+		Limit(limit)
+	return readLiveChatInboxQuery(ctx, query)
+}
+
+func (c *FirestoreControllerImplements) listExpiredLiveChatInboxMessages(
+	ctx context.Context,
+	liveChatID string,
+	now time.Time,
+	limit int,
+) ([]LiveChatInboxDoc, error) {
+	query := c.liveChatInboxCollection().
+		Where("live-chat-id", "==", liveChatID).
+		Where("status", "==", LiveChatInboxProcessing).
+		Where("lease-until", "<=", now).
+		OrderBy("lease-until", firestore.Asc).
+		OrderBy("sequence", firestore.Asc).
+		Limit(limit)
+	return readLiveChatInboxQuery(ctx, query)
+}
+
+func readLiveChatInboxQuery(ctx context.Context, query firestore.Query) ([]LiveChatInboxDoc, error) {
+	iterator := query.Documents(ctx)
+	defer iterator.Stop()
+
+	var messages []LiveChatInboxDoc
+	for {
+		doc, err := iterator.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("iterate live chat inbox query: %w", err)
+		}
+		var message LiveChatInboxDoc
+		if err := doc.DataTo(&message); err != nil {
+			return nil, fmt.Errorf("decode live chat inbox document %q: %w", doc.Ref.Path, err)
+		}
+		messages = append(messages, message)
+	}
+	return messages, nil
+}
+
+// ClaimLiveChatInboxMessage acquires or reacquires a processing lease for one
+// deterministic source message. AttemptCount counts processing leases, including
+// a lease reclaimed after a worker crash. When the configured maximum has
+// already been consumed, the message is atomically dead-lettered instead.
+func (c *FirestoreControllerImplements) ClaimLiveChatInboxMessage(
+	ctx context.Context,
+	liveChatID string,
+	messageID string,
+	workerID string,
+	now time.Time,
+	leaseDuration time.Duration,
+	maxAttempts int,
+) (LiveChatInboxDoc, error) {
+	if strings.TrimSpace(workerID) == "" {
+		return LiveChatInboxDoc{}, errors.New("worker id is empty")
+	}
+	if now.IsZero() {
+		return LiveChatInboxDoc{}, errors.New("now is zero")
+	}
+	if leaseDuration <= 0 {
+		return LiveChatInboxDoc{}, fmt.Errorf("lease duration must be positive: %s", leaseDuration)
+	}
+	if maxAttempts <= 0 {
+		return LiveChatInboxDoc{}, fmt.Errorf("max attempts must be positive: %d", maxAttempts)
+	}
+
+	ref, err := c.liveChatInboxMessageRef(liveChatID, messageID)
+	if err != nil {
+		return LiveChatInboxDoc{}, err
+	}
+
+	var claimed LiveChatInboxDoc
+	deadLettered := false
+	if err := c.firestoreClient.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
+		message, err := readLiveChatInboxMessageTx(tx, ref)
+		if err != nil {
+			return err
+		}
+		if message.LiveChatID != liveChatID || message.MessageID != messageID {
+			return fmt.Errorf("%w: deterministic key points to different source message", ErrLiveChatInboxCorruptState)
+		}
+
+		claimable := false
+		switch message.Status {
+		case LiveChatInboxPending:
+			if message.LeaseOwner != "" || message.LeaseUntil != nil {
+				return fmt.Errorf("%w: pending message still has a lease", ErrLiveChatInboxCorruptState)
+			}
+			claimable = true
+		case LiveChatInboxProcessing:
+			if message.LeaseOwner == "" || message.LeaseUntil == nil {
+				return fmt.Errorf("%w: processing message is missing lease metadata", ErrLiveChatInboxCorruptState)
+			}
+			claimable = !message.LeaseUntil.After(now)
+		case LiveChatInboxProcessed, LiveChatInboxDeadLettered:
+			return ErrLiveChatInboxNotClaimable
+		default:
+			return fmt.Errorf("%w: unknown status %q", ErrLiveChatInboxCorruptState, message.Status)
+		}
+		if !claimable {
+			return ErrLiveChatInboxNotClaimable
+		}
+
+		if message.AttemptCount >= maxAttempts {
+			message.Status = LiveChatInboxDeadLettered
+			message.LeaseOwner = ""
+			message.LeaseUntil = nil
+			if message.LastError == "" {
+				message.LastError = "processing lease expired after retry limit was exhausted"
+			}
+			if err := c.set(ctx, tx, ref, message); err != nil {
+				return fmt.Errorf("dead-letter exhausted live chat inbox message: %w", err)
+			}
+			claimed = message
+			deadLettered = true
+			return nil
+		}
+
+		leaseUntil := now.Add(leaseDuration)
+		message.Status = LiveChatInboxProcessing
+		message.AttemptCount++
+		message.LeaseOwner = workerID
+		message.LeaseUntil = &leaseUntil
+		if err := c.set(ctx, tx, ref, message); err != nil {
+			return fmt.Errorf("claim live chat inbox message: %w", err)
+		}
+		claimed = message
+		return nil
+	}); err != nil {
+		return LiveChatInboxDoc{}, fmt.Errorf("claim live chat inbox transaction: %w", err)
+	}
+	if deadLettered {
+		return claimed, ErrLiveChatInboxRetryExhausted
+	}
+	return claimed, nil
+}
+
+// CompleteLiveChatInboxMessage marks a message processed only while the caller
+// still owns an unexpired lease. Once a lease expires, the old worker must not
+// commit completion because another worker is allowed to reclaim the message.
+func (c *FirestoreControllerImplements) CompleteLiveChatInboxMessage(
+	ctx context.Context,
+	liveChatID string,
+	messageID string,
+	workerID string,
+	now time.Time,
+) error {
+	if strings.TrimSpace(workerID) == "" {
+		return errors.New("worker id is empty")
+	}
+	if now.IsZero() {
+		return errors.New("now is zero")
+	}
+	ref, err := c.liveChatInboxMessageRef(liveChatID, messageID)
+	if err != nil {
+		return err
+	}
+
+	if err := c.firestoreClient.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
+		message, err := readLiveChatInboxMessageTx(tx, ref)
+		if err != nil {
+			return err
+		}
+		if err := validateLiveChatInboxLease(message, workerID, now); err != nil {
+			return err
+		}
+		processedAt := now
+		message.Status = LiveChatInboxProcessed
+		message.ProcessedAt = &processedAt
+		message.LeaseOwner = ""
+		message.LeaseUntil = nil
+		message.LastError = ""
+		if err := c.set(ctx, tx, ref, message); err != nil {
+			return fmt.Errorf("complete live chat inbox message: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("complete live chat inbox transaction: %w", err)
+	}
+	return nil
+}
+
+// FailLiveChatInboxMessage records a processing failure while the caller still
+// owns the lease. Attempts below maxAttempts return the message to Pending;
+// reaching maxAttempts moves it to DeadLettered so poison messages cannot block
+// later source messages forever.
+func (c *FirestoreControllerImplements) FailLiveChatInboxMessage(
+	ctx context.Context,
+	liveChatID string,
+	messageID string,
+	workerID string,
+	now time.Time,
+	maxAttempts int,
+	processingErr error,
+) (LiveChatInboxStatus, error) {
+	if strings.TrimSpace(workerID) == "" {
+		return "", errors.New("worker id is empty")
+	}
+	if now.IsZero() {
+		return "", errors.New("now is zero")
+	}
+	if maxAttempts <= 0 {
+		return "", fmt.Errorf("max attempts must be positive: %d", maxAttempts)
+	}
+	if processingErr == nil {
+		return "", errors.New("processing error is nil")
+	}
+	ref, err := c.liveChatInboxMessageRef(liveChatID, messageID)
+	if err != nil {
+		return "", err
+	}
+
+	var resultStatus LiveChatInboxStatus
+	if err := c.firestoreClient.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
+		message, err := readLiveChatInboxMessageTx(tx, ref)
+		if err != nil {
+			return err
+		}
+		if err := validateLiveChatInboxLease(message, workerID, now); err != nil {
+			return err
+		}
+
+		message.LastError = processingErr.Error()
+		message.LeaseOwner = ""
+		message.LeaseUntil = nil
+		if message.AttemptCount >= maxAttempts {
+			message.Status = LiveChatInboxDeadLettered
+		} else {
+			message.Status = LiveChatInboxPending
+		}
+		if err := c.set(ctx, tx, ref, message); err != nil {
+			return fmt.Errorf("record live chat inbox failure: %w", err)
+		}
+		resultStatus = message.Status
+		return nil
+	}); err != nil {
+		return "", fmt.Errorf("fail live chat inbox transaction: %w", err)
+	}
+	return resultStatus, nil
+}
+
+func (c *FirestoreControllerImplements) liveChatInboxMessageRef(
+	liveChatID string,
+	messageID string,
+) (*firestore.DocumentRef, error) {
+	key, err := LiveChatMessageKey(liveChatID, messageID)
+	if err != nil {
+		return nil, err
+	}
+	return c.liveChatInboxCollection().Doc(key), nil
+}
+
+func readLiveChatInboxMessageTx(
+	tx *firestore.Transaction,
+	ref *firestore.DocumentRef,
+) (LiveChatInboxDoc, error) {
+	doc, err := tx.Get(ref)
+	if status.Code(err) == codes.NotFound {
+		return LiveChatInboxDoc{}, fmt.Errorf("live chat inbox document not found: %w", err)
+	}
+	if err != nil {
+		return LiveChatInboxDoc{}, fmt.Errorf("get live chat inbox document: %w", err)
+	}
+	var message LiveChatInboxDoc
+	if err := doc.DataTo(&message); err != nil {
+		return LiveChatInboxDoc{}, fmt.Errorf("decode live chat inbox document: %w", err)
+	}
+	return message, nil
+}
+
+func validateLiveChatInboxLease(message LiveChatInboxDoc, workerID string, now time.Time) error {
+	if message.Status != LiveChatInboxProcessing {
+		return ErrLiveChatInboxLeaseLost
+	}
+	if message.LeaseOwner != workerID || message.LeaseUntil == nil || !message.LeaseUntil.After(now) {
+		return ErrLiveChatInboxLeaseLost
+	}
+	return nil
+}

--- a/system/core/repository/live_chat_inbox_processing_integration_test.go
+++ b/system/core/repository/live_chat_inbox_processing_integration_test.go
@@ -1,0 +1,269 @@
+//go:build integration
+
+package repository_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"app.modules/core/repository"
+	"app.modules/internal/integrationtest"
+)
+
+func TestFirestoreRepository_LiveChatInboxClaimCompleteLifecycle(t *testing.T) {
+	integrationtest.ResetFirestore(t)
+	controller := integrationtest.NewFirestoreController(t)
+	ctx := context.Background()
+	liveChatID := "live-chat-processing"
+	ingestedAt := time.Date(2026, 8, 14, 20, 0, 0, 0, time.UTC)
+	message := liveChatHistoryDoc(liveChatID, "message-1", "author-1", "!in", ingestedAt)
+	require.NoError(t, controller.IngestLiveChatPage(ctx, liveChatID, "", "cursor-1", []repository.LiveChatHistoryDoc{message}, ingestedAt))
+
+	claimAt := ingestedAt.Add(time.Minute)
+	claimed, err := controller.ClaimLiveChatInboxMessage(
+		ctx,
+		liveChatID,
+		message.ID,
+		"worker-a",
+		claimAt,
+		30*time.Second,
+		3,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, repository.LiveChatInboxProcessing, claimed.Status)
+	assert.Equal(t, 1, claimed.AttemptCount)
+	assert.Equal(t, "worker-a", claimed.LeaseOwner)
+	require.NotNil(t, claimed.LeaseUntil)
+	assert.Equal(t, claimAt.Add(30*time.Second), *claimed.LeaseUntil)
+
+	_, err = controller.ClaimLiveChatInboxMessage(
+		ctx,
+		liveChatID,
+		message.ID,
+		"worker-b",
+		claimAt.Add(10*time.Second),
+		30*time.Second,
+		3,
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, repository.ErrLiveChatInboxNotClaimable)
+
+	err = controller.CompleteLiveChatInboxMessage(
+		ctx,
+		liveChatID,
+		message.ID,
+		"worker-b",
+		claimAt.Add(15*time.Second),
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, repository.ErrLiveChatInboxLeaseLost)
+
+	completeAt := claimAt.Add(20 * time.Second)
+	require.NoError(t, controller.CompleteLiveChatInboxMessage(
+		ctx,
+		liveChatID,
+		message.ID,
+		"worker-a",
+		completeAt,
+	))
+
+	stored := readInboxMessage(t, controller, liveChatID, message.ID)
+	assert.Equal(t, repository.LiveChatInboxProcessed, stored.Status)
+	assert.Equal(t, 1, stored.AttemptCount)
+	assert.Empty(t, stored.LeaseOwner)
+	assert.Nil(t, stored.LeaseUntil)
+	require.NotNil(t, stored.ProcessedAt)
+	assert.Equal(t, completeAt, *stored.ProcessedAt)
+
+	_, err = controller.ClaimLiveChatInboxMessage(
+		ctx,
+		liveChatID,
+		message.ID,
+		"worker-c",
+		completeAt.Add(time.Second),
+		30*time.Second,
+		3,
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, repository.ErrLiveChatInboxNotClaimable)
+}
+
+func TestFirestoreRepository_LiveChatInboxExpiredLeaseCanBeReclaimed(t *testing.T) {
+	integrationtest.ResetFirestore(t)
+	controller := integrationtest.NewFirestoreController(t)
+	ctx := context.Background()
+	liveChatID := "live-chat-reclaim"
+	ingestedAt := time.Date(2026, 8, 14, 21, 0, 0, 0, time.UTC)
+	message := liveChatHistoryDoc(liveChatID, "message-1", "author-1", "!out", ingestedAt)
+	require.NoError(t, controller.IngestLiveChatPage(ctx, liveChatID, "", "cursor-1", []repository.LiveChatHistoryDoc{message}, ingestedAt))
+
+	firstClaimAt := ingestedAt.Add(time.Minute)
+	_, err := controller.ClaimLiveChatInboxMessage(ctx, liveChatID, message.ID, "worker-a", firstClaimAt, 10*time.Second, 3)
+	require.NoError(t, err)
+
+	candidates, err := controller.ListClaimableLiveChatInboxMessages(ctx, liveChatID, firstClaimAt.Add(5*time.Second), 10)
+	require.NoError(t, err)
+	assert.Empty(t, candidates)
+
+	reclaimAt := firstClaimAt.Add(10 * time.Second)
+	candidates, err = controller.ListClaimableLiveChatInboxMessages(ctx, liveChatID, reclaimAt, 10)
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+	assert.Equal(t, message.ID, candidates[0].MessageID)
+	assert.Equal(t, repository.LiveChatInboxProcessing, candidates[0].Status)
+
+	reclaimed, err := controller.ClaimLiveChatInboxMessage(ctx, liveChatID, message.ID, "worker-b", reclaimAt, 20*time.Second, 3)
+	require.NoError(t, err)
+	assert.Equal(t, 2, reclaimed.AttemptCount)
+	assert.Equal(t, "worker-b", reclaimed.LeaseOwner)
+
+	err = controller.CompleteLiveChatInboxMessage(ctx, liveChatID, message.ID, "worker-a", reclaimAt.Add(time.Second))
+	require.Error(t, err)
+	assert.ErrorIs(t, err, repository.ErrLiveChatInboxLeaseLost)
+}
+
+func TestFirestoreRepository_LiveChatInboxFailureRetriesThenDeadLetters(t *testing.T) {
+	integrationtest.ResetFirestore(t)
+	controller := integrationtest.NewFirestoreController(t)
+	ctx := context.Background()
+	liveChatID := "live-chat-retry"
+	ingestedAt := time.Date(2026, 8, 14, 22, 0, 0, 0, time.UTC)
+	message := liveChatHistoryDoc(liveChatID, "message-1", "author-1", "!change x", ingestedAt)
+	require.NoError(t, controller.IngestLiveChatPage(ctx, liveChatID, "", "cursor-1", []repository.LiveChatHistoryDoc{message}, ingestedAt))
+
+	firstClaimAt := ingestedAt.Add(time.Minute)
+	_, err := controller.ClaimLiveChatInboxMessage(ctx, liveChatID, message.ID, "worker-a", firstClaimAt, time.Minute, 2)
+	require.NoError(t, err)
+
+	failureOne := errors.New("temporary processing failure")
+	status, err := controller.FailLiveChatInboxMessage(
+		ctx,
+		liveChatID,
+		message.ID,
+		"worker-a",
+		firstClaimAt.Add(10*time.Second),
+		2,
+		failureOne,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, repository.LiveChatInboxPending, status)
+
+	stored := readInboxMessage(t, controller, liveChatID, message.ID)
+	assert.Equal(t, repository.LiveChatInboxPending, stored.Status)
+	assert.Equal(t, 1, stored.AttemptCount)
+	assert.Equal(t, failureOne.Error(), stored.LastError)
+	assert.Empty(t, stored.LeaseOwner)
+	assert.Nil(t, stored.LeaseUntil)
+
+	secondClaimAt := firstClaimAt.Add(20 * time.Second)
+	_, err = controller.ClaimLiveChatInboxMessage(ctx, liveChatID, message.ID, "worker-b", secondClaimAt, time.Minute, 2)
+	require.NoError(t, err)
+
+	failureTwo := errors.New("permanent processing failure")
+	status, err = controller.FailLiveChatInboxMessage(
+		ctx,
+		liveChatID,
+		message.ID,
+		"worker-b",
+		secondClaimAt.Add(10*time.Second),
+		2,
+		failureTwo,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, repository.LiveChatInboxDeadLettered, status)
+
+	stored = readInboxMessage(t, controller, liveChatID, message.ID)
+	assert.Equal(t, repository.LiveChatInboxDeadLettered, stored.Status)
+	assert.Equal(t, 2, stored.AttemptCount)
+	assert.Equal(t, failureTwo.Error(), stored.LastError)
+	assert.Empty(t, stored.LeaseOwner)
+	assert.Nil(t, stored.LeaseUntil)
+
+	candidates, err := controller.ListClaimableLiveChatInboxMessages(ctx, liveChatID, secondClaimAt.Add(time.Minute), 10)
+	require.NoError(t, err)
+	assert.Empty(t, candidates)
+}
+
+func TestFirestoreRepository_LiveChatInboxExpiredFinalAttemptDeadLettersOnClaim(t *testing.T) {
+	integrationtest.ResetFirestore(t)
+	controller := integrationtest.NewFirestoreController(t)
+	ctx := context.Background()
+	liveChatID := "live-chat-expired-final"
+	ingestedAt := time.Date(2026, 8, 14, 23, 0, 0, 0, time.UTC)
+	message := liveChatHistoryDoc(liveChatID, "message-1", "author-1", "!more", ingestedAt)
+	require.NoError(t, controller.IngestLiveChatPage(ctx, liveChatID, "", "cursor-1", []repository.LiveChatHistoryDoc{message}, ingestedAt))
+
+	claimAt := ingestedAt.Add(time.Minute)
+	_, err := controller.ClaimLiveChatInboxMessage(ctx, liveChatID, message.ID, "worker-a", claimAt, 10*time.Second, 1)
+	require.NoError(t, err)
+
+	claimed, err := controller.ClaimLiveChatInboxMessage(
+		ctx,
+		liveChatID,
+		message.ID,
+		"worker-b",
+		claimAt.Add(10*time.Second),
+		10*time.Second,
+		1,
+	)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, repository.ErrLiveChatInboxRetryExhausted)
+	assert.Equal(t, repository.LiveChatInboxDeadLettered, claimed.Status)
+	assert.Equal(t, 1, claimed.AttemptCount)
+
+	stored := readInboxMessage(t, controller, liveChatID, message.ID)
+	assert.Equal(t, repository.LiveChatInboxDeadLettered, stored.Status)
+	assert.Empty(t, stored.LeaseOwner)
+	assert.Nil(t, stored.LeaseUntil)
+	assert.NotEmpty(t, stored.LastError)
+}
+
+func TestFirestoreRepository_ListClaimableLiveChatInboxMessagesPreservesSequence(t *testing.T) {
+	integrationtest.ResetFirestore(t)
+	controller := integrationtest.NewFirestoreController(t)
+	ctx := context.Background()
+	liveChatID := "live-chat-order"
+	ingestedAt := time.Date(2026, 8, 15, 0, 0, 0, 0, time.UTC)
+	messages := []repository.LiveChatHistoryDoc{
+		liveChatHistoryDoc(liveChatID, "message-1", "author-1", "one", ingestedAt),
+		liveChatHistoryDoc(liveChatID, "message-2", "author-2", "two", ingestedAt.Add(time.Second)),
+		liveChatHistoryDoc(liveChatID, "message-3", "author-3", "three", ingestedAt.Add(2*time.Second)),
+	}
+	require.NoError(t, controller.IngestLiveChatPage(ctx, liveChatID, "", "cursor-1", messages, ingestedAt))
+
+	// Make the first message an expired Processing candidate while messages 2-3
+	// remain Pending. The merged advisory list should still be sequence ordered.
+	claimAt := ingestedAt.Add(time.Minute)
+	_, err := controller.ClaimLiveChatInboxMessage(ctx, liveChatID, messages[0].ID, "worker-a", claimAt, 5*time.Second, 3)
+	require.NoError(t, err)
+
+	candidates, err := controller.ListClaimableLiveChatInboxMessages(ctx, liveChatID, claimAt.Add(5*time.Second), 10)
+	require.NoError(t, err)
+	require.Len(t, candidates, 3)
+	assert.Equal(t, []string{"message-1", "message-2", "message-3"}, []string{
+		candidates[0].MessageID,
+		candidates[1].MessageID,
+		candidates[2].MessageID,
+	})
+}
+
+func readInboxMessage(
+	t *testing.T,
+	controller *repository.FirestoreControllerImplements,
+	liveChatID string,
+	messageID string,
+) repository.LiveChatInboxDoc {
+	t.Helper()
+	key, err := repository.LiveChatMessageKey(liveChatID, messageID)
+	require.NoError(t, err)
+	snapshot, err := controller.FirestoreClient().Collection(repository.LiveChatInbox).Doc(key).Get(context.Background())
+	require.NoError(t, err)
+	var message repository.LiveChatInboxDoc
+	require.NoError(t, snapshot.DataTo(&message))
+	return message
+}


### PR DESCRIPTION
## 概要

P1「YouTubeチャット処理を冪等化・耐障害化」の次段階として、durable Inbox を安全にworker処理するための lease / retry / dead-letter repository基盤を追加します。

#1000 で Inbox + deterministic History + StreamState の atomic ingest までは入っていますが、checkpointをruntimeへ切り替える前に「commit後にbotが落ちてもPendingが確実に再処理される」基盤が必要です。このPRではまだ `ProcessMessage` を接続せず、worker concurrencyの土台を先に固めます。

## 変更内容

- Inbox status追加
  - `processing`
  - `processed`
  - `dead-lettered`
- `ListClaimableLiveChatInboxMessages`
  - Pending
  - lease期限切れProcessing
  - 2系統を取得してdurable `sequence` 順にmerge
  - listはadvisoryで、最終claim権限はtransaction側に残す
- `ClaimLiveChatInboxMessage`
  - deterministic message key単位のtransactional claim
  - active lease中は別workerを拒否
  - lease失効後は別workerがreclaim可能
  - claimごとに `AttemptCount` を増加
  - retry上限消費済みのexpired messageはclaimせずatomicにdead-letter
- `CompleteLiveChatInboxMessage`
  - lease owner一致かつlease有効中のみProcessedへ遷移
  - expired/他worker leaseではcommit拒否
- `FailLiveChatInboxMessage`
  - maxAttempts未満ならPendingへ戻す
  - maxAttempts到達ならDeadLettered
  - `LastError` を保存
- sentinel errors
  - not claimable
  - lease lost
  - retry exhausted
  - corrupt processing state
- Firestore composite indexes
  - Pendingを `live-chat-id/status/sequence` で取得
  - expired Processingを `live-chat-id/status/lease-until/sequence` で取得

## Emulator tests

- Pending → Processing → Processed
- active lease中の二重claim拒否
- wrong worker completion拒否
- lease expiration後のreclaim
- old workerがreclaim後にcompleteできないこと
- failure → Pending retry → DeadLetter
- final attemptのworker crash後、lease expiration時にDeadLetter
- Pending + expired Processing のsequence順merge
- **2 workerの同時claimで成功するworkerが1つだけ**であること

## 重要な境界

- このPRでは `youtube-bot` runtime flowをまだ切り替えない
- `ProcessMessage` はまだInbox workerから呼ばない
- reply outbox / domain effect atomicity は後続PR
- concrete repository実装として追加し、巨大 `Repository` interface / gomockはまだ拡張しない
- 新しい処理indexは追加するが、本番ではInboxをruntime利用するまでquery負荷は発生しない

## Acceptance criteria

- System Go Test成功
- Go Lint成功
- Firestore Emulator integration test成功
- concurrent claimテスト成功
- CI Gate成功
- 現行youtube-bot挙動に変更なし
