### PR TITLE
fix: avoid reserved BigQuery ROWS alias in history audit

### DIFF
--- a/system/cmd/history-transfer-gap-audit/main.go
+++ b/system/cmd/history-transfer-gap-audit/main.go
@@ -65,7 +65,7 @@ type historyCollectionAudit struct {
 
 type dailyCount struct {
 	Date string `json:"date" bigquery:"date"`
-	Rows int64  `json:"rows" bigquery:"rows"`
+	Rows int64  `json:"rows" bigquery:"row_count"`
 }
 
 type gcsCoverageAudit struct {
@@ -411,7 +411,7 @@ FROM %s`, spec.TimestampColumn, spec.TimestampColumn, spec.TimestampColumn, tabl
 	dailySQL := fmt.Sprintf(`
 SELECT
   FORMAT_DATE('%%Y-%%m-%%d', DATE(%s, 'Asia/Tokyo')) AS date,
-  COUNT(*) AS rows
+  COUNT(*) AS row_count
 FROM %s
 WHERE %s >= @from
 GROUP BY date


### PR DESCRIPTION
## Summary

- `history-transfer-gap-audit` の日別BigQuery集計で `COUNT(*) AS rows` を使っていたため、BigQuery Standard SQL の予約語 `ROWS` と衝突して実行時に400エラーになっていた問題を修正
- aliasを `row_count` に変更
- Go側のBigQuery struct tagも `row_count` に合わせる

## Observed production error

```text
history-transfer-gap-audit: inspect BigQuery history: run BigQuery daily query for user-activity-history: googleapi: Error 400: Syntax error: Unexpected keyword ROWS at [4:15], invalidQuery
```

## Safety

監査コマンド自体のread-only性は変更していません。Firestore / BigQuery / GCSへのdelete/update/export/importは追加していません。
