### PR TITLE
Extract reusable ProcessMessage preparation phase

### DIFF
--- a/system/core/workspaceapp/message_preparation.go
+++ b/system/core/workspaceapp/message_preparation.go
@@ -67,6 +67,7 @@ func (app *WorkspaceApp) prepareMessage(
 			if err := app.CreateUser(ctx, tx); err != nil {
 				return fmt.Errorf("in CreateUser(): %w", err)
 			}
+		}
 		return nil
 	})
 	if txErr != nil {

--- a/system/core/workspaceapp/message_preparation.go
+++ b/system/core/workspaceapp/message_preparation.go
@@ -1,0 +1,92 @@
+package workspaceapp
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/firestore"
+
+	i18nmsg "app.modules/core/i18n/typed"
+	"app.modules/core/utils"
+)
+
+type preparedMessage struct {
+	CommandDetails *utils.CommandDetails
+	ImmediateReply string
+	SkipExecution  bool
+}
+
+// prepareMessage performs the behavior that must happen before command
+// execution, but deliberately does not post the normal YouTube reply itself.
+// Legacy ProcessMessage sends ImmediateReply immediately; the durable Inbox
+// worker can later persist the same reply as an outbox intent instead.
+//
+// Moderation side effects and first-use user initialization intentionally remain
+// unchanged in this first extraction. They will be separated in later phases.
+func (app *WorkspaceApp) prepareMessage(
+	ctx context.Context,
+	ngWordConfig NGWordConfig,
+	commandString string,
+	userID string,
+	userDisplayName string,
+	userProfileImageURL string,
+	isChatModerator bool,
+	isChatOwner bool,
+	isChatMember bool,
+) (preparedMessage, error) {
+	if userID == app.Configs.LiveChatBotChannelID {
+		return preparedMessage{SkipExecution: true}, nil
+	}
+	if !app.Configs.Constants.YoutubeMembershipEnabled {
+		isChatMember = false
+	}
+	app.SetProcessedUser(userID, userDisplayName, userProfileImageURL, isChatModerator, isChatOwner, isChatMember)
+
+	// Preserve existing moderation behavior while moving normal chat replies out
+	// of the preparation phase.
+	if !isChatModerator && !isChatOwner {
+		blocked, err := app.CheckIfUnwantedWordIncluded(ctx, ngWordConfig, userID, commandString, userDisplayName)
+		if err != nil {
+			app.MessageToOwnerWithError(ctx, "in CheckIfUnwantedWordIncluded", err)
+			// Existing behavior continues processing when the moderation check itself
+			// fails, because owner notification is the fallback.
+		}
+		if blocked {
+			return preparedMessage{SkipExecution: true}, nil
+		}
+	}
+
+	// Preserve the existing first-use initialization transaction. This will be
+	// folded into the durable message transaction in a later migration step.
+	txErr := app.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
+		isRegistered, err := app.IfUserRegistered(ctx, tx)
+		if err != nil {
+			return fmt.Errorf("in IfUserRegistered(): %w", err)
+		}
+		if !isRegistered {
+			if err := app.CreateUser(ctx, tx); err != nil {
+				return fmt.Errorf("in CreateUser(): %w", err)
+			}
+		return nil
+	})
+	if txErr != nil {
+		return preparedMessage{}, fmt.Errorf("in RunTransaction(): %w", txErr)
+	}
+
+	commandDetails, message := utils.ParseCommand(commandString, isChatMember)
+	if message != "" {
+		return preparedMessage{
+			ImmediateReply: i18nmsg.CommonSir(app.ProcessedUserDisplayName) + message,
+			SkipExecution:  true,
+		}, nil
+	}
+
+	if message = app.ValidateCommand(*commandDetails); message != "" {
+		return preparedMessage{
+			ImmediateReply: i18nmsg.CommonSir(app.ProcessedUserDisplayName) + message,
+			SkipExecution:  true,
+		}, nil
+	}
+
+	return preparedMessage{CommandDetails: commandDetails}, nil
+}

--- a/system/core/workspaceapp/message_preparation_test.go
+++ b/system/core/workspaceapp/message_preparation_test.go
@@ -1,0 +1,212 @@
+package workspaceapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"cloud.google.com/go/firestore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"app.modules/core/i18n"
+	i18nmsg "app.modules/core/i18n/typed"
+	"app.modules/core/moderatorbot"
+	"app.modules/core/repository"
+	mock_repository "app.modules/core/repository/mocks"
+	"app.modules/core/utils"
+	mock_youtubebot "app.modules/core/youtubebot/mocks"
+)
+
+func TestPrepareMessage_SelfBotSkipsWithoutRepository(t *testing.T) {
+	t.Parallel()
+
+	app := WorkspaceApp{
+		Configs: &Configs{LiveChatBotChannelID: "bot-channel"},
+	}
+
+	prepared, err := app.prepareMessage(
+		context.Background(),
+		NGWordConfig{},
+		"!info",
+		"bot-channel",
+		"Bot",
+		"",
+		false,
+		false,
+		false,
+	)
+	require.NoError(t, err)
+	assert.True(t, prepared.SkipExecution)
+	assert.Empty(t, prepared.ImmediateReply)
+	assert.Nil(t, prepared.CommandDetails)
+}
+
+func TestPrepareMessage_ReturnsCommandWithoutPostingReply(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	app := newPreparationTestApp(t, ctrl, true)
+	mockLiveChatBot := mock_youtubebot.NewMockLiveChatBot(ctrl)
+	app.LiveChatBot = mockLiveChatBot
+
+	prepared, err := app.prepareMessage(
+		context.Background(),
+		NGWordConfig{},
+		"!info",
+		"user-1",
+		"User One",
+		"https://example.com/profile.png",
+		true,
+		false,
+		true,
+	)
+	require.NoError(t, err)
+	assert.False(t, prepared.SkipExecution)
+	assert.Empty(t, prepared.ImmediateReply)
+	require.NotNil(t, prepared.CommandDetails)
+	assert.Equal(t, utils.Info, prepared.CommandDetails.CommandType)
+	assert.Equal(t, "user-1", app.ProcessedUserID)
+	assert.Equal(t, "User One", app.ProcessedUserDisplayName)
+	assert.True(t, app.ProcessedUserIsModeratorOrOwner)
+	assert.True(t, app.ProcessedUserIsMember)
+}
+
+func TestPrepareMessage_DisabledMembershipNormalizesActor(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	app := newPreparationTestApp(t, ctrl, false)
+	app.LiveChatBot = mock_youtubebot.NewMockLiveChatBot(ctrl)
+
+	prepared, err := app.prepareMessage(
+		context.Background(),
+		NGWordConfig{},
+		"!info",
+		"user-1",
+		"User One",
+		"",
+		true,
+		false,
+		true,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, prepared.CommandDetails)
+	assert.Equal(t, utils.Info, prepared.CommandDetails.CommandType)
+	assert.False(t, app.ProcessedUserIsMember)
+}
+
+func TestPrepareMessage_ReturnsValidationReplyWithoutPosting(t *testing.T) {
+	loadWorkspaceAppTestI18n(t)
+	ctrl := gomock.NewController(t)
+	app := newPreparationTestApp(t, ctrl, true)
+	app.LiveChatBot = mock_youtubebot.NewMockLiveChatBot(ctrl)
+
+	prepared, err := app.prepareMessage(
+		context.Background(),
+		NGWordConfig{},
+		"!more 0",
+		"user-1",
+		"User One",
+		"",
+		true,
+		false,
+		false,
+	)
+	require.NoError(t, err)
+	assert.True(t, prepared.SkipExecution)
+	assert.Nil(t, prepared.CommandDetails)
+	assert.Equal(
+		t,
+		i18nmsg.CommonSir("User One")+i18nmsg.ValidateNonOneOrMoreExtendedTime(),
+		prepared.ImmediateReply,
+	)
+}
+
+func TestProcessMessage_PreservesImmediateReplyDelivery(t *testing.T) {
+	loadWorkspaceAppTestI18n(t)
+	ctrl := gomock.NewController(t)
+	app := newPreparationTestApp(t, ctrl, true)
+	mockLiveChatBot := mock_youtubebot.NewMockLiveChatBot(ctrl)
+	expected := i18nmsg.CommonSir("User One") + i18nmsg.ValidateNonOneOrMoreExtendedTime()
+	mockLiveChatBot.EXPECT().PostMessage(gomock.Any(), expected).Return(nil).Times(1)
+	app.LiveChatBot = mockLiveChatBot
+
+	err := app.ProcessMessage(
+		context.Background(),
+		NGWordConfig{},
+		"!more 0",
+		"user-1",
+		"User One",
+		"",
+		true,
+		false,
+		false,
+	)
+	require.NoError(t, err)
+}
+
+func TestProcessMessage_PreservesUserInitializationFailureReply(t *testing.T) {
+	loadWorkspaceAppTestI18n(t)
+	ctrl := gomock.NewController(t)
+	mockDB := mock_repository.NewMockRepository(ctrl)
+	mockFirestoreClient := mock_repository.NewMockDBClient(ctrl)
+	failure := errors.New("database unavailable")
+	mockDB.EXPECT().FirestoreClient().Return(mockFirestoreClient).Times(1)
+	mockFirestoreClient.EXPECT().RunTransaction(gomock.Any(), gomock.Any()).Return(failure).Times(1)
+
+	mockLiveChatBot := mock_youtubebot.NewMockLiveChatBot(ctrl)
+	mockLiveChatBot.EXPECT().PostMessage(gomock.Any(), i18nmsg.CommandError("User One")).Return(nil).Times(1)
+	app := WorkspaceApp{
+		Configs: &Configs{
+			Constants: repository.ConstantsConfigDoc{YoutubeMembershipEnabled: true},
+		},
+		Repository:         mockDB,
+		LiveChatBot:        mockLiveChatBot,
+		alertOwnerBot:      moderatorbot.DummyMessageBot{},
+		alertModeratorsBot: moderatorbot.DummyMessageBot{},
+		logModeratorsBot:   moderatorbot.DummyMessageBot{},
+	}
+
+	err := app.ProcessMessage(
+		context.Background(),
+		NGWordConfig{},
+		"!info",
+		"user-1",
+		"User One",
+		"",
+		true,
+		false,
+		false,
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, failure.Error())
+}
+
+func newPreparationTestApp(t *testing.T, ctrl *gomock.Controller, membershipEnabled bool) *WorkspaceApp {
+	t.Helper()
+	mockDB := mock_repository.NewMockRepository(ctrl)
+	mockFirestoreClient := mock_repository.NewMockDBClient(ctrl)
+	mockDB.EXPECT().FirestoreClient().Return(mockFirestoreClient).AnyTimes()
+	mockFirestoreClient.EXPECT().RunTransaction(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, f func(context.Context, *firestore.Transaction) error, _ ...firestore.TransactionOption) error {
+			return f(ctx, &firestore.Transaction{})
+		},
+	).AnyTimes()
+	mockDB.EXPECT().ReadUser(gomock.Any(), gomock.Any(), gomock.Any()).Return(repository.UserDoc{}, nil).AnyTimes()
+
+	return &WorkspaceApp{
+		Configs: &Configs{
+			Constants: repository.ConstantsConfigDoc{YoutubeMembershipEnabled: membershipEnabled},
+		},
+		Repository:         mockDB,
+		alertOwnerBot:      moderatorbot.DummyMessageBot{},
+		alertModeratorsBot: moderatorbot.DummyMessageBot{},
+		logModeratorsBot:   moderatorbot.DummyMessageBot{},
+	}
+}
+
+func loadWorkspaceAppTestI18n(t *testing.T) {
+	t.Helper()
+	if err := i18n.LoadLocaleFolderFS(); err != nil {
+		t.Fatal(fmt.Errorf("load locale folder: %w", err))
+	}
+}

--- a/system/core/workspaceapp/message_processing.go
+++ b/system/core/workspaceapp/message_processing.go
@@ -1,0 +1,90 @@
+package workspaceapp
+
+import (
+	"context"
+	"errors"
+
+	i18nmsg "app.modules/core/i18n/typed"
+	"app.modules/core/utils"
+)
+
+// ProcessMessage 入力コマンドを解析して実行
+func (app *WorkspaceApp) ProcessMessage(
+	ctx context.Context,
+	ngWordConfig NGWordConfig,
+	commandString string,
+	userID string,
+	userDisplayName string,
+	userProfileImageURL string,
+	isChatModerator bool,
+	isChatOwner bool,
+	isChatMember bool,
+) error {
+	prepared, err := app.prepareMessage(
+		ctx,
+		ngWordConfig,
+		commandString,
+		userID,
+		userDisplayName,
+		userProfileImageURL,
+		isChatModerator,
+		isChatOwner,
+		isChatMember,
+	)
+	if err != nil {
+		app.MessageToLiveChat(ctx, i18nmsg.CommandError(app.ProcessedUserDisplayName))
+		return err
+	}
+	if prepared.ImmediateReply != "" {
+		app.MessageToLiveChat(ctx, prepared.ImmediateReply)
+	}
+	if prepared.SkipExecution {
+		return nil
+	}
+	return app.executeCommand(ctx, prepared.CommandDetails, commandString)
+}
+
+// executeCommand 解析済みのコマンドを実行する
+func (app *WorkspaceApp) executeCommand(ctx context.Context, commandDetails *utils.CommandDetails, commandString string) error {
+	// commandDetailsに基づいて命令処理
+	switch commandDetails.CommandType {
+	case utils.NotCommand:
+		return nil
+	case utils.InvalidCommand:
+		return nil
+	case utils.In:
+		return app.In(ctx, &commandDetails.InOption)
+	case utils.Out:
+		return app.Out(ctx)
+	case utils.Info:
+		return app.ShowUserInfo(ctx, &commandDetails.InfoOption)
+	case utils.My:
+		return app.My(ctx, commandDetails.MyOptions)
+	case utils.Change:
+		return app.Change(ctx, &commandDetails.ChangeOption)
+	case utils.Seat:
+		return app.ShowSeatInfo(ctx, &commandDetails.SeatOption)
+	case utils.Report:
+		return app.Report(ctx, &commandDetails.ReportOption)
+	case utils.Kick:
+		return app.Kick(ctx, &commandDetails.KickOption)
+	case utils.Check:
+		return app.Check(ctx, &commandDetails.CheckOption)
+	case utils.Block:
+		return app.Block(ctx, &commandDetails.BlockOption)
+	case utils.More:
+		return app.More(ctx, &commandDetails.MoreOption)
+	case utils.Break:
+		return app.Break(ctx, &commandDetails.BreakOption)
+	case utils.Resume:
+		return app.Resume(ctx, &commandDetails.ResumeOption)
+	case utils.Rank:
+		return app.Rank(ctx, commandDetails)
+	case utils.Order:
+		return app.Order(ctx, &commandDetails.OrderOption)
+	case utils.Clear:
+		return app.Clear(ctx)
+	default:
+		return errors.New("Unknown command: " + commandString)
+	}
+}

--- a/system/core/workspaceapp/workspace_app.go
+++ b/system/core/workspaceapp/workspace_app.go
@@ -12,7 +12,6 @@ import (
 	"google.golang.org/api/option"
 
 	"app.modules/core/i18n"
-	i18nmsg "app.modules/core/i18n/typed"
 	"app.modules/core/moderatorbot"
 	"app.modules/core/repository"
 	"app.modules/core/timeutil"
@@ -212,7 +211,7 @@ func (app *WorkspaceApp) CheckIfUnwantedWordIncluded(ctx context.Context, ngWord
 		if err := app.BanUser(ctx, userID); err != nil {
 			return false, fmt.Errorf("in BanUser(): %w", err)
 		}
-		return true, app.LogToModerators(ctx, "発言から禁止ワードを検出、ユーザーをブロックしました。"+
+		return true, app.LogToModerators(ctx, "発言から禁止ワードを検出、ユーザーをブロックしました."+
 			"\n禁止ワード: `"+ngWordConfig.blockRegexesForChatMessage[index]+"`"+
 			"\nチャンネル名: `"+channelName+"`"+
 			"\nチャンネルURL: https://youtube.com/channel/"+userID+
@@ -227,7 +226,7 @@ func (app *WorkspaceApp) CheckIfUnwantedWordIncluded(ctx context.Context, ngWord
 		if err := app.BanUser(ctx, userID); err != nil {
 			return false, fmt.Errorf("in BanUser(): %w", err)
 		}
-		return true, app.LogToModerators(ctx, "チャンネル名から禁止ワードを検出、ユーザーをブロックしました。"+
+		return true, app.LogToModerators(ctx, "チャンネル名から禁止ワードを検出、ユーザーをブロックしました."+
 			"\n禁止ワード: `"+ngWordConfig.blockRegexesForChannelName[index]+"`"+
 			"\nチャンネル名: `"+channelName+"`"+
 			"\nチャンネルURL: https://youtube.com/channel/"+userID+
@@ -261,115 +260,4 @@ func (app *WorkspaceApp) CheckIfUnwantedWordIncluded(ctx context.Context, ngWord
 			"\n日時: "+app.currentTime().String())
 	}
 	return false, nil
-}
-
-// ProcessMessage 入力コマンドを解析して実行
-func (app *WorkspaceApp) ProcessMessage(
-	ctx context.Context,
-	ngWordConfig NGWordConfig,
-	commandString string,
-	userID string,
-	userDisplayName string,
-	userProfileImageURL string,
-	isChatModerator bool,
-	isChatOwner bool,
-	isChatMember bool,
-) error {
-	if userID == app.Configs.LiveChatBotChannelID {
-		return nil
-	}
-	if !app.Configs.Constants.YoutubeMembershipEnabled {
-		isChatMember = false
-	}
-	app.SetProcessedUser(userID, userDisplayName, userProfileImageURL, isChatModerator, isChatOwner, isChatMember)
-
-	// check if an unwanted word included
-	if !isChatModerator && !isChatOwner {
-		blocked, err := app.CheckIfUnwantedWordIncluded(ctx, ngWordConfig, userID, commandString, userDisplayName)
-		if err != nil {
-			app.MessageToOwnerWithError(ctx, "in CheckIfUnwantedWordIncluded", err)
-			// continue
-		}
-		if blocked {
-			return nil
-		}
-	}
-
-	// 初回の利用の場合はユーザーデータを初期化
-	txErr := app.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
-		isRegistered, err := app.IfUserRegistered(ctx, tx)
-		if err != nil {
-			return fmt.Errorf("in IfUserRegistered(): %w", err)
-		}
-		if !isRegistered {
-			if err := app.CreateUser(ctx, tx); err != nil {
-				return fmt.Errorf("in CreateUser(): %w", err)
-			}
-		}
-		return nil
-	})
-	if txErr != nil {
-		app.MessageToLiveChat(ctx, i18nmsg.CommandError(app.ProcessedUserDisplayName))
-		return fmt.Errorf("in RunTransaction(): %w", txErr)
-	}
-
-	// コマンドの解析
-	commandDetails, message := utils.ParseCommand(commandString, isChatMember)
-	if message != "" { // これはシステム内部のエラーではなく、入力コマンドが不正ということなので、return nil
-		app.MessageToLiveChat(ctx, i18nmsg.CommonSir(app.ProcessedUserDisplayName)+message)
-		return nil
-	}
-
-	if message = app.ValidateCommand(*commandDetails); message != "" {
-		app.MessageToLiveChat(ctx, i18nmsg.CommonSir(app.ProcessedUserDisplayName)+message)
-		return nil
-	}
-
-	// コマンドの実行
-	return app.executeCommand(ctx, commandDetails, commandString)
-}
-
-// executeCommand 解析済みのコマンドを実行する
-func (app *WorkspaceApp) executeCommand(ctx context.Context, commandDetails *utils.CommandDetails, commandString string) error {
-	// commandDetailsに基づいて命令処理
-	switch commandDetails.CommandType {
-	case utils.NotCommand:
-		return nil
-	case utils.InvalidCommand:
-		return nil
-	case utils.In:
-		return app.In(ctx, &commandDetails.InOption)
-	case utils.Out:
-		return app.Out(ctx)
-	case utils.Info:
-		return app.ShowUserInfo(ctx, &commandDetails.InfoOption)
-	case utils.My:
-		return app.My(ctx, commandDetails.MyOptions)
-	case utils.Change:
-		return app.Change(ctx, &commandDetails.ChangeOption)
-	case utils.Seat:
-		return app.ShowSeatInfo(ctx, &commandDetails.SeatOption)
-	case utils.Report:
-		return app.Report(ctx, &commandDetails.ReportOption)
-	case utils.Kick:
-		return app.Kick(ctx, &commandDetails.KickOption)
-	case utils.Check:
-		return app.Check(ctx, &commandDetails.CheckOption)
-	case utils.Block:
-		return app.Block(ctx, &commandDetails.BlockOption)
-	case utils.More:
-		return app.More(ctx, &commandDetails.MoreOption)
-	case utils.Break:
-		return app.Break(ctx, &commandDetails.BreakOption)
-	case utils.Resume:
-		return app.Resume(ctx, &commandDetails.ResumeOption)
-	case utils.Rank:
-		return app.Rank(ctx, commandDetails)
-	case utils.Order:
-		return app.Order(ctx, &commandDetails.OrderOption)
-	case utils.Clear:
-		return app.Clear(ctx)
-	default:
-		return errors.New("Unknown command: " + commandString)
-	}
 }

--- a/system/core/workspaceapp/workspace_app.go
+++ b/system/core/workspaceapp/workspace_app.go
@@ -211,7 +211,7 @@ func (app *WorkspaceApp) CheckIfUnwantedWordIncluded(ctx context.Context, ngWord
 		if err := app.BanUser(ctx, userID); err != nil {
 			return false, fmt.Errorf("in BanUser(): %w", err)
 		}
-		return true, app.LogToModerators(ctx, "発言から禁止ワードを検出、ユーザーをブロックしました."+
+		return true, app.LogToModerators(ctx, "発言から禁止ワードを検出、ユーザーをブロックしました。"+
 			"\n禁止ワード: `"+ngWordConfig.blockRegexesForChatMessage[index]+"`"+
 			"\nチャンネル名: `"+channelName+"`"+
 			"\nチャンネルURL: https://youtube.com/channel/"+userID+
@@ -226,7 +226,7 @@ func (app *WorkspaceApp) CheckIfUnwantedWordIncluded(ctx context.Context, ngWord
 		if err := app.BanUser(ctx, userID); err != nil {
 			return false, fmt.Errorf("in BanUser(): %w", err)
 		}
-		return true, app.LogToModerators(ctx, "チャンネル名から禁止ワードを検出、ユーザーをブロックしました."+
+		return true, app.LogToModerators(ctx, "チャンネル名から禁止ワードを検出、ユーザーをブロックしました。"+
 			"\n禁止ワード: `"+ngWordConfig.blockRegexesForChannelName[index]+"`"+
 			"\nチャンネル名: `"+channelName+"`"+
 			"\nチャンネルURL: https://youtube.com/channel/"+userID+


### PR DESCRIPTION
## 概要

P1 durable Inbox workerへ既存command処理を段階的に接続するため、`ProcessMessage` を「準備」と「実行」に分離します。

このPRは**本番挙動を変えないリファクタリング**です。legacy `ProcessMessage` は引き続きYouTubeへ即時返信しますが、parse/validationで生じる通常返信を `prepareMessage` が値として返せるようにし、後続のdurable workerでは同じ返信をOutbox intentへ変換できる境界を作ります。

## 変更内容

### `prepareMessage`

以下を既存順序のまま担当します。

- bot自身のchannel messageはskip
- membership disabled時のmember flag正規化
- `SetProcessedUser`
- NG word / moderation check
  - 既存の外部moderation side effectはこのPRでは変更しない
  - moderation check自体のerrorはowner通知して処理継続という既存挙動を維持
  - blockedならskip
- 初回利用者のuser初期化transaction
- `ParseCommand`
- `ValidateCommand`

ただし通常のYouTube返信は送らず、以下として返します。

```go
type preparedMessage struct {
    CommandDetails *utils.CommandDetails
    ImmediateReply string
    SkipExecution  bool
}
```

### legacy `ProcessMessage`

- `prepareMessage` を呼ぶ
- preparation error時は従来どおり `CommandError` を即時返信してerrorを返す
- `ImmediateReply` があれば従来どおり即時YouTube返信
- skipなら終了
- それ以外は従来の `executeCommand`

### ファイル整理

- `workspace_app.go` から `ProcessMessage` / `executeCommand` をそのまま `message_processing.go` へ移動
- `workspace_app.go` の既存ロジック・文言は変更しない

## テスト

- bot自身のmessageはrepositoryを触らずskip
- valid `!info` がcommand detailsを返し、preparation内ではYouTube返信しない
- membership disabled時にactor member flagをfalseへ正規化
- validation error (`!more 0`) は `ImmediateReply` として返し、preparation内では投稿しない
- legacy `ProcessMessage` は同じvalidation replyを1回投稿する
- user initialization transaction failure時は従来どおり `CommandError` を投稿しerrorを返す

## 重要な境界

このPRではまだ以下を変えません。

- NG word moderationのYouTube Ban / Discord通知
- 初回user初期化transaction
- 各commandのdomain transaction
- command内の `MessageToLiveChat`
- youtube-bot runtime loop

後続PRで、prepared messageをdurable Inbox workerから使い、command transactionを `BeginLiveChatMessageTransaction` / `FinalizeLiveChatMessageTransaction` へ接続していきます。

## Acceptance criteria

- System Go Test成功
- Go Lint成功
- Generated Files Up-to-Date成功
- CI Gate成功
- 既存command tests成功
- 本番runtime挙動変更なし
