### PR TITLE
Wire durable live chat ingest behind runtime flag

### DIFF
--- a/system/cmd/youtube-bot/durable_ingest.go
+++ b/system/cmd/youtube-bot/durable_ingest.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"google.golang.org/api/youtube/v3"
+
+	"app.modules/core/repository"
+	"app.modules/core/workspaceapp"
+	"app.modules/core/youtubebot"
+)
+
+const durableLiveChatIngestEnabledEnv = "DURABLE_LIVE_CHAT_INGEST_ENABLED"
+
+type durableLiveChatPageIngester interface {
+	IngestLiveChatSourcePage(
+		ctx context.Context,
+		liveChatID string,
+		expectedPageToken string,
+		nextPageToken string,
+		messages []repository.LiveChatIngestMessage,
+		ingestedAt time.Time,
+	) error
+}
+
+func readDurableLiveChatIngestEnabled() (bool, error) {
+	raw := strings.TrimSpace(os.Getenv(durableLiveChatIngestEnabledEnv))
+	if raw == "" {
+		return false, nil
+	}
+	enabled, err := strconv.ParseBool(raw)
+	if err != nil {
+		return false, fmt.Errorf("parse %s: %w", durableLiveChatIngestEnabledEnv, err)
+	}
+	return enabled, nil
+}
+
+func ingestFetchedLiveChatPage(
+	ctx context.Context,
+	ingester durableLiveChatPageIngester,
+	liveChatID string,
+	expectedPageToken string,
+	nextPageToken string,
+	chatMessages []*youtube.LiveChatMessage,
+	ingestedAt time.Time,
+) error {
+	sourceMessages := make([]repository.LiveChatIngestMessage, 0, len(chatMessages))
+	for i, chatMessage := range chatMessages {
+		if chatMessage == nil {
+			return fmt.Errorf("live chat message at index %d is nil", i)
+		}
+		if chatMessage.Snippet == nil {
+			return fmt.Errorf("live chat message at index %d has nil snippet", i)
+		}
+		if !youtubebot.HasTextMessageByAuthor(chatMessage) {
+			continue
+		}
+		sourceMessage, err := workspaceapp.BuildLiveChatIngestMessage(chatMessage)
+		if err != nil {
+			return fmt.Errorf("build durable live chat ingest message at index %d: %w", i, err)
+		}
+		sourceMessages = append(sourceMessages, sourceMessage)
+	}
+
+	if err := ingester.IngestLiveChatSourcePage(
+		ctx,
+		liveChatID,
+		expectedPageToken,
+		nextPageToken,
+		sourceMessages,
+		ingestedAt,
+	); err != nil {
+		return fmt.Errorf("ingest durable live chat page: %w", err)
+	}
+	return nil
+}

--- a/system/cmd/youtube-bot/durable_ingest_test.go
+++ b/system/cmd/youtube-bot/durable_ingest_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/youtube/v3"
+
+	"app.modules/core/repository"
+	"app.modules/core/youtubebot"
+)
+
+type fakeDurableLiveChatPageIngester struct {
+	calls             int
+	liveChatID        string
+	expectedPageToken string
+	nextPageToken     string
+	messages          []repository.LiveChatIngestMessage
+	ingestedAt        time.Time
+	err               error
+}
+
+func (f *fakeDurableLiveChatPageIngester) IngestLiveChatSourcePage(
+	_ context.Context,
+	liveChatID string,
+	expectedPageToken string,
+	nextPageToken string,
+	messages []repository.LiveChatIngestMessage,
+	ingestedAt time.Time,
+) error {
+	f.calls++
+	f.liveChatID = liveChatID
+	f.expectedPageToken = expectedPageToken
+	f.nextPageToken = nextPageToken
+	f.messages = append([]repository.LiveChatIngestMessage(nil), messages...)
+	f.ingestedAt = ingestedAt
+	return f.err
+}
+
+func TestReadDurableLiveChatIngestEnabled(t *testing.T) {
+	t.Run("default off", func(t *testing.T) {
+		t.Setenv(durableLiveChatIngestEnabledEnv, "")
+		enabled, err := readDurableLiveChatIngestEnabled()
+		require.NoError(t, err)
+		assert.False(t, enabled)
+	})
+
+	t.Run("explicit true", func(t *testing.T) {
+		t.Setenv(durableLiveChatIngestEnabledEnv, " true ")
+		enabled, err := readDurableLiveChatIngestEnabled()
+		require.NoError(t, err)
+		assert.True(t, enabled)
+	})
+
+	t.Run("invalid value", func(t *testing.T) {
+		t.Setenv(durableLiveChatIngestEnabledEnv, "sometimes")
+		_, err := readDurableLiveChatIngestEnabled()
+		require.Error(t, err)
+		assert.ErrorContains(t, err, durableLiveChatIngestEnabledEnv)
+	})
+}
+
+func TestIngestFetchedLiveChatPagePersistsOnlyAuthorTextMessages(t *testing.T) {
+	ingester := &fakeDurableLiveChatPageIngester{}
+	ingestedAt := time.Date(2026, 8, 15, 1, 30, 0, 0, time.UTC)
+	messages := []*youtube.LiveChatMessage{
+		{
+			Id: "text-1",
+			AuthorDetails: &youtube.LiveChatMessageAuthorDetails{
+				ChannelId:   "author-1",
+				DisplayName: "Viewer",
+			},
+			Snippet: &youtube.LiveChatMessageSnippet{
+				LiveChatId:  "chat-1",
+				PublishedAt: "2026-08-15T01:29:00Z",
+				Type:        youtubebot.TextMessageEvent,
+				TextMessageDetails: &youtube.LiveChatTextMessageDetails{
+					MessageText: "!info",
+				},
+			},
+		},
+		{
+			Id: "sponsor-event",
+			AuthorDetails: &youtube.LiveChatMessageAuthorDetails{
+				ChannelId: "author-2",
+			},
+			Snippet: &youtube.LiveChatMessageSnippet{
+				LiveChatId:  "chat-1",
+				PublishedAt: "2026-08-15T01:29:30Z",
+				Type:        youtubebot.NewSponsorEvent,
+			},
+		},
+	}
+
+	err := ingestFetchedLiveChatPage(
+		context.Background(),
+		ingester,
+		"chat-1",
+		"page-a",
+		"page-b",
+		messages,
+		ingestedAt,
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 1, ingester.calls)
+	assert.Equal(t, "chat-1", ingester.liveChatID)
+	assert.Equal(t, "page-a", ingester.expectedPageToken)
+	assert.Equal(t, "page-b", ingester.nextPageToken)
+	assert.Equal(t, ingestedAt, ingester.ingestedAt)
+	require.Len(t, ingester.messages, 1)
+	assert.Equal(t, "text-1", ingester.messages[0].History.ID)
+	assert.Equal(t, "!info", ingester.messages[0].History.MessageText)
+}
+
+func TestIngestFetchedLiveChatPageAdvancesEmptyPage(t *testing.T) {
+	ingester := &fakeDurableLiveChatPageIngester{}
+	ingestedAt := time.Date(2026, 8, 15, 1, 31, 0, 0, time.UTC)
+
+	require.NoError(t, ingestFetchedLiveChatPage(
+		context.Background(),
+		ingester,
+		"chat-1",
+		"page-a",
+		"page-b",
+		nil,
+		ingestedAt,
+	))
+	assert.Equal(t, 1, ingester.calls)
+	assert.Empty(t, ingester.messages)
+	assert.Equal(t, "page-b", ingester.nextPageToken)
+}
+
+func TestIngestFetchedLiveChatPageRejectsMalformedSourceBeforeCommit(t *testing.T) {
+	ingester := &fakeDurableLiveChatPageIngester{}
+
+	err := ingestFetchedLiveChatPage(
+		context.Background(),
+		ingester,
+		"chat-1",
+		"page-a",
+		"page-b",
+		[]*youtube.LiveChatMessage{nil},
+		time.Now(),
+	)
+	require.Error(t, err)
+	assert.Zero(t, ingester.calls)
+}
+
+func TestIngestFetchedLiveChatPageWrapsRepositoryFailure(t *testing.T) {
+	ingester := &fakeDurableLiveChatPageIngester{err: errors.New("firestore unavailable")}
+
+	err := ingestFetchedLiveChatPage(
+		context.Background(),
+		ingester,
+		"chat-1",
+		"page-a",
+		"page-b",
+		nil,
+		time.Now(),
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "durable live chat page")
+	assert.ErrorContains(t, err, "firestore unavailable")
+}

--- a/system/cmd/youtube-bot/main.go
+++ b/system/cmd/youtube-bot/main.go
@@ -78,6 +78,27 @@ func Bot(ctx context.Context, clientOption option.ClientOption) {
 	}
 	defer app.CloseFirestoreClient()
 
+	durableLiveChatIngestEnabled, err := readDurableLiveChatIngestEnabled()
+	if err != nil {
+		app.MessageToOwnerWithError(ctx, "failed to read durable live chat ingest feature flag", err)
+		return
+	}
+	var durablePageIngester durableLiveChatPageIngester
+	var durableLiveChatID string
+	if durableLiveChatIngestEnabled {
+		var ok bool
+		durablePageIngester, ok = app.Repository.(durableLiveChatPageIngester)
+		if !ok {
+			app.MessageToOwnerWithError(ctx, "failed to enable durable live chat ingest", errors.New("repository does not support durable live chat page ingest"))
+			return
+		}
+		durableLiveChatID, err = app.Repository.ReadLiveChatID(ctx, nil)
+		if err != nil {
+			app.MessageToOwnerWithError(ctx, "failed to read live chat ID for durable ingest", err)
+			return
+		}
+	}
+
 	ngWordConfig, err := loadNGWordConfig(ctx, clientOption, app.Configs.Constants.BotConfigSpreadsheetID)
 	if err != nil {
 		app.MessageToOwnerWithError(ctx, "failed loadNGWordConfig()", err)
@@ -85,6 +106,9 @@ func Bot(ctx context.Context, clientOption option.ClientOption) {
 	}
 
 	app.MessageToOwner(ctx, fmt.Sprintf("Botが起動しました。\n全規制ワード数: %d", ngWordConfig.Count()))
+	if durableLiveChatIngestEnabled {
+		app.MessageToOwner(ctx, "Durable live chat ingest shadow mode is enabled.")
+	}
 	defer func() { // when error occurred
 		app.MessageToLiveChat(ctx, "エラーが起きたため終了します。お手数ですが管理者に連絡してください。")
 		app.MessageToOwner(ctx, "app stopped!!")
@@ -151,7 +175,30 @@ func Bot(ctx context.Context, clientOption option.ClientOption) {
 		}
 		lastChatFetched = timeutil.JstNow()
 
-		// save nextPageToken
+		// In shadow mode, durable ingest owns live-chat-history writes and advances
+		// its StreamState atomically with the Inbox. A failed durable write must not
+		// advance the legacy checkpoint, otherwise the next poll could skip a page.
+		if durableLiveChatIngestEnabled {
+			if err := ingestFetchedLiveChatPage(
+				ctx,
+				durablePageIngester,
+				durableLiveChatID,
+				pageToken,
+				nextPageToken,
+				chatMessages,
+				lastChatFetched,
+			); err != nil {
+				app.MessageToOwnerWithError(ctx, "failed durable live chat page ingest", err)
+				time.Sleep(3 * time.Second)
+				continue
+			}
+		}
+
+		// Keep the legacy page-token checkpoint synchronized so disabling shadow
+		// mode is an immediate rollback. If synchronization cannot be confirmed in
+		// durable mode, do not process the page yet; refetching the same page is
+		// idempotent on the durable side and avoids direct ProcessMessage replay.
+		legacyPageTokenSaved := true
 		if err := app.SaveNextPageToken(ctx, nextPageToken); err != nil {
 			app.MessageToOwnerWithError(ctx, "(1回目) failed to save next page token", err)
 			// 少し待ってから再試行
@@ -159,23 +206,31 @@ func Bot(ctx context.Context, clientOption option.ClientOption) {
 			err2 := app.SaveNextPageToken(ctx, nextPageToken)
 			if err2 != nil {
 				app.MessageToOwnerWithError(ctx, "(2回目) failed to save next page token", err2)
-				// pass
+				legacyPageTokenSaved = false
 			}
 		}
+		if durableLiveChatIngestEnabled && !legacyPageTokenSaved {
+			time.Sleep(3 * time.Second)
+			continue
+		}
 
-		// chatMessagesを保存
-		for _, chatMessage := range chatMessages {
-			// only if chatMessage has a text message
-			if !youtubebot.HasTextMessageByAuthor(chatMessage) {
-				continue
-			}
+		// Legacy mode keeps the historical writer unchanged. Durable shadow mode
+		// already wrote the same schema under deterministic message IDs, so running
+		// both writers would duplicate analytics rows.
+		if !durableLiveChatIngestEnabled {
+			for _, chatMessage := range chatMessages {
+				// only if chatMessage has a text message
+				if !youtubebot.HasTextMessageByAuthor(chatMessage) {
+					continue
+				}
 
-			if err = app.AddLiveChatHistoryDoc(ctx, chatMessage); err != nil {
-				app.MessageToOwnerWithError(ctx, "(1回目) failed to add live chat history", err)
-				time.Sleep(2 * time.Second)
-				if err2 := app.AddLiveChatHistoryDoc(ctx, chatMessage); err2 != nil {
-					app.MessageToOwnerWithError(ctx, "(2回目) failed to add live chat history", err2)
-					// pass
+				if err = app.AddLiveChatHistoryDoc(ctx, chatMessage); err != nil {
+					app.MessageToOwnerWithError(ctx, "(1回目) failed to add live chat history", err)
+					time.Sleep(2 * time.Second)
+					if err2 := app.AddLiveChatHistoryDoc(ctx, chatMessage); err2 != nil {
+						app.MessageToOwnerWithError(ctx, "(2回目) failed to add live chat history", err2)
+						// pass
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## 概要

P1 durable chat migration の runtime ingest を **default OFF の feature flag** の後ろへ接続します。

`DURABLE_LIVE_CHAT_INGEST_ENABLED` が未設定/falseなら現行 youtube-bot の挙動は変更しません。trueの場合のみ、取得した1ページを durable `Inbox + deterministic live-chat-history + StreamState` へ原子的に保存します。

**このPRでは durable worker への command cutoverはまだ行いません。flagは後続cutover準備が整うまでproductionで有効化しない前提です。**

## ON時の順序

1. legacy credentials の page token で YouTube API をpoll
2. author text messageを `BuildLiveChatIngestMessage` でsource-aware shapeへ変換
3. `IngestLiveChatSourcePage(expectedToken -> nextToken)`
   - Inbox
   - deterministic history
   - StreamState
   を同一Firestore transactionでcommit
4. durable ingest成功後に legacy page token も同期
   - feature flagをOFFに戻した際のrollback checkpointとして維持
5. legacy `ProcessMessage` は現時点ではそのまま実行

## Failure semantics

- durable ingest失敗: legacy page tokenを進めず、そのページを再取得
- durable ingest成功後にlegacy checkpoint同期が2回失敗: direct `ProcessMessage` を実行せず再取得
  - durable側はexact replayをidempotentに受理
  - direct command replayを避ける
- flag OFF: 既存のcheckpoint/history/processフローをそのまま維持

## History writer

flag ON時は durable ingest が `live-chat-history` も保存するため、旧 `AddLiveChatHistoryDoc` loopは実行しません。両方を実行すると同じsource messageがrandom ID + deterministic IDで二重保存されるためです。

## Helper / tests

`durable_ingest.go`:
- feature flag parse（default false）
- empty pageでもStreamState advance
- author text messageのみdurable sourceへ変換
- malformed sourceはcommit前に拒否
- repository error wrap

## 重要な境界

このPRだけではproduction flagをONにしません。ONにするとPending Inboxが蓄積するため、後続のworker/cutoverで「shadow期間のInboxを再適用しない」境界を完成させてから有効化します。

## Acceptance criteria

- System Go Test成功
- Go Lint成功
- Generated Files Up-to-Date成功
- CI Gate成功
- flag未設定/falseでruntime挙動変更なし
- flag trueでdurable ingestがlegacy checkpointより先に成功必須
- flag trueでlegacy history二重保存なし
