### PR TITLE
Extract transactional first-use user initialization

### DIFF
--- a/system/core/workspaceapp/message_preparation.go
+++ b/system/core/workspaceapp/message_preparation.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"cloud.google.com/go/firestore"
-
 	i18nmsg "app.modules/core/i18n/typed"
 	"app.modules/core/utils"
 )
@@ -21,8 +19,9 @@ type preparedMessage struct {
 // Legacy ProcessMessage sends ImmediateReply immediately; the durable Inbox
 // worker can later persist the same reply as an outbox intent instead.
 //
-// Moderation side effects and first-use user initialization intentionally remain
-// unchanged in this first extraction. They will be separated in later phases.
+// Moderation side effects intentionally remain unchanged in this extraction.
+// First-use user initialization is now reusable inside a caller-owned tx, but
+// legacy preparation still wraps it in its own transaction to preserve behavior.
 func (app *WorkspaceApp) prepareMessage(
 	ctx context.Context,
 	ngWordConfig NGWordConfig,
@@ -56,20 +55,7 @@ func (app *WorkspaceApp) prepareMessage(
 		}
 	}
 
-	// Preserve the existing first-use initialization transaction. This will be
-	// folded into the durable message transaction in a later migration step.
-	txErr := app.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
-		isRegistered, err := app.IfUserRegistered(ctx, tx)
-		if err != nil {
-			return fmt.Errorf("in IfUserRegistered(): %w", err)
-		}
-		if !isRegistered {
-			if err := app.CreateUser(ctx, tx); err != nil {
-				return fmt.Errorf("in CreateUser(): %w", err)
-			}
-		}
-		return nil
-	})
+	txErr := app.RunTransaction(ctx, app.ensureProcessedUserRegisteredTx)
 	if txErr != nil {
 		return preparedMessage{}, fmt.Errorf("in RunTransaction(): %w", txErr)
 	}

--- a/system/core/workspaceapp/user_initialization.go
+++ b/system/core/workspaceapp/user_initialization.go
@@ -1,0 +1,29 @@
+package workspaceapp
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/firestore"
+)
+
+// ensureProcessedUserRegisteredTx makes first-use user initialization reusable
+// inside a caller-owned Firestore transaction. Legacy message preparation wraps
+// it in its own transaction; the durable Inbox worker can compose the same
+// operation after BeginLiveChatMessageTransaction and before finalization.
+func (app *WorkspaceApp) ensureProcessedUserRegisteredTx(
+	ctx context.Context,
+	tx *firestore.Transaction,
+) error {
+	isRegistered, err := app.IfUserRegistered(ctx, tx)
+	if err != nil {
+		return fmt.Errorf("in IfUserRegistered(): %w", err)
+	}
+	if isRegistered {
+		return nil
+	}
+	if err := app.CreateUser(ctx, tx); err != nil {
+		return fmt.Errorf("in CreateUser(): %w", err)
+	}
+	return nil
+}

--- a/system/core/workspaceapp/user_initialization_test.go
+++ b/system/core/workspaceapp/user_initialization_test.go
@@ -1,0 +1,93 @@
+package workspaceapp
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/firestore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"app.modules/core/repository"
+	mock_repository "app.modules/core/repository/mocks"
+	"app.modules/core/timeutil"
+)
+
+func TestEnsureProcessedUserRegisteredTx_AlreadyRegistered(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockDB := mock_repository.NewMockRepository(ctrl)
+	tx := &firestore.Transaction{}
+	mockDB.EXPECT().ReadUser(gomock.Any(), tx, "user-1").Return(repository.UserDoc{}, nil).Times(1)
+	app := WorkspaceApp{Repository: mockDB, ProcessedUserID: "user-1"}
+
+	require.NoError(t, app.ensureProcessedUserRegisteredTx(context.Background(), tx))
+}
+
+func TestEnsureProcessedUserRegisteredTx_CreatesMissingUser(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockDB := mock_repository.NewMockRepository(ctrl)
+	tx := &firestore.Transaction{}
+	fixedNow := time.Date(2026, 8, 15, 10, 0, 0, 0, timeutil.JapanLocation())
+	mockDB.EXPECT().ReadUser(gomock.Any(), tx, "user-1").Return(
+		repository.UserDoc{},
+		status.Error(codes.NotFound, "missing"),
+	).Times(1)
+	mockDB.EXPECT().CreateUser(gomock.Any(), tx, "user-1", gomock.Any()).DoAndReturn(
+		func(_ context.Context, _ *firestore.Transaction, _ string, user repository.UserDoc) error {
+			assert.Equal(t, fixedNow, user.RegistrationDate)
+			assert.Zero(t, user.DailyTotalStudySec)
+			assert.Zero(t, user.TotalStudySec)
+			return nil
+		},
+	).Times(1)
+	app := WorkspaceApp{
+		Repository:      mockDB,
+		ProcessedUserID: "user-1",
+		nowFunc:         func() time.Time { return fixedNow },
+	}
+
+	require.NoError(t, app.ensureProcessedUserRegisteredTx(context.Background(), tx))
+}
+
+func TestEnsureProcessedUserRegisteredTx_PropagatesReadFailure(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockDB := mock_repository.NewMockRepository(ctrl)
+	tx := &firestore.Transaction{}
+	readErr := errors.New("read failed")
+	mockDB.EXPECT().ReadUser(gomock.Any(), tx, "user-1").Return(repository.UserDoc{}, readErr).Times(1)
+	app := WorkspaceApp{Repository: mockDB, ProcessedUserID: "user-1"}
+
+	err := app.ensureProcessedUserRegisteredTx(context.Background(), tx)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, readErr.Error())
+}
+
+func TestEnsureProcessedUserRegisteredTx_PropagatesCreateFailure(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockDB := mock_repository.NewMockRepository(ctrl)
+	tx := &firestore.Transaction{}
+	createErr := errors.New("create failed")
+	mockDB.EXPECT().ReadUser(gomock.Any(), tx, "user-1").Return(
+		repository.UserDoc{},
+		status.Error(codes.NotFound, "missing"),
+	).Times(1)
+	mockDB.EXPECT().CreateUser(gomock.Any(), tx, "user-1", gomock.Any()).Return(createErr).Times(1)
+	app := WorkspaceApp{Repository: mockDB, ProcessedUserID: "user-1"}
+
+	err := app.ensureProcessedUserRegisteredTx(context.Background(), tx)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, createErr.Error())
+}


### PR DESCRIPTION
## 概要

P1 durable Inbox processingへ既存commandを段階的に接続するため、`ProcessMessage` の前処理に残っていた「初回利用者のUser作成」を、caller-owned Firestore transactionで再利用できるhelperへ抽出します。

このPRも本番挙動を変えません。legacy `prepareMessage` は従来どおり自前のtransactionを開始し、その中で新helperを呼びます。

## 変更内容

### `ensureProcessedUserRegisteredTx`

- `IfUserRegistered(ctx, tx)` で既存Userを確認
- 未登録なら `CreateUser(ctx, tx)`
- read/create errorをcontext付きで返す
- 自身ではtransactionを開始しない

これにより後続のdurable workerでは、以下の同一transaction内に初回User作成も含められます。

```text
BeginLiveChatMessageTransaction
→ ensureProcessedUserRegisteredTx
→ command domain reads/writes
→ reply intent
→ FinalizeLiveChatMessageTransaction
→ commit
```

### legacy preparation

従来のinline user initializationを

```go
app.RunTransaction(ctx, app.ensureProcessedUserRegisteredTx)
```

へ置換するだけで、transaction境界・実行順・エラー返信は変更しません。

## テスト

- 登録済みUserではCreateしない
- NotFoundなら同じtxでUser作成
- RegistrationDateが注入時刻になる
- ReadUser失敗を伝播
- CreateUser失敗を伝播
- 既存 `message_preparation_test.go` によりlegacy preparationの成功/失敗挙動も継続検証

## 重要な境界

- runtime cutoverなし
- moderation side effect変更なし
- command transaction変更なし
- `ProcessedUser*` mutable stateはまだ残す
- Repository interface変更なし

## Acceptance criteria

- System Go Test成功
- Go Lint成功
- Firestore Emulator Test成功
- Generated Files Up-to-Date成功
- CI Gate成功
- 既存ProcessMessage挙動変更なし
