### PR TITLE
Add YouTube message to durable ingest builder

### DIFF
--- a/system/core/workspaceapp/live_chat_ingest_message.go
+++ b/system/core/workspaceapp/live_chat_ingest_message.go
@@ -1,0 +1,55 @@
+package workspaceapp
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"google.golang.org/api/youtube/v3"
+
+	"app.modules/core/repository"
+	"app.modules/core/timeutil"
+	"app.modules/core/youtubebot"
+)
+
+// BuildLiveChatIngestMessage converts one YouTube source message into the
+// durable ingest shape while preserving the existing live-chat-history schema.
+// The returned History is intentionally equivalent to AddLiveChatHistoryDoc's
+// current document, and owner/sponsor metadata is carried separately for Inbox
+// command processing.
+func BuildLiveChatIngestMessage(chatMessage *youtube.LiveChatMessage) (repository.LiveChatIngestMessage, error) {
+	if chatMessage == nil {
+		return repository.LiveChatIngestMessage{}, errors.New("live chat message is nil")
+	}
+	if chatMessage.Snippet == nil {
+		return repository.LiveChatIngestMessage{}, errors.New("live chat message snippet is nil")
+	}
+	if chatMessage.AuthorDetails == nil {
+		return repository.LiveChatIngestMessage{}, errors.New("live chat message author details are nil")
+	}
+	if !youtubebot.HasTextMessageByAuthor(chatMessage) {
+		return repository.LiveChatIngestMessage{}, errors.New("live chat message has no author text message")
+	}
+
+	publishedAt, err := time.Parse(time.RFC3339Nano, chatMessage.Snippet.PublishedAt)
+	if err != nil {
+		return repository.LiveChatIngestMessage{}, fmt.Errorf("parse live chat published at: %w", err)
+	}
+	publishedAt = publishedAt.In(timeutil.JapanLocation())
+
+	return repository.LiveChatIngestMessage{
+		History: repository.LiveChatHistoryDoc{
+			AuthorChannelID:       chatMessage.AuthorDetails.ChannelId,
+			AuthorDisplayName:     chatMessage.AuthorDetails.DisplayName,
+			AuthorProfileImageURL: chatMessage.AuthorDetails.ProfileImageUrl,
+			AuthorIsChatModerator: chatMessage.AuthorDetails.IsChatModerator,
+			ID:                    chatMessage.Id,
+			LiveChatID:            chatMessage.Snippet.LiveChatId,
+			MessageText:           youtubebot.ExtractTextMessageByAuthor(chatMessage),
+			PublishedAt:           publishedAt,
+			Type:                  chatMessage.Snippet.Type,
+		},
+		AuthorIsChatOwner:   youtubebot.IsChatMessageByOwner(chatMessage),
+		AuthorIsChatSponsor: youtubebot.IsChatMessageByMember(chatMessage),
+	}, nil
+}

--- a/system/core/workspaceapp/live_chat_ingest_message_test.go
+++ b/system/core/workspaceapp/live_chat_ingest_message_test.go
@@ -1,0 +1,120 @@
+package workspaceapp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/youtube/v3"
+
+	"app.modules/core/timeutil"
+	"app.modules/core/youtubebot"
+)
+
+func TestBuildLiveChatIngestMessage(t *testing.T) {
+	t.Parallel()
+
+	message := &youtube.LiveChatMessage{
+		Id: "message-1",
+		AuthorDetails: &youtube.LiveChatMessageAuthorDetails{
+			ChannelId:       "author-1",
+			DisplayName:     "@Member User",
+			ProfileImageUrl: "https://example.com/profile.png",
+			IsChatModerator: true,
+			IsChatOwner:     false,
+			IsChatSponsor:   true,
+		},
+		Snippet: &youtube.LiveChatMessageSnippet{
+			LiveChatId:  "chat-1",
+			PublishedAt: "2026-08-15T06:00:00.123456Z",
+			Type:        youtubebot.TextMessageEvent,
+			TextMessageDetails: &youtube.LiveChatTextMessageDetails{
+				MessageText: "!info",
+			},
+		},
+	}
+
+	got, err := BuildLiveChatIngestMessage(message)
+	require.NoError(t, err)
+	assert.Equal(t, "message-1", got.History.ID)
+	assert.Equal(t, "chat-1", got.History.LiveChatID)
+	assert.Equal(t, "author-1", got.History.AuthorChannelID)
+	assert.Equal(t, "@Member User", got.History.AuthorDisplayName, "history keeps the raw display name")
+	assert.Equal(t, "https://example.com/profile.png", got.History.AuthorProfileImageURL)
+	assert.True(t, got.History.AuthorIsChatModerator)
+	assert.Equal(t, "!info", got.History.MessageText)
+	assert.Equal(t, youtubebot.TextMessageEvent, got.History.Type)
+	assert.True(t, got.AuthorIsChatSponsor)
+	assert.False(t, got.AuthorIsChatOwner)
+
+	wantPublishedAt := time.Date(2026, 8, 15, 15, 0, 0, 123456000, timeutil.JapanLocation())
+	assert.Equal(t, wantPublishedAt, got.History.PublishedAt)
+}
+
+func TestBuildLiveChatIngestMessagePreservesOwnerMetadata(t *testing.T) {
+	t.Parallel()
+
+	message := &youtube.LiveChatMessage{
+		Id: "message-owner",
+		AuthorDetails: &youtube.LiveChatMessageAuthorDetails{
+			ChannelId:   "owner",
+			DisplayName: "Owner",
+			IsChatOwner: true,
+		},
+		Snippet: &youtube.LiveChatMessageSnippet{
+			LiveChatId:  "chat-1",
+			PublishedAt: "2026-08-15T06:00:00Z",
+			Type:        youtubebot.TextMessageEvent,
+			TextMessageDetails: &youtube.LiveChatTextMessageDetails{
+				MessageText: "hello",
+			},
+		},
+	}
+
+	got, err := BuildLiveChatIngestMessage(message)
+	require.NoError(t, err)
+	assert.True(t, got.AuthorIsChatOwner)
+	assert.False(t, got.AuthorIsChatSponsor)
+}
+
+func TestBuildLiveChatIngestMessageRejectsIncompleteSource(t *testing.T) {
+	t.Parallel()
+
+	_, err := BuildLiveChatIngestMessage(nil)
+	require.Error(t, err)
+
+	_, err = BuildLiveChatIngestMessage(&youtube.LiveChatMessage{})
+	require.Error(t, err)
+
+	_, err = BuildLiveChatIngestMessage(&youtube.LiveChatMessage{
+		Snippet: &youtube.LiveChatMessageSnippet{},
+	})
+	require.Error(t, err)
+
+	_, err = BuildLiveChatIngestMessage(&youtube.LiveChatMessage{
+		AuthorDetails: &youtube.LiveChatMessageAuthorDetails{},
+		Snippet: &youtube.LiveChatMessageSnippet{
+			Type: youtubebot.NewSponsorEvent,
+		},
+	})
+	require.Error(t, err)
+}
+
+func TestBuildLiveChatIngestMessageRejectsInvalidPublishedAt(t *testing.T) {
+	t.Parallel()
+
+	message := &youtube.LiveChatMessage{
+		AuthorDetails: &youtube.LiveChatMessageAuthorDetails{},
+		Snippet: &youtube.LiveChatMessageSnippet{
+			PublishedAt: "not-a-timestamp",
+			Type:        youtubebot.TextMessageEvent,
+			TextMessageDetails: &youtube.LiveChatTextMessageDetails{
+				MessageText: "hello",
+			},
+		},
+	}
+	_, err := BuildLiveChatIngestMessage(message)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "published at")
+}


### PR DESCRIPTION
## 概要

P1 runtime cutoverで YouTube API message を source-aware durable ingestへ渡すため、1 message → `repository.LiveChatIngestMessage` の変換を専用helperへ分離します。

既存runtime loopはまだ変更しません。

## `BuildLiveChatIngestMessage`

既存 `AddLiveChatHistoryDoc` と同じHistory内容を構築します。

- author channel ID
- raw display name
- profile image URL
- moderator flag
- message ID / live chat ID
- author text
- published-atをRFC3339Nano parse後JSTへ変換
- event type

加えて durable Inbox processing用に:
- owner flag
- sponsor/member source flag

を `LiveChatIngestMessage` の別metadataとして保持します。

History schema自体は変更せず、Inbox側で legacy同等のdisplay-name正規化とeffective member計算を行う既存 #1012 の責務を維持します。

## Defensive validation

runtime cutover前に入力境界を明示するため、以下をerrorにします。
- nil message
- nil snippet
- nil author details
- author textを持たないevent
- invalid published-at

## テスト

- text messageの全History field変換
- raw `@Member User` display nameがHistoryでは保持されること
- sponsor / owner metadataの保持
- RFC3339Nano → JST変換
- incomplete source rejection
- invalid timestamp rejection

## 次段

youtube-bot durable ingest loopでは各text messageをこのhelperで変換し、`IngestLiveChatSourcePage` へ渡します。

## Acceptance criteria

- System Go Test成功
- Go Lint成功
- Generated Files Up-to-Date成功
- CI Gate成功
- 現行youtube-bot runtime挙動変更なし
