### PR TITLE
Add atomic live chat message transaction finalization

### DIFF
--- a/system/core/repository/live_chat_message_transaction.go
+++ b/system/core/repository/live_chat_message_transaction.go
@@ -1,0 +1,121 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/firestore"
+)
+
+var ErrLiveChatInboxAlreadyProcessed = errors.New("live chat inbox message is already processed")
+
+// LiveChatMessageTransactionGuard proves that the source Inbox document was
+// read and its active processing lease was validated in the current Firestore
+// transaction before domain writes begin.
+type LiveChatMessageTransactionGuard struct {
+	Inbox    LiveChatInboxDoc
+	WorkerID string
+}
+
+// BeginLiveChatMessageTransaction must be called near the beginning of the
+// caller's Firestore transaction, before domain writes. Firestore tracks this
+// Inbox read as part of the transaction read set, so a concurrent lease reclaim
+// or status change forces the whole domain transaction to retry/abort.
+func (c *FirestoreControllerImplements) BeginLiveChatMessageTransaction(
+	tx *firestore.Transaction,
+	liveChatID string,
+	messageID string,
+	workerID string,
+	now time.Time,
+) (LiveChatMessageTransactionGuard, error) {
+	if tx == nil {
+		return LiveChatMessageTransactionGuard{}, errors.New("live chat message transaction requires a Firestore transaction")
+	}
+	if now.IsZero() {
+		return LiveChatMessageTransactionGuard{}, errors.New("now is zero")
+	}
+	ref, err := c.liveChatInboxMessageRef(liveChatID, messageID)
+	if err != nil {
+		return LiveChatMessageTransactionGuard{}, err
+	}
+	inbox, err := readLiveChatInboxMessageTx(tx, ref)
+	if err != nil {
+		return LiveChatMessageTransactionGuard{}, err
+	}
+	if inbox.LiveChatID != liveChatID || inbox.MessageID != messageID {
+		return LiveChatMessageTransactionGuard{}, fmt.Errorf(
+			"%w: deterministic key points to different source message",
+			ErrLiveChatInboxCorruptState,
+		)
+	}
+	if inbox.Status == LiveChatInboxProcessed {
+		return LiveChatMessageTransactionGuard{}, ErrLiveChatInboxAlreadyProcessed
+	}
+	if err := validateLiveChatInboxLease(inbox, workerID, now); err != nil {
+		return LiveChatMessageTransactionGuard{}, err
+	}
+	return LiveChatMessageTransactionGuard{Inbox: inbox, WorkerID: workerID}, nil
+}
+
+// FinalizeLiveChatMessageTransaction stages reply intents and marks the source
+// Inbox Processed without performing another Firestore read. The caller may
+// stage domain writes before this function; all domain writes, reply intents,
+// and Inbox completion then commit or roll back together.
+func (c *FirestoreControllerImplements) FinalizeLiveChatMessageTransaction(
+	ctx context.Context,
+	tx *firestore.Transaction,
+	guard LiveChatMessageTransactionGuard,
+	replyIntents []LiveChatReplyOutboxDoc,
+	now time.Time,
+) error {
+	if tx == nil {
+		return errors.New("live chat message transaction requires a Firestore transaction")
+	}
+	if now.IsZero() {
+		return errors.New("now is zero")
+	}
+	if err := validateLiveChatInboxLease(guard.Inbox, guard.WorkerID, now); err != nil {
+		return err
+	}
+
+	seenSlots := make(map[string]struct{}, len(replyIntents))
+	for i, intent := range replyIntents {
+		if intent.LiveChatID != guard.Inbox.LiveChatID ||
+			intent.SourceMessageID != guard.Inbox.MessageID ||
+			intent.SourceAuthorChannelID != guard.Inbox.AuthorChannelID ||
+			intent.SourceSequence != guard.Inbox.Sequence {
+			return fmt.Errorf("reply intent at index %d does not match source Inbox message", i)
+		}
+		if _, exists := seenSlots[intent.IntentSlot]; exists {
+			return fmt.Errorf("duplicate reply intent slot %q", intent.IntentSlot)
+		}
+		seenSlots[intent.IntentSlot] = struct{}{}
+		if err := validateNewLiveChatReplyIntent(intent); err != nil {
+			return fmt.Errorf("validate reply intent at index %d: %w", i, err)
+		}
+	}
+
+	for _, intent := range replyIntents {
+		if err := c.CreateLiveChatReplyIntent(ctx, tx, intent); err != nil {
+			return err
+		}
+	}
+
+	processed := guard.Inbox
+	processedAt := now
+	processed.Status = LiveChatInboxProcessed
+	processed.ProcessedAt = &processedAt
+	processed.LeaseOwner = ""
+	processed.LeaseUntil = nil
+	processed.LastError = ""
+	ref, err := c.liveChatInboxMessageRef(processed.LiveChatID, processed.MessageID)
+	if err != nil {
+		return err
+	}
+	if err := c.set(ctx, tx, ref, processed); err != nil {
+		return fmt.Errorf("finalize live chat Inbox message: %w", err)
+	}
+	return nil
+}

--- a/system/core/repository/live_chat_message_transaction_integration_test.go
+++ b/system/core/repository/live_chat_message_transaction_integration_test.go
@@ -1,0 +1,204 @@
+//go:build integration
+
+package repository_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/firestore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"app.modules/core/repository"
+	"app.modules/internal/integrationtest"
+)
+
+func TestFirestoreRepository_LiveChatMessageTransactionCommitsDomainReplyAndInboxTogether(t *testing.T) {
+	integrationtest.ResetFirestore(t)
+	controller := integrationtest.NewFirestoreController(t)
+	ctx := context.Background()
+	liveChatID := "live-chat-reply"
+	ingestedAt := time.Date(2026, 8, 15, 7, 0, 0, 0, time.UTC)
+	source := liveChatHistoryDoc(liveChatID, "message-atomic", "author-1", "!in", ingestedAt)
+	require.NoError(t, controller.IngestLiveChatPage(ctx, liveChatID, "", "cursor-1", []repository.LiveChatHistoryDoc{source}, ingestedAt))
+
+	claimAt := ingestedAt.Add(time.Minute)
+	claimed, err := controller.ClaimLiveChatInboxMessage(ctx, liveChatID, source.ID, "worker-a", claimAt, time.Minute, 3)
+	require.NoError(t, err)
+	markerRef := controller.FirestoreClient().Collection("test-domain-effects").Doc("atomic-effect")
+	_, err = markerRef.Set(ctx, map[string]any{"count": int64(0)})
+	require.NoError(t, err)
+
+	finalizeAt := claimAt.Add(10 * time.Second)
+	intent := repository.LiveChatReplyOutboxDoc{
+		LiveChatID:            liveChatID,
+		SourceMessageID:       source.ID,
+		SourceAuthorChannelID: source.AuthorChannelID,
+		IntentSlot:            "primary",
+		SourceSequence:        claimed.Sequence,
+		Message:               "welcome",
+		Status:                repository.LiveChatReplyOutboxPending,
+		CreatedAt:             finalizeAt,
+		AvailableAt:           finalizeAt,
+	}
+
+	require.NoError(t, controller.FirestoreClient().RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
+		guard, err := controller.BeginLiveChatMessageTransaction(tx, liveChatID, source.ID, "worker-a", finalizeAt)
+		if err != nil {
+			return err
+		}
+		marker, err := tx.Get(markerRef)
+		if err != nil {
+			return err
+		}
+		count, err := marker.DataAt("count")
+		if err != nil {
+			return err
+		}
+		if err := tx.Set(markerRef, map[string]any{"count": count.(int64) + 1}); err != nil {
+			return err
+		}
+		return controller.FinalizeLiveChatMessageTransaction(ctx, tx, guard, []repository.LiveChatReplyOutboxDoc{intent}, finalizeAt)
+	}))
+
+	marker, err := markerRef.Get(ctx)
+	require.NoError(t, err)
+	count, err := marker.DataAt("count")
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, count)
+
+	inbox := readInboxMessage(t, controller, liveChatID, source.ID)
+	assert.Equal(t, repository.LiveChatInboxProcessed, inbox.Status)
+	require.NotNil(t, inbox.ProcessedAt)
+	assert.Equal(t, finalizeAt, *inbox.ProcessedAt)
+	assert.Empty(t, inbox.LeaseOwner)
+	assert.Nil(t, inbox.LeaseUntil)
+
+	outbox := readReplyIntent(t, controller, intent)
+	assert.Equal(t, repository.LiveChatReplyOutboxPending, outbox.Status)
+	assert.Equal(t, "welcome", outbox.Message)
+
+	// Unknown commit outcome retry: the Inbox itself is the effect ledger. A
+	// second execution cannot enter the domain mutation path after Processed.
+	err = controller.FirestoreClient().RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
+		_, err := controller.BeginLiveChatMessageTransaction(tx, liveChatID, source.ID, "worker-a", finalizeAt.Add(time.Second))
+		return err
+	})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, repository.ErrLiveChatInboxAlreadyProcessed)
+	marker, err = markerRef.Get(ctx)
+	require.NoError(t, err)
+	count, err = marker.DataAt("count")
+	require.NoError(t, err)
+	assert.EqualValues(t, 1, count)
+}
+
+func TestFirestoreRepository_LiveChatMessageTransactionRollsBackAllThreeParts(t *testing.T) {
+	integrationtest.ResetFirestore(t)
+	controller := integrationtest.NewFirestoreController(t)
+	ctx := context.Background()
+	liveChatID := "live-chat-reply"
+	ingestedAt := time.Date(2026, 8, 15, 8, 0, 0, 0, time.UTC)
+	source := liveChatHistoryDoc(liveChatID, "message-rollback-finalize", "author-2", "!out", ingestedAt)
+	require.NoError(t, controller.IngestLiveChatPage(ctx, liveChatID, "", "cursor-1", []repository.LiveChatHistoryDoc{source}, ingestedAt))
+
+	claimAt := ingestedAt.Add(time.Minute)
+	claimed, err := controller.ClaimLiveChatInboxMessage(ctx, liveChatID, source.ID, "worker-a", claimAt, time.Minute, 3)
+	require.NoError(t, err)
+	markerRef := controller.FirestoreClient().Collection("test-domain-effects").Doc("rollback-effect")
+	_, err = markerRef.Set(ctx, map[string]any{"count": int64(0)})
+	require.NoError(t, err)
+	finalizeAt := claimAt.Add(10 * time.Second)
+	intent := repository.LiveChatReplyOutboxDoc{
+		LiveChatID:            liveChatID,
+		SourceMessageID:       source.ID,
+		SourceAuthorChannelID: source.AuthorChannelID,
+		IntentSlot:            "primary",
+		SourceSequence:        claimed.Sequence,
+		Message:               "bye",
+		Status:                repository.LiveChatReplyOutboxPending,
+		CreatedAt:             finalizeAt,
+		AvailableAt:           finalizeAt,
+	}
+
+	expectedErr := errors.New("abort after finalization was staged")
+	err = controller.FirestoreClient().RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
+		guard, err := controller.BeginLiveChatMessageTransaction(tx, liveChatID, source.ID, "worker-a", finalizeAt)
+		if err != nil {
+			return err
+		}
+		marker, err := tx.Get(markerRef)
+		if err != nil {
+			return err
+		}
+		count, err := marker.DataAt("count")
+		if err != nil {
+			return err
+		}
+		if err := tx.Set(markerRef, map[string]any{"count": count.(int64) + 1}); err != nil {
+			return err
+		}
+		if err := controller.FinalizeLiveChatMessageTransaction(ctx, tx, guard, []repository.LiveChatReplyOutboxDoc{intent}, finalizeAt); err != nil {
+			return err
+		}
+		return expectedErr
+	})
+	require.ErrorIs(t, err, expectedErr)
+
+	marker, err := markerRef.Get(ctx)
+	require.NoError(t, err)
+	count, err := marker.DataAt("count")
+	require.NoError(t, err)
+	assert.EqualValues(t, 0, count)
+
+	inbox := readInboxMessage(t, controller, liveChatID, source.ID)
+	assert.Equal(t, repository.LiveChatInboxProcessing, inbox.Status)
+	assert.Equal(t, "worker-a", inbox.LeaseOwner)
+	assert.Nil(t, inbox.ProcessedAt)
+
+	key, keyErr := repository.LiveChatReplyOutboxKey(liveChatID, source.ID, intent.IntentSlot)
+	require.NoError(t, keyErr)
+	_, err = controller.FirestoreClient().Collection(repository.LiveChatReplyOutbox).Doc(key).Get(ctx)
+	require.Error(t, err)
+}
+
+func TestFirestoreRepository_LiveChatMessageTransactionRejectsMismatchedReplyIntent(t *testing.T) {
+	integrationtest.ResetFirestore(t)
+	controller := integrationtest.NewFirestoreController(t)
+	ctx := context.Background()
+	liveChatID := "live-chat-reply"
+	ingestedAt := time.Date(2026, 8, 15, 9, 0, 0, 0, time.UTC)
+	source := liveChatHistoryDoc(liveChatID, "message-mismatch", "author-3", "!info", ingestedAt)
+	require.NoError(t, controller.IngestLiveChatPage(ctx, liveChatID, "", "cursor-1", []repository.LiveChatHistoryDoc{source}, ingestedAt))
+	claimAt := ingestedAt.Add(time.Minute)
+	claimed, err := controller.ClaimLiveChatInboxMessage(ctx, liveChatID, source.ID, "worker-a", claimAt, time.Minute, 3)
+	require.NoError(t, err)
+
+	badIntent := repository.LiveChatReplyOutboxDoc{
+		LiveChatID:            liveChatID,
+		SourceMessageID:       "different-message",
+		SourceAuthorChannelID: source.AuthorChannelID,
+		IntentSlot:            "primary",
+		SourceSequence:        claimed.Sequence,
+		Message:               "bad",
+		Status:                repository.LiveChatReplyOutboxPending,
+		CreatedAt:             claimAt,
+		AvailableAt:           claimAt,
+	}
+
+	err = controller.FirestoreClient().RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
+		guard, err := controller.BeginLiveChatMessageTransaction(tx, liveChatID, source.ID, "worker-a", claimAt)
+		if err != nil {
+			return err
+		}
+		return controller.FinalizeLiveChatMessageTransaction(ctx, tx, guard, []repository.LiveChatReplyOutboxDoc{badIntent}, claimAt)
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not match source Inbox message")
+
+	inbox := readInboxMessage(t, controller, liveChatID, source.ID)
+	assert.Equal(t, repository.LiveChatInboxProcessing, inbox.Status)
+}


### PR DESCRIPTION
## 概要

P1の `domain effect + reply outbox intent + Inbox Processed` を1つのFirestore transactionで確定するためのrepository原子操作を追加します。

Inbox自体を source message の effect ledger として使うため、別のprocessed-message台帳collectionは増やしません。

## 追加API

### `BeginLiveChatMessageTransaction`

transactionの先頭付近、domain writeより前に呼びます。

- deterministic Inbox documentをtransaction内でread
- source liveChat/message identityを検証
- `Processing` status、worker lease owner、有効期限を検証
- Inbox readをFirestore transaction read setへ入れる
- 既に `Processed` なら `ErrLiveChatInboxAlreadyProcessed`

これにより処理中に別workerがlease reclaim/status変更した場合、domain transaction全体が競合してretry/abortされます。

### `FinalizeLiveChatMessageTransaction`

追加readを行わず、transactionのwrite phaseで呼びます。

- reply intentがsource Inboxの liveChat/message/author/sequence と一致することを検証
- intent slot重複を拒否
- reply intentsをdeterministic outboxへ `Create`
- Inboxを `Processed` に変更
- ProcessedAt設定、leaseクリア、LastErrorクリア

callerがその前にstagingしたdomain writesと合わせて、**domain + reply intents + Inbox Processed が同一commit boundary**になります。

## Emulator tests

- claim済みInboxをbegin
- domain markerを更新
- reply intentを作成
- InboxをProcessed
- 上記3点が同一transactionでcommitされること
- commit後に同じsource messageを再実行すると `ErrLiveChatInboxAlreadyProcessed` となりdomain markerが二重加算されないこと
- finalize後にtransactionを意図的にabortすると
  - domain marker rollback
  - reply intent未作成
  - InboxはProcessingのまま
  となること
- source messageと一致しないreply intentを拒否し、InboxをProcessedにしないこと

## Firestore read/write order

Firestore transactionはread後writeの順序制約があるため、beginとfinalizeを分けています。

```text
Begin (Inbox read/lease validation)
→ domain reads
→ domain writes
→ Finalize (reply Create + Inbox Processed write, no additional read)
→ commit
```

後続のcommand refactorではこの順序を守ります。

## 重要な境界

- runtime切替なし
- 既存 `ProcessMessage` / command methodsはまだ変更しない
- external YouTube/Discord side effectはこのtransactionに含めない
- YouTube replyはoutbox配送へ移行する予定
- moderation等の外部effectは別途分類してから移行する

## Acceptance criteria

- System Go Test成功
- Go Lint成功
- Firestore Emulator integration test成功
- atomic commit / rollback / already-processed tests成功
- CI Gate成功
- 現行youtube-bot挙動に変更なし
