### PR TITLE
Extract pure !info reply renderer

### DIFF
--- a/system/core/workspaceapp/command_user_info_tx.go
+++ b/system/core/workspaceapp/command_user_info_tx.go
@@ -3,10 +3,12 @@ package workspaceapp
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"cloud.google.com/go/firestore"
 
 	i18nmsg "app.modules/core/i18n/typed"
+	"app.modules/core/repository"
 	"app.modules/core/timeutil"
 	"app.modules/core/utils"
 )
@@ -24,14 +26,28 @@ func (app *WorkspaceApp) buildUserInfoReplyTx(
 	if err != nil {
 		return "", fmt.Errorf("in app.GetUserRealtimeTotalStudyDurations(): %w", err)
 	}
-	dailyTotalTimeStr := timeutil.DurationToString(dailyTotalStudyDuration)
-	totalTimeStr := timeutil.DurationToString(totalStudyDuration)
-	replyMessage := i18nmsg.CommandUserInfoBase(app.ProcessedUserDisplayName, dailyTotalTimeStr, totalTimeStr)
 
 	userDoc, err := app.Repository.ReadUser(ctx, tx, app.ProcessedUserID)
 	if err != nil {
 		return "", fmt.Errorf("in app.Repository.ReadUser: %w", err)
 	}
+
+	return app.buildUserInfoReply(userDoc, totalStudyDuration, dailyTotalStudyDuration, infoOption), nil
+}
+
+// buildUserInfoReply renders an !info response from already-read domain data.
+// It performs no repository access and no external delivery. The durable Inbox
+// path can therefore render the first-use response before staging User creation,
+// avoiding Firestore's read-after-write transaction restriction.
+func (app *WorkspaceApp) buildUserInfoReply(
+	userDoc repository.UserDoc,
+	totalStudyDuration time.Duration,
+	dailyTotalStudyDuration time.Duration,
+	infoOption *utils.InfoOption,
+) string {
+	dailyTotalTimeStr := timeutil.DurationToString(dailyTotalStudyDuration)
+	totalTimeStr := timeutil.DurationToString(totalStudyDuration)
+	replyMessage := i18nmsg.CommandUserInfoBase(app.ProcessedUserDisplayName, dailyTotalTimeStr, totalTimeStr)
 
 	if userDoc.RankVisible {
 		replyMessage += i18nmsg.CommandUserInfoRank(userDoc.RankPoint)
@@ -64,5 +80,5 @@ func (app *WorkspaceApp) buildUserInfoReplyTx(
 
 		replyMessage += i18nmsg.CommandUserInfoRegisterDate(userDoc.RegistrationDate.In(timeutil.JapanLocation()).Format("2006年01月02日"))
 	}
-	return replyMessage, nil
+	return replyMessage
 }

--- a/system/core/workspaceapp/command_user_info_tx_test.go
+++ b/system/core/workspaceapp/command_user_info_tx_test.go
@@ -75,3 +75,25 @@ func TestBuildUserInfoReplyTx_PropagatesRealtimeReadFailure(t *testing.T) {
 	assert.Empty(t, reply)
 	assert.ErrorContains(t, err, "seat lookup failed")
 }
+
+func TestBuildUserInfoReply_FirstUseDetailsNeedNoRepositoryRead(t *testing.T) {
+	loadWorkspaceAppTestI18n(t)
+	now := time.Date(2026, 8, 15, 11, 30, 0, 0, timeutil.JapanLocation())
+	app := WorkspaceApp{
+		ProcessedUserDisplayName: "New User",
+		nowFunc:                  func() time.Time { return now },
+	}
+	userDoc := repository.UserDoc{RegistrationDate: now}
+
+	reply := app.buildUserInfoReply(userDoc, 0, 0, &utils.InfoOption{ShowDetails: true})
+
+	expected := i18nmsg.CommandUserInfoBase(
+		"New User",
+		timeutil.DurationToString(0),
+		timeutil.DurationToString(0),
+	) + i18nmsg.CommandUserInfoRankOff() +
+		i18nmsg.CommandUserInfoDefaultWorkOff() +
+		i18nmsg.CommandUserInfoFavoriteColorOff() +
+		i18nmsg.CommandUserInfoRegisterDate("2026年08月15日")
+	assert.Equal(t, expected, reply)
+}


### PR DESCRIPTION
## 概要

P1 durable Inbox transactionで初回ユーザーの `!info` まで同一commit boundaryに載せるため、`!info` の表示組み立てを既読データだけから行う副作用なしrendererへ分離します。

背景として、Firestore transactionではwrite後のreadができません。初回ユーザーを同一transactionで作成した直後に従来の `buildUserInfoReplyTx` を呼ぶとUserを再readしてしまうため、durable pathでは「全read → reply構築 → User作成/Outbox/Processed write」の順にする必要があります。

## 変更内容

### `buildUserInfoReply`

入力:
- `repository.UserDoc`
- total/daily study duration
- `InfoOption`

から既存の `!info` replyを構築します。

このrendererは:
- Repository readなし
- Firestore transactionなし
- YouTube/Discord side effectなし

です。

### `buildUserInfoReplyTx`

既存read順序とerror semanticsを維持したまま、最後の表示組み立てだけ新rendererへ委譲します。legacy `ShowUserInfo` の挙動は変わりません。

## テスト

- 既存transaction bodyのreply回帰
- realtime read failure伝播
- **初回ユーザー相当のzero-value UserDoc + RegistrationDate** から、repository readなしで詳細 `!info` replyを構築できること

## 次段

後続durable `!info` では:

```text
Begin Inbox read
→ User存在確認 + command reads
→ replyをbuildUserInfoReplyで構築
→ 未登録ならUser Create
→ reply intent Create
→ Inbox Processed
→ commit
```

とし、read-after-writeを避けます。

## Acceptance criteria

- System Go Test成功
- Go Lint成功
- Firestore Emulator Test成功
- Generated Files Up-to-Date成功
- CI Gate成功
- legacy `!info` reply変更なし
