### PR TITLE
Extract reusable !info transaction body

### DIFF
--- a/system/core/workspaceapp/command_user.go
+++ b/system/core/workspaceapp/command_user.go
@@ -7,7 +7,6 @@ import (
 
 	i18nmsg "app.modules/core/i18n/typed"
 	"app.modules/core/repository"
-	"app.modules/core/timeutil"
 	"app.modules/core/utils"
 
 	"cloud.google.com/go/firestore"
@@ -16,51 +15,9 @@ import (
 func (app *WorkspaceApp) ShowUserInfo(ctx context.Context, infoOption *utils.InfoOption) error {
 	var replyMessage string
 	txErr := app.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
-		totalStudyDuration, dailyTotalStudyDuration, err := app.GetUserRealtimeTotalStudyDurations(ctx, tx, app.ProcessedUserID)
-		if err != nil {
-			return fmt.Errorf("in app.GetUserRealtimeTotalStudyDurations(): %w", err)
-		}
-		dailyTotalTimeStr := timeutil.DurationToString(dailyTotalStudyDuration)
-		totalTimeStr := timeutil.DurationToString(totalStudyDuration)
-		replyMessage += i18nmsg.CommandUserInfoBase(app.ProcessedUserDisplayName, dailyTotalTimeStr, totalTimeStr)
-
-		userDoc, err := app.Repository.ReadUser(ctx, tx, app.ProcessedUserID)
-		if err != nil {
-			return fmt.Errorf("in app.Repository.ReadUser: %w", err)
-		}
-
-		if userDoc.RankVisible {
-			replyMessage += i18nmsg.CommandUserInfoRank(userDoc.RankPoint)
-		}
-
-		if infoOption.ShowDetails {
-			switch userDoc.RankVisible {
-			case true:
-				replyMessage += i18nmsg.CommandUserInfoRankOn()
-			case false:
-				replyMessage += i18nmsg.CommandUserInfoRankOff()
-			}
-
-			if userDoc.IsContinuousActive {
-				continuousActiveDays := int(app.currentTime().Sub(userDoc.CurrentActivityStateStarted).Hours() / 24)
-				replyMessage += i18nmsg.CommandUserInfoRankOnContinuous(continuousActiveDays+1, continuousActiveDays)
-			}
-
-			if userDoc.DefaultStudyMin == 0 {
-				replyMessage += i18nmsg.CommandUserInfoDefaultWorkOff()
-			} else {
-				replyMessage += i18nmsg.CommandUserInfoDefaultWork(userDoc.DefaultStudyMin)
-			}
-
-			if userDoc.FavoriteColor == "" {
-				replyMessage += i18nmsg.CommandUserInfoFavoriteColorOff()
-			} else {
-				replyMessage += i18nmsg.CommandUserInfoFavoriteColor(utils.ColorCodeToColorName(userDoc.FavoriteColor))
-			}
-
-			replyMessage += i18nmsg.CommandUserInfoRegisterDate(userDoc.RegistrationDate.In(timeutil.JapanLocation()).Format("2006年01月02日"))
-		}
-		return nil
+		var err error
+		replyMessage, err = app.buildUserInfoReplyTx(ctx, tx, infoOption)
+		return err
 	})
 	if txErr != nil {
 		slog.Error("txErr in ShowUserInfo()", "txErr", txErr)

--- a/system/core/workspaceapp/command_user_info_tx.go
+++ b/system/core/workspaceapp/command_user_info_tx.go
@@ -1,0 +1,68 @@
+package workspaceapp
+
+import (
+	"context"
+	"fmt"
+
+	"cloud.google.com/go/firestore"
+
+	i18nmsg "app.modules/core/i18n/typed"
+	"app.modules/core/timeutil"
+	"app.modules/core/utils"
+)
+
+// buildUserInfoReplyTx performs the !info reads inside a caller-owned
+// Firestore transaction and returns the reply instead of posting it. Legacy
+// ShowUserInfo wraps this helper in its own transaction; the durable Inbox
+// worker can compose it between Begin/Finalize in the same message transaction.
+func (app *WorkspaceApp) buildUserInfoReplyTx(
+	ctx context.Context,
+	tx *firestore.Transaction,
+	infoOption *utils.InfoOption,
+) (string, error) {
+	totalStudyDuration, dailyTotalStudyDuration, err := app.GetUserRealtimeTotalStudyDurations(ctx, tx, app.ProcessedUserID)
+	if err != nil {
+		return "", fmt.Errorf("in app.GetUserRealtimeTotalStudyDurations(): %w", err)
+	}
+	dailyTotalTimeStr := timeutil.DurationToString(dailyTotalStudyDuration)
+	totalTimeStr := timeutil.DurationToString(totalStudyDuration)
+	replyMessage := i18nmsg.CommandUserInfoBase(app.ProcessedUserDisplayName, dailyTotalTimeStr, totalTimeStr)
+
+	userDoc, err := app.Repository.ReadUser(ctx, tx, app.ProcessedUserID)
+	if err != nil {
+		return "", fmt.Errorf("in app.Repository.ReadUser: %w", err)
+	}
+
+	if userDoc.RankVisible {
+		replyMessage += i18nmsg.CommandUserInfoRank(userDoc.RankPoint)
+	}
+
+	if infoOption.ShowDetails {
+		switch userDoc.RankVisible {
+		case true:
+			replyMessage += i18nmsg.CommandUserInfoRankOn()
+		case false:
+			replyMessage += i18nmsg.CommandUserInfoRankOff()
+		}
+
+		if userDoc.IsContinuousActive {
+			continuousActiveDays := int(app.currentTime().Sub(userDoc.CurrentActivityStateStarted).Hours() / 24)
+			replyMessage += i18nmsg.CommandUserInfoRankOnContinuous(continuousActiveDays+1, continuousActiveDays)
+		}
+
+		if userDoc.DefaultStudyMin == 0 {
+			replyMessage += i18nmsg.CommandUserInfoDefaultWorkOff()
+		} else {
+			replyMessage += i18nmsg.CommandUserInfoDefaultWork(userDoc.DefaultStudyMin)
+		}
+
+		if userDoc.FavoriteColor == "" {
+			replyMessage += i18nmsg.CommandUserInfoFavoriteColorOff()
+		} else {
+			replyMessage += i18nmsg.CommandUserInfoFavoriteColor(utils.ColorCodeToColorName(userDoc.FavoriteColor))
+		}
+
+		replyMessage += i18nmsg.CommandUserInfoRegisterDate(userDoc.RegistrationDate.In(timeutil.JapanLocation()).Format("2006年01月02日"))
+	}
+	return replyMessage, nil
+}

--- a/system/core/workspaceapp/command_user_info_tx_test.go
+++ b/system/core/workspaceapp/command_user_info_tx_test.go
@@ -1,0 +1,77 @@
+package workspaceapp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/firestore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	i18nmsg "app.modules/core/i18n/typed"
+	"app.modules/core/repository"
+	mock_repository "app.modules/core/repository/mocks"
+	"app.modules/core/timeutil"
+	"app.modules/core/utils"
+)
+
+func TestBuildUserInfoReplyTx_BuildsReplyWithoutExternalPost(t *testing.T) {
+	loadWorkspaceAppTestI18n(t)
+	ctrl := gomock.NewController(t)
+	mockDB := mock_repository.NewMockRepository(ctrl)
+	tx := &firestore.Transaction{}
+	userID := "user-1"
+	userDoc := repository.UserDoc{
+		DailyTotalStudySec: 60 * 60,
+		TotalStudySec:      2 * 60 * 60,
+		RankVisible:        true,
+		RankPoint:          42,
+	}
+
+	// Offline user: realtime duration is zero, so only the persisted totals are
+	// reflected in the reply. No LiveChatBot is configured, which also proves
+	// this transaction body does not post externally.
+	mockDB.EXPECT().ReadSeatWithUserID(gomock.Any(), userID, true).Return(
+		repository.SeatDoc{},
+		status.Error(codes.NotFound, "not in member room"),
+	).Times(1)
+	mockDB.EXPECT().ReadSeatWithUserID(gomock.Any(), userID, false).Return(
+		repository.SeatDoc{},
+		status.Error(codes.NotFound, "not in general room"),
+	).Times(1)
+	mockDB.EXPECT().ReadUser(gomock.Any(), tx, userID).Return(userDoc, nil).Times(2)
+
+	app := WorkspaceApp{
+		Repository:               mockDB,
+		ProcessedUserID:          userID,
+		ProcessedUserDisplayName: "User One",
+	}
+
+	reply, err := app.buildUserInfoReplyTx(context.Background(), tx, &utils.InfoOption{})
+	require.NoError(t, err)
+	expected := i18nmsg.CommandUserInfoBase(
+		"User One",
+		timeutil.DurationToString(time.Hour),
+		timeutil.DurationToString(2*time.Hour),
+	) + i18nmsg.CommandUserInfoRank(42)
+	assert.Equal(t, expected, reply)
+}
+
+func TestBuildUserInfoReplyTx_PropagatesRealtimeReadFailure(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockDB := mock_repository.NewMockRepository(ctrl)
+	tx := &firestore.Transaction{}
+	readErr := status.Error(codes.Internal, "seat lookup failed")
+	mockDB.EXPECT().ReadSeatWithUserID(gomock.Any(), "user-1", true).Return(repository.SeatDoc{}, readErr).Times(1)
+
+	app := WorkspaceApp{Repository: mockDB, ProcessedUserID: "user-1"}
+	reply, err := app.buildUserInfoReplyTx(context.Background(), tx, &utils.InfoOption{})
+	require.Error(t, err)
+	assert.Empty(t, reply)
+	assert.ErrorContains(t, err, "seat lookup failed")
+}


### PR DESCRIPTION
## 概要

P1 durable Inbox workerへ既存commandを段階的に載せる最初の実commandとして、read中心の `!info` を caller-owned Firestore transaction で実行できるbodyへ抽出します。

legacy `ShowUserInfo` の外部挙動は変えません。従来どおり自前transactionを開始し、成功時はYouTubeへ同じ返信を送ります。

## `buildUserInfoReplyTx`

- `GetUserRealtimeTotalStudyDurations`
- UserDoc読込
- rank表示
- `!info detail` の各詳細表示

を既存と同じ順序で実行し、**返信文字列をreturnするだけ**にします。

このhelper自身は:
- Firestore transactionを開始しない
- YouTubeへ投稿しない
- Discord通知しない
- writeしない

ため、後続durable workerでは以下のように同一transactionへ組み込めます。

```text
BeginLiveChatMessageTransaction
→ ensureProcessedUserRegisteredTx
→ buildUserInfoReplyTx
→ reply intent
→ FinalizeLiveChatMessageTransaction
→ commit
```

## legacy `ShowUserInfo`

既存transaction wrapperを残し、内部bodyだけ新helperへ置換します。error時のlog / `CommandError` reply / return errorも変更しません。

`My` / `Rank` は変更しません。

## テスト

- offline userのpersisted daily/total study timeとrankから既存 `!info` replyが生成されること
- helper実行時にLiveChatBotが不要、つまり外部postしないこと
- seat lookup failureをerrorとして伝播すること
- 既存Go test / Emulator回帰を継続実行

## Acceptance criteria

- System Go Test成功
- Go Lint成功
- Firestore Emulator Test成功
- Generated Files Up-to-Date成功
- CI Gate成功
- legacy `!info` 外部挙動変更なし
