### PR TITLE
Add first end-to-end durable Inbox processor

### DIFF
--- a/system/core/workspaceapp/durable_message_processing.go
+++ b/system/core/workspaceapp/durable_message_processing.go
@@ -92,7 +92,7 @@ func (app *WorkspaceApp) ProcessClaimedDurableInboxMessage(
 			now,
 		)
 		if err != nil {
-			return err
+			return fmt.Errorf("begin durable live chat message transaction: %w", err)
 		}
 
 		userDoc, userExists, err := app.readDurableMessageUser(ctx, tx, now)
@@ -160,7 +160,7 @@ func (app *WorkspaceApp) readDurableMessageUser(
 	userDoc, err := app.Repository.ReadUser(ctx, tx, app.ProcessedUserID)
 	if status.Code(err) == codes.NotFound {
 		return repository.UserDoc{
-			RegistrationDate:    now,
+			RegistrationDate:   now,
 			DailyTotalStudySec: 0,
 			TotalStudySec:      0,
 		}, false, nil
@@ -187,7 +187,7 @@ func (app *WorkspaceApp) finalizeDurableNoopMessage(
 			now,
 		)
 		if err != nil {
-			return err
+			return fmt.Errorf("begin durable noop live chat message transaction: %w", err)
 		}
 		return durableRepo.FinalizeLiveChatMessageTransaction(ctx, tx, guard, nil, now)
 	})

--- a/system/core/workspaceapp/durable_message_processing.go
+++ b/system/core/workspaceapp/durable_message_processing.go
@@ -62,18 +62,19 @@ func (app *WorkspaceApp) ProcessClaimedDurableInboxMessage(
 		return app.finalizeDurableNoopMessage(ctx, durableRepo, inbox, workerID)
 	}
 
-	// #1012 will persist owner/member source metadata before runtime cutover.
-	// !info and NotCommand do not depend on those flags, so this first slice can
-	// safely preserve the currently available moderator flag only.
+	isChatMember := inbox.AuthorIsChatMember
+	if !app.Configs.Constants.YoutubeMembershipEnabled {
+		isChatMember = false
+	}
 	app.SetProcessedUser(
 		inbox.AuthorChannelID,
 		inbox.AuthorDisplayName,
 		inbox.AuthorProfileImageURL,
 		inbox.AuthorIsChatModerator,
-		false,
-		false,
+		inbox.AuthorIsChatOwner,
+		isChatMember,
 	)
-	prepared := app.parseAndValidateMessage(inbox.MessageText, false)
+	prepared := app.parseAndValidateMessage(inbox.MessageText, isChatMember)
 	if prepared.ImmediateReply != "" || prepared.SkipExecution || prepared.CommandDetails == nil {
 		return ErrDurableCommandNotSupported
 	}

--- a/system/core/workspaceapp/durable_message_processing.go
+++ b/system/core/workspaceapp/durable_message_processing.go
@@ -1,0 +1,214 @@
+package workspaceapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/firestore"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"app.modules/core/repository"
+	"app.modules/core/utils"
+)
+
+const durablePrimaryReplyIntentSlot = "primary"
+
+var ErrDurableCommandNotSupported = errors.New("command is not supported by durable live chat processing yet")
+
+type liveChatMessageTransactionRepository interface {
+	BeginLiveChatMessageTransaction(
+		tx *firestore.Transaction,
+		liveChatID string,
+		messageID string,
+		workerID string,
+		now time.Time,
+	) (repository.LiveChatMessageTransactionGuard, error)
+	FinalizeLiveChatMessageTransaction(
+		ctx context.Context,
+		tx *firestore.Transaction,
+		guard repository.LiveChatMessageTransactionGuard,
+		replyIntents []repository.LiveChatReplyOutboxDoc,
+		now time.Time,
+	) error
+}
+
+// ProcessClaimedDurableInboxMessage is the first executable slice of the P1
+// durable worker. It intentionally supports only behavior whose domain and
+// reply effects can already be committed atomically:
+//   - bot's own source message: mark Processed, no user/reply effect
+//   - ordinary non-command text: first-use User creation + Processed
+//   - !info: first-use User creation + reply intent + Processed
+//
+// Unsupported commands return ErrDurableCommandNotSupported before opening a
+// transaction, leaving the caller-owned Inbox lease unchanged. Runtime cutover
+// must not route all commands here until later command slices are supported.
+func (app *WorkspaceApp) ProcessClaimedDurableInboxMessage(
+	ctx context.Context,
+	inbox repository.LiveChatInboxDoc,
+	workerID string,
+) error {
+	durableRepo, ok := app.Repository.(liveChatMessageTransactionRepository)
+	if !ok {
+		return errors.New("workspace repository does not support durable live chat message transactions")
+	}
+	if app.Configs == nil {
+		return errors.New("workspace configs are nil")
+	}
+
+	if inbox.AuthorChannelID == app.Configs.LiveChatBotChannelID {
+		return app.finalizeDurableNoopMessage(ctx, durableRepo, inbox, workerID)
+	}
+
+	// #1012 will persist owner/member source metadata before runtime cutover.
+	// !info and NotCommand do not depend on those flags, so this first slice can
+	// safely preserve the currently available moderator flag only.
+	app.SetProcessedUser(
+		inbox.AuthorChannelID,
+		inbox.AuthorDisplayName,
+		inbox.AuthorProfileImageURL,
+		inbox.AuthorIsChatModerator,
+		false,
+		false,
+	)
+	prepared := app.parseAndValidateMessage(inbox.MessageText, false)
+	if prepared.ImmediateReply != "" || prepared.SkipExecution || prepared.CommandDetails == nil {
+		return ErrDurableCommandNotSupported
+	}
+	if prepared.CommandDetails.CommandType != utils.NotCommand && prepared.CommandDetails.CommandType != utils.Info {
+		return ErrDurableCommandNotSupported
+	}
+
+	now := app.currentTime()
+	return app.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
+		guard, err := durableRepo.BeginLiveChatMessageTransaction(
+			tx,
+			inbox.LiveChatID,
+			inbox.MessageID,
+			workerID,
+			now,
+		)
+		if err != nil {
+			return err
+		}
+
+		userDoc, userExists, err := app.readDurableMessageUser(ctx, tx, now)
+		if err != nil {
+			return err
+		}
+
+		var reply string
+		switch prepared.CommandDetails.CommandType {
+		case utils.NotCommand:
+			// Legacy ProcessMessage still registers first-use users for ordinary
+			// text, then performs no command side effect or reply.
+		case utils.Info:
+			var totalStudyDuration time.Duration
+			var dailyTotalStudyDuration time.Duration
+			if userExists {
+				totalStudyDuration, dailyTotalStudyDuration, err = app.GetUserRealtimeTotalStudyDurations(
+					ctx,
+					tx,
+					app.ProcessedUserID,
+				)
+				if err != nil {
+					return fmt.Errorf("read realtime study durations for durable !info: %w", err)
+				}
+			} else {
+				inMemberRoom, inGeneralRoom, roomErr := app.IsUserInRoom(ctx, app.ProcessedUserID)
+				if roomErr != nil {
+					return fmt.Errorf("check room state for unregistered durable user: %w", roomErr)
+				}
+				if inMemberRoom || inGeneralRoom {
+					return errors.New("unregistered user unexpectedly has an active seat")
+				}
+			}
+			reply = app.buildUserInfoReply(
+				userDoc,
+				totalStudyDuration,
+				dailyTotalStudyDuration,
+				&prepared.CommandDetails.InfoOption,
+			)
+		default:
+			return ErrDurableCommandNotSupported
+		}
+
+		// All reads are complete before this point. Firestore transaction writes
+		// start here and Finalize performs no additional reads.
+		if !userExists {
+			if err := app.Repository.CreateUser(ctx, tx, app.ProcessedUserID, userDoc); err != nil {
+				return fmt.Errorf("create first-use durable user: %w", err)
+			}
+		}
+
+		intents := durableReplyIntents(inbox, reply, now)
+		if err := durableRepo.FinalizeLiveChatMessageTransaction(ctx, tx, guard, intents, now); err != nil {
+			return fmt.Errorf("finalize durable live chat message: %w", err)
+		}
+		return nil
+	})
+}
+
+func (app *WorkspaceApp) readDurableMessageUser(
+	ctx context.Context,
+	tx *firestore.Transaction,
+	now time.Time,
+) (repository.UserDoc, bool, error) {
+	userDoc, err := app.Repository.ReadUser(ctx, tx, app.ProcessedUserID)
+	if status.Code(err) == codes.NotFound {
+		return repository.UserDoc{
+			RegistrationDate:    now,
+			DailyTotalStudySec: 0,
+			TotalStudySec:      0,
+		}, false, nil
+	}
+	if err != nil {
+		return repository.UserDoc{}, false, fmt.Errorf("read durable message user: %w", err)
+	}
+	return userDoc, true, nil
+}
+
+func (app *WorkspaceApp) finalizeDurableNoopMessage(
+	ctx context.Context,
+	durableRepo liveChatMessageTransactionRepository,
+	inbox repository.LiveChatInboxDoc,
+	workerID string,
+) error {
+	now := app.currentTime()
+	return app.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
+		guard, err := durableRepo.BeginLiveChatMessageTransaction(
+			tx,
+			inbox.LiveChatID,
+			inbox.MessageID,
+			workerID,
+			now,
+		)
+		if err != nil {
+			return err
+		}
+		return durableRepo.FinalizeLiveChatMessageTransaction(ctx, tx, guard, nil, now)
+	})
+}
+
+func durableReplyIntents(
+	inbox repository.LiveChatInboxDoc,
+	reply string,
+	now time.Time,
+) []repository.LiveChatReplyOutboxDoc {
+	if reply == "" {
+		return nil
+	}
+	return []repository.LiveChatReplyOutboxDoc{{
+		LiveChatID:            inbox.LiveChatID,
+		SourceMessageID:       inbox.MessageID,
+		SourceAuthorChannelID: inbox.AuthorChannelID,
+		IntentSlot:            durablePrimaryReplyIntentSlot,
+		SourceSequence:        inbox.Sequence,
+		Message:               reply,
+		Status:                repository.LiveChatReplyOutboxPending,
+		CreatedAt:             now,
+		AvailableAt:           now,
+	}}
+}

--- a/system/core/workspaceapp/durable_message_processing_integration_test.go
+++ b/system/core/workspaceapp/durable_message_processing_integration_test.go
@@ -1,0 +1,156 @@
+//go:build integration
+
+package workspaceapp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	i18nmsg "app.modules/core/i18n/typed"
+	"app.modules/core/repository"
+	"app.modules/core/timeutil"
+	"app.modules/internal/integrationtest"
+)
+
+func durableSourceHistory(liveChatID, messageID, authorID, displayName, text string, publishedAt time.Time) repository.LiveChatHistoryDoc {
+	return repository.LiveChatHistoryDoc{
+		AuthorChannelID:       authorID,
+		AuthorDisplayName:     displayName,
+		AuthorProfileImageURL: "https://example.com/profile.png",
+		AuthorIsChatModerator: false,
+		ID:                    messageID,
+		LiveChatID:            liveChatID,
+		MessageText:           text,
+		PublishedAt:           publishedAt,
+		Type:                  "textMessageEvent",
+	}
+}
+
+func TestProcessClaimedDurableInboxMessage_FirstUseInfoCommitsUserReplyAndProcessed(t *testing.T) {
+	loadWorkspaceAppTestI18n(t)
+	integrationtest.ResetFirestore(t)
+	controller := integrationtest.NewFirestoreController(t)
+	ctx := context.Background()
+	liveChatID := "durable-info-chat"
+	now := time.Date(2026, 8, 15, 15, 0, 0, 0, timeutil.JapanLocation())
+	history := durableSourceHistory(liveChatID, "message-info", "author-1", "New User", "!info", now.Add(-time.Minute))
+	require.NoError(t, controller.IngestLiveChatPage(ctx, liveChatID, "", "cursor-1", []repository.LiveChatHistoryDoc{history}, now.Add(-30*time.Second)))
+
+	claimed, err := controller.ClaimLiveChatInboxMessage(ctx, liveChatID, history.ID, "worker-a", now.Add(-10*time.Second), time.Minute, 3)
+	require.NoError(t, err)
+	app := WorkspaceApp{
+		Configs: &Configs{
+			Constants:            repository.ConstantsConfigDoc{YoutubeMembershipEnabled: true},
+			LiveChatBotChannelID: "bot-channel",
+		},
+		Repository: controller,
+		nowFunc:    func() time.Time { return now },
+	}
+
+	// No LiveChatBot is configured. Any accidental external reply would fail the
+	// test; durable processing must only create an Outbox intent.
+	require.NoError(t, app.ProcessClaimedDurableInboxMessage(ctx, claimed, "worker-a"))
+
+	user, err := controller.ReadUser(ctx, nil, history.AuthorChannelID)
+	require.NoError(t, err)
+	assert.Equal(t, now, user.RegistrationDate)
+	assert.Zero(t, user.DailyTotalStudySec)
+	assert.Zero(t, user.TotalStudySec)
+
+	messageKey, err := repository.LiveChatMessageKey(liveChatID, history.ID)
+	require.NoError(t, err)
+	inboxSnapshot, err := controller.FirestoreClient().Collection(repository.LiveChatInbox).Doc(messageKey).Get(ctx)
+	require.NoError(t, err)
+	var inbox repository.LiveChatInboxDoc
+	require.NoError(t, inboxSnapshot.DataTo(&inbox))
+	assert.Equal(t, repository.LiveChatInboxProcessed, inbox.Status)
+	require.NotNil(t, inbox.ProcessedAt)
+	assert.Equal(t, now, *inbox.ProcessedAt)
+	assert.Empty(t, inbox.LeaseOwner)
+	assert.Nil(t, inbox.LeaseUntil)
+
+	outboxKey, err := repository.LiveChatReplyOutboxKey(liveChatID, history.ID, durablePrimaryReplyIntentSlot)
+	require.NoError(t, err)
+	outboxSnapshot, err := controller.FirestoreClient().Collection(repository.LiveChatReplyOutbox).Doc(outboxKey).Get(ctx)
+	require.NoError(t, err)
+	var outbox repository.LiveChatReplyOutboxDoc
+	require.NoError(t, outboxSnapshot.DataTo(&outbox))
+	assert.Equal(t, repository.LiveChatReplyOutboxPending, outbox.Status)
+	assert.Equal(t, history.AuthorChannelID, outbox.SourceAuthorChannelID)
+	assert.Equal(t, i18nmsg.CommandUserInfoBase(
+		"New User",
+		timeutil.DurationToString(0),
+		timeutil.DurationToString(0),
+	), outbox.Message)
+
+	// The Inbox itself is the effect ledger: a retry cannot recreate the User or
+	// reply intent after a successful commit.
+	err = app.ProcessClaimedDurableInboxMessage(ctx, claimed, "worker-a")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, repository.ErrLiveChatInboxAlreadyProcessed)
+}
+
+func TestProcessClaimedDurableInboxMessage_NonCommandCreatesUserWithoutReply(t *testing.T) {
+	loadWorkspaceAppTestI18n(t)
+	integrationtest.ResetFirestore(t)
+	controller := integrationtest.NewFirestoreController(t)
+	ctx := context.Background()
+	liveChatID := "durable-non-command-chat"
+	now := time.Date(2026, 8, 15, 16, 0, 0, 0, timeutil.JapanLocation())
+	history := durableSourceHistory(liveChatID, "message-text", "author-2", "Viewer", "hello study room", now.Add(-time.Minute))
+	require.NoError(t, controller.IngestLiveChatPage(ctx, liveChatID, "", "cursor-1", []repository.LiveChatHistoryDoc{history}, now.Add(-30*time.Second)))
+	claimed, err := controller.ClaimLiveChatInboxMessage(ctx, liveChatID, history.ID, "worker-a", now.Add(-10*time.Second), time.Minute, 3)
+	require.NoError(t, err)
+
+	app := WorkspaceApp{
+		Configs:    &Configs{Constants: repository.ConstantsConfigDoc{YoutubeMembershipEnabled: true}},
+		Repository: controller,
+		nowFunc:    func() time.Time { return now },
+	}
+	require.NoError(t, app.ProcessClaimedDurableInboxMessage(ctx, claimed, "worker-a"))
+	_, err = controller.ReadUser(ctx, nil, history.AuthorChannelID)
+	require.NoError(t, err)
+
+	outboxKey, err := repository.LiveChatReplyOutboxKey(liveChatID, history.ID, durablePrimaryReplyIntentSlot)
+	require.NoError(t, err)
+	_, err = controller.FirestoreClient().Collection(repository.LiveChatReplyOutbox).Doc(outboxKey).Get(ctx)
+	require.Error(t, err)
+}
+
+func TestProcessClaimedDurableInboxMessage_UnsupportedCommandDoesNotCommit(t *testing.T) {
+	loadWorkspaceAppTestI18n(t)
+	integrationtest.ResetFirestore(t)
+	controller := integrationtest.NewFirestoreController(t)
+	ctx := context.Background()
+	liveChatID := "durable-unsupported-chat"
+	now := time.Date(2026, 8, 15, 17, 0, 0, 0, timeutil.JapanLocation())
+	history := durableSourceHistory(liveChatID, "message-out", "author-3", "Viewer", "!out", now.Add(-time.Minute))
+	require.NoError(t, controller.IngestLiveChatPage(ctx, liveChatID, "", "cursor-1", []repository.LiveChatHistoryDoc{history}, now.Add(-30*time.Second)))
+	claimed, err := controller.ClaimLiveChatInboxMessage(ctx, liveChatID, history.ID, "worker-a", now.Add(-10*time.Second), time.Minute, 3)
+	require.NoError(t, err)
+
+	app := WorkspaceApp{
+		Configs:    &Configs{Constants: repository.ConstantsConfigDoc{YoutubeMembershipEnabled: true}},
+		Repository: controller,
+		nowFunc:    func() time.Time { return now },
+	}
+	err = app.ProcessClaimedDurableInboxMessage(ctx, claimed, "worker-a")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrDurableCommandNotSupported)
+
+	messageKey, err := repository.LiveChatMessageKey(liveChatID, history.ID)
+	require.NoError(t, err)
+	snapshot, err := controller.FirestoreClient().Collection(repository.LiveChatInbox).Doc(messageKey).Get(ctx)
+	require.NoError(t, err)
+	var inbox repository.LiveChatInboxDoc
+	require.NoError(t, snapshot.DataTo(&inbox))
+	assert.Equal(t, repository.LiveChatInboxProcessing, inbox.Status)
+	assert.Equal(t, "worker-a", inbox.LeaseOwner)
+
+	_, err = controller.ReadUser(ctx, nil, history.AuthorChannelID)
+	require.Error(t, err)
+}

--- a/system/core/workspaceapp/durable_message_processing_integration_test.go
+++ b/system/core/workspaceapp/durable_message_processing_integration_test.go
@@ -75,7 +75,7 @@ func TestProcessClaimedDurableInboxMessage_FirstUseInfoCommitsUserReplyAndProces
 
 	user, err := controller.ReadUser(ctx, nil, history.AuthorChannelID)
 	require.NoError(t, err)
-	assert.Equal(t, now, user.RegistrationDate)
+	assert.True(t, user.RegistrationDate.Equal(now), "Firestore normalizes timestamps to UTC")
 	assert.Zero(t, user.DailyTotalStudySec)
 	assert.Zero(t, user.TotalStudySec)
 
@@ -87,7 +87,7 @@ func TestProcessClaimedDurableInboxMessage_FirstUseInfoCommitsUserReplyAndProces
 	require.NoError(t, inboxSnapshot.DataTo(&inbox))
 	assert.Equal(t, repository.LiveChatInboxProcessed, inbox.Status)
 	require.NotNil(t, inbox.ProcessedAt)
-	assert.Equal(t, now, *inbox.ProcessedAt)
+	assert.True(t, inbox.ProcessedAt.Equal(now), "Firestore normalizes timestamps to UTC")
 	assert.Empty(t, inbox.LeaseOwner)
 	assert.Nil(t, inbox.LeaseUntil)
 

--- a/system/core/workspaceapp/durable_message_processing_integration_test.go
+++ b/system/core/workspaceapp/durable_message_processing_integration_test.go
@@ -37,11 +37,27 @@ func TestProcessClaimedDurableInboxMessage_FirstUseInfoCommitsUserReplyAndProces
 	ctx := context.Background()
 	liveChatID := "durable-info-chat"
 	now := time.Date(2026, 8, 15, 15, 0, 0, 0, timeutil.JapanLocation())
-	history := durableSourceHistory(liveChatID, "message-info", "author-1", "New User", "!info", now.Add(-time.Minute))
-	require.NoError(t, controller.IngestLiveChatPage(ctx, liveChatID, "", "cursor-1", []repository.LiveChatHistoryDoc{history}, now.Add(-30*time.Second)))
+	history := durableSourceHistory(liveChatID, "message-info", "author-1", "@New User", "!info", now.Add(-time.Minute))
+	source := repository.LiveChatIngestMessage{
+		History:             history,
+		AuthorIsChatOwner:   true,
+		AuthorIsChatSponsor: false,
+	}
+	require.NoError(t, controller.IngestLiveChatSourcePage(
+		ctx,
+		liveChatID,
+		"",
+		"cursor-1",
+		[]repository.LiveChatIngestMessage{source},
+		now.Add(-30*time.Second),
+	))
 
 	claimed, err := controller.ClaimLiveChatInboxMessage(ctx, liveChatID, history.ID, "worker-a", now.Add(-10*time.Second), time.Minute, 3)
 	require.NoError(t, err)
+	assert.Equal(t, "New User", claimed.AuthorDisplayName)
+	assert.True(t, claimed.AuthorIsChatOwner)
+	assert.True(t, claimed.AuthorIsChatMember)
+
 	app := WorkspaceApp{
 		Configs: &Configs{
 			Constants:            repository.ConstantsConfigDoc{YoutubeMembershipEnabled: true},
@@ -54,6 +70,8 @@ func TestProcessClaimedDurableInboxMessage_FirstUseInfoCommitsUserReplyAndProces
 	// No LiveChatBot is configured. Any accidental external reply would fail the
 	// test; durable processing must only create an Outbox intent.
 	require.NoError(t, app.ProcessClaimedDurableInboxMessage(ctx, claimed, "worker-a"))
+	assert.True(t, app.ProcessedUserIsModeratorOrOwner)
+	assert.True(t, app.ProcessedUserIsMember)
 
 	user, err := controller.ReadUser(ctx, nil, history.AuthorChannelID)
 	require.NoError(t, err)


### PR DESCRIPTION
## 概要

P1「YouTubeチャット処理を冪等化・耐障害化」で初めて、実command経路を durable Inbox → atomic domain transaction → reply Outbox → Inbox Processed まで接続します。

安全に切れる最初のsliceとして、現時点では **通常チャット (`NotCommand`) と `!info` のみ**を対応します。その他のcommandは明示的に `ErrDurableCommandNotSupported` を返し、InboxやUserをcommitしません。runtime cutoverはまだ行いません。

## `ProcessClaimedDurableInboxMessage`

入力:
- `ClaimLiveChatInboxMessage` で取得した Inbox
- worker ID

処理:

1. Inbox actor metadataから legacy と同じ `ProcessedUser*` を設定
   - moderator
   - owner
   - effective member
   - membership機能disabled時はmember=falseへ正規化
2. side-effect-free `parseAndValidateMessage`
3. 未対応commandはtransaction開始前に拒否
4. caller transaction内で `BeginLiveChatMessageTransaction`
5. Userをread
   - 未登録ならzero/default UserDocをメモリ上で構築
6. `!info` の必要readを完了
7. pure `buildUserInfoReply` でreply生成
8. ここからwrite phase
   - 初回UserをCreate
   - deterministic reply Outbox intent
   - Inbox Processed
9. `FinalizeLiveChatMessageTransaction`
10. すべて同一Firestore commit boundary

通常チャットはlegacyと同じく初回User登録のみ行い、reply intentは作りません。

bot自身のsource messageはUserを作らず、InboxをProcessedにするnoop経路です。

## 原子性 / 冪等性

- User creation + reply intent + Inbox Processed が同一transaction
- transaction失敗時は全rollback
- successful commit後の再実行は Inbox `Processed` がeffect ledgerとなり `ErrLiveChatInboxAlreadyProcessed`
- external YouTube postは行わず、replyはOutboxにのみ保存

## Actor metadata

#1012 の source-aware ingestを前提に、Inboxの
- normalized display name
- owner
- effective member
を実際に使用します。

E2E testでは `@New User` のowner sourceを `IngestLiveChatSourcePage` → claim → durable processing と通し、`New User` のreply、owner/member actor stateまで確認します。

## Emulator tests

- first-use `!info`
  - User作成
  - Outbox Pending作成
  - Inbox Processed
  - external postなし
  - 再実行で二重effectなし
- ordinary non-command
  - User作成
  - reply Outboxなし
  - Inbox Processed
- unsupported `!out`
  - `ErrDurableCommandNotSupported`
  - InboxはProcessing/lease維持
  - User未作成

## 重要な境界

まだruntime cutoverしません。未対応:
- parse/validation immediate replyのdurable化
- `In/Out/My/Rank/...` 等のdomain command
- NG word moderation / Ban / Discord外部effect
- YouTube reply delivery worker
- durable ingest/checkpointをyoutube-bot loopへ接続

## Acceptance criteria

- System Go Test成功
- Go Lint成功
- Firestore Emulator integration test成功
- first-use !info のUser/Outbox/Processed atomic path成功
- already-processed retry protection成功
- unsupported commandがcommitしないこと
- CI Gate成功
- 現行youtube-bot runtime挙動に変更なし
