### PR TITLE
Extract side-effect-free message parsing and validation

### DIFF
--- a/system/core/workspaceapp/message_parsing.go
+++ b/system/core/workspaceapp/message_parsing.go
@@ -1,0 +1,32 @@
+package workspaceapp
+
+import (
+	i18nmsg "app.modules/core/i18n/typed"
+	"app.modules/core/utils"
+)
+
+// parseAndValidateMessage converts chat text into executable command details or
+// an immediate user-facing validation reply. It performs no repository access,
+// Firestore transaction, YouTube post, or moderation side effect, so durable
+// Inbox processing can safely call it inside its own transaction boundary.
+func (app *WorkspaceApp) parseAndValidateMessage(
+	commandString string,
+	isChatMember bool,
+) preparedMessage {
+	commandDetails, message := utils.ParseCommand(commandString, isChatMember)
+	if message != "" {
+		return preparedMessage{
+			ImmediateReply: i18nmsg.CommonSir(app.ProcessedUserDisplayName) + message,
+			SkipExecution:  true,
+		}
+	}
+
+	if message = app.ValidateCommand(*commandDetails); message != "" {
+		return preparedMessage{
+			ImmediateReply: i18nmsg.CommonSir(app.ProcessedUserDisplayName) + message,
+			SkipExecution:  true,
+		}
+	}
+
+	return preparedMessage{CommandDetails: commandDetails}
+}

--- a/system/core/workspaceapp/message_parsing_test.go
+++ b/system/core/workspaceapp/message_parsing_test.go
@@ -1,0 +1,50 @@
+package workspaceapp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	i18nmsg "app.modules/core/i18n/typed"
+	"app.modules/core/utils"
+)
+
+func TestParseAndValidateMessage_ValidCommand(t *testing.T) {
+	loadWorkspaceAppTestI18n(t)
+	app := WorkspaceApp{ProcessedUserDisplayName: "User One"}
+
+	prepared := app.parseAndValidateMessage("!info", false)
+
+	assert.False(t, prepared.SkipExecution)
+	assert.Empty(t, prepared.ImmediateReply)
+	require.NotNil(t, prepared.CommandDetails)
+	assert.Equal(t, utils.Info, prepared.CommandDetails.CommandType)
+}
+
+func TestParseAndValidateMessage_ValidationReply(t *testing.T) {
+	loadWorkspaceAppTestI18n(t)
+	app := WorkspaceApp{ProcessedUserDisplayName: "User One"}
+
+	prepared := app.parseAndValidateMessage("!more 0", false)
+
+	assert.True(t, prepared.SkipExecution)
+	assert.Nil(t, prepared.CommandDetails)
+	assert.Equal(
+		t,
+		i18nmsg.CommonSir("User One")+i18nmsg.ValidateNonOneOrMoreExtendedTime(),
+		prepared.ImmediateReply,
+	)
+}
+
+func TestParseAndValidateMessage_NonCommandNeedsNoReply(t *testing.T) {
+	loadWorkspaceAppTestI18n(t)
+	app := WorkspaceApp{ProcessedUserDisplayName: "User One"}
+
+	prepared := app.parseAndValidateMessage("hello study room", false)
+
+	assert.False(t, prepared.SkipExecution)
+	assert.Empty(t, prepared.ImmediateReply)
+	require.NotNil(t, prepared.CommandDetails)
+	assert.Equal(t, utils.NotCommand, prepared.CommandDetails.CommandType)
+}

--- a/system/core/workspaceapp/message_preparation.go
+++ b/system/core/workspaceapp/message_preparation.go
@@ -3,16 +3,17 @@ package workspaceapp
 import (
 	"context"
 	"fmt"
-
-	i18nmsg "app.modules/core/i18n/typed"
-	"app.modules/core/utils"
 )
 
 type preparedMessage struct {
-	CommandDetails *utils.CommandDetails
+	CommandDetails anyCommandDetails
 	ImmediateReply string
 	SkipExecution  bool
 }
+
+// anyCommandDetails keeps the preparation result typed without coupling this
+// file to the command parser import; the concrete alias lives in parsing.go.
+type anyCommandDetails = commandDetailsPtr
 
 // prepareMessage performs the behavior that must happen before command
 // execution, but deliberately does not post the normal YouTube reply itself.
@@ -20,8 +21,8 @@ type preparedMessage struct {
 // worker can later persist the same reply as an outbox intent instead.
 //
 // Moderation side effects intentionally remain unchanged in this extraction.
-// First-use user initialization is now reusable inside a caller-owned tx, but
-// legacy preparation still wraps it in its own transaction to preserve behavior.
+// First-use user initialization is reusable inside a caller-owned tx, and
+// parse/validation is now a separate side-effect-free phase.
 func (app *WorkspaceApp) prepareMessage(
 	ctx context.Context,
 	ngWordConfig NGWordConfig,
@@ -60,20 +61,5 @@ func (app *WorkspaceApp) prepareMessage(
 		return preparedMessage{}, fmt.Errorf("in RunTransaction(): %w", txErr)
 	}
 
-	commandDetails, message := utils.ParseCommand(commandString, isChatMember)
-	if message != "" {
-		return preparedMessage{
-			ImmediateReply: i18nmsg.CommonSir(app.ProcessedUserDisplayName) + message,
-			SkipExecution:  true,
-		}, nil
-	}
-
-	if message = app.ValidateCommand(*commandDetails); message != "" {
-		return preparedMessage{
-			ImmediateReply: i18nmsg.CommonSir(app.ProcessedUserDisplayName) + message,
-			SkipExecution:  true,
-		}, nil
-	}
-
-	return preparedMessage{CommandDetails: commandDetails}, nil
+	return app.parseAndValidateMessage(commandString, isChatMember), nil
 }

--- a/system/core/workspaceapp/message_preparation.go
+++ b/system/core/workspaceapp/message_preparation.go
@@ -3,17 +3,15 @@ package workspaceapp
 import (
 	"context"
 	"fmt"
+
+	"app.modules/core/utils"
 )
 
 type preparedMessage struct {
-	CommandDetails anyCommandDetails
+	CommandDetails *utils.CommandDetails
 	ImmediateReply string
 	SkipExecution  bool
 }
-
-// anyCommandDetails keeps the preparation result typed without coupling this
-// file to the command parser import; the concrete alias lives in parsing.go.
-type anyCommandDetails = commandDetailsPtr
 
 // prepareMessage performs the behavior that must happen before command
 // execution, but deliberately does not post the normal YouTube reply itself.


### PR DESCRIPTION
## 概要

P1 durable Inbox workerで既存 `ProcessMessage` のparse/validation結果を再利用できるよう、コマンド解析とvalidationを副作用なしのフェーズへ抽出します。

このPRも本番挙動を変えません。legacy `prepareMessage` はmoderationとUser初期化後に新helperを呼ぶだけです。

## `parseAndValidateMessage`

入力:
- command string
- membership判定済み `isChatMember`

出力:
- executable `CommandDetails`
- または `ImmediateReply + SkipExecution`

この関数は以下を行いません。
- Repositoryアクセス
- Firestore transaction開始
- YouTube投稿
- Discord通知
- moderation side effect

そのため、後続durable workerではcaller-owned transaction内で安全に利用できます。

## legacy flow

```text
actor setup / moderation
→ own tx: ensureProcessedUserRegisteredTx
→ parseAndValidateMessage
→ legacy ProcessMessageがImmediateReplyを直接送信
→ executeCommand
```

後続では同じparserを

```text
BeginLiveChatMessageTransaction
→ ensureProcessedUserRegisteredTx
→ parseAndValidateMessage
→ reply intent
→ command domain work
→ Finalize
```

へ組み込めます。

## テスト

- valid `!info` → executable command details
- invalid `!more 0` →既存validation文面をImmediateReplyとして返す
- non-command text → `NotCommand`、replyなし
- 既存 preparation / command tests でlegacy挙動も継続保証

## 重要な境界

- runtime cutoverなし
- moderation変更なし
- command transaction変更なし
- `ProcessedUser*` mutable stateはまだ残す

## Acceptance criteria

- System Go Test成功
- Go Lint成功
- Firestore Emulator Test成功
- Generated Files Up-to-Date成功
- CI Gate成功
- 既存ProcessMessage挙動変更なし
