### PR TITLE
Add leased live chat reply delivery worker

### DIFF
--- a/system/core/workspaceapp/live_chat_reply_delivery.go
+++ b/system/core/workspaceapp/live_chat_reply_delivery.go
@@ -1,0 +1,201 @@
+package workspaceapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"app.modules/core/repository"
+)
+
+// LiveChatReplyDeliveryRepository is the narrow persistence port required by
+// the external YouTube reply worker. The Firestore implementation already
+// provides lease/retry/dead-letter semantics for these operations.
+type LiveChatReplyDeliveryRepository interface {
+	ListClaimableLiveChatReplies(
+		ctx context.Context,
+		liveChatID string,
+		now time.Time,
+		limit int,
+	) ([]repository.LiveChatReplyOutboxDoc, error)
+	ClaimLiveChatReply(
+		ctx context.Context,
+		liveChatID, sourceMessageID, intentSlot, workerID string,
+		now time.Time,
+		leaseDuration time.Duration,
+		maxAttempts int,
+	) (repository.LiveChatReplyOutboxDoc, error)
+	CompleteLiveChatReply(
+		ctx context.Context,
+		liveChatID, sourceMessageID, intentSlot, workerID string,
+		now time.Time,
+	) error
+	FailLiveChatReply(
+		ctx context.Context,
+		liveChatID, sourceMessageID, intentSlot, workerID string,
+		now time.Time,
+		maxAttempts int,
+		retryDelay time.Duration,
+		deliveryErr error,
+	) (repository.LiveChatReplyOutboxStatus, error)
+}
+
+type LiveChatReplySender interface {
+	PostMessage(ctx context.Context, message string) error
+}
+
+type LiveChatReplyDeliveryOptions struct {
+	LeaseDuration time.Duration
+	RetryDelay    time.Duration
+	MaxAttempts   int
+}
+
+func (o LiveChatReplyDeliveryOptions) validate() error {
+	if o.LeaseDuration <= 0 {
+		return fmt.Errorf("reply lease duration must be positive: %s", o.LeaseDuration)
+	}
+	if o.RetryDelay < 0 {
+		return fmt.Errorf("reply retry delay must not be negative: %s", o.RetryDelay)
+	}
+	if o.MaxAttempts <= 0 {
+		return fmt.Errorf("reply max attempts must be positive: %d", o.MaxAttempts)
+	}
+	return nil
+}
+
+type LiveChatReplyDeliveryResult struct {
+	DidWork         bool
+	SourceMessageID string
+	IntentSlot      string
+	Status          repository.LiveChatReplyOutboxStatus
+}
+
+type LiveChatReplyDeliveryWorker struct {
+	repository LiveChatReplyDeliveryRepository
+	sender     LiveChatReplySender
+	now        func() time.Time
+}
+
+func NewLiveChatReplyDeliveryWorker(
+	repo LiveChatReplyDeliveryRepository,
+	sender LiveChatReplySender,
+) *LiveChatReplyDeliveryWorker {
+	return &LiveChatReplyDeliveryWorker{
+		repository: repo,
+		sender:     sender,
+		now:        time.Now,
+	}
+}
+
+// DeliverNext delivers at most one reply intent. Limiting each pass to the
+// first claimable item preserves source ordering within one live chat and makes
+// retry behavior explicit. Concurrent workers are still safe because Claim is
+// the transactional authority.
+//
+// YouTube's live-chat insert API has no idempotency key. Therefore outbound
+// delivery is at-least-once: if PostMessage succeeds but the process crashes or
+// CompleteLiveChatReply fails before the durable Delivered marker commits, the
+// item may be sent again after its lease expires.
+func (w *LiveChatReplyDeliveryWorker) DeliverNext(
+	ctx context.Context,
+	liveChatID string,
+	workerID string,
+	options LiveChatReplyDeliveryOptions,
+) (LiveChatReplyDeliveryResult, error) {
+	if w == nil || w.repository == nil {
+		return LiveChatReplyDeliveryResult{}, errors.New("live chat reply delivery repository is nil")
+	}
+	if w.sender == nil {
+		return LiveChatReplyDeliveryResult{}, errors.New("live chat reply sender is nil")
+	}
+	if w.now == nil {
+		return LiveChatReplyDeliveryResult{}, errors.New("live chat reply delivery clock is nil")
+	}
+	if err := options.validate(); err != nil {
+		return LiveChatReplyDeliveryResult{}, err
+	}
+
+	now := w.now()
+	items, err := w.repository.ListClaimableLiveChatReplies(ctx, liveChatID, now, 1)
+	if err != nil {
+		return LiveChatReplyDeliveryResult{}, fmt.Errorf("list claimable live chat replies: %w", err)
+	}
+	if len(items) == 0 {
+		return LiveChatReplyDeliveryResult{}, nil
+	}
+	candidate := items[0]
+
+	claimed, err := w.repository.ClaimLiveChatReply(
+		ctx,
+		candidate.LiveChatID,
+		candidate.SourceMessageID,
+		candidate.IntentSlot,
+		workerID,
+		now,
+		options.LeaseDuration,
+		options.MaxAttempts,
+	)
+	if err != nil {
+		if errors.Is(err, repository.ErrLiveChatReplyNotClaimable) {
+			// Another worker won the race after the advisory list query.
+			return LiveChatReplyDeliveryResult{}, nil
+		}
+		result := LiveChatReplyDeliveryResult{
+			DidWork:         errors.Is(err, repository.ErrLiveChatReplyRetryExhausted),
+			SourceMessageID: candidate.SourceMessageID,
+			IntentSlot:      candidate.IntentSlot,
+		}
+		if errors.Is(err, repository.ErrLiveChatReplyRetryExhausted) {
+			result.Status = repository.LiveChatReplyOutboxDeadLettered
+		}
+		return result, fmt.Errorf("claim live chat reply: %w", err)
+	}
+
+	result := LiveChatReplyDeliveryResult{
+		DidWork:         true,
+		SourceMessageID: claimed.SourceMessageID,
+		IntentSlot:      claimed.IntentSlot,
+		Status:          claimed.Status,
+	}
+
+	if err := w.sender.PostMessage(ctx, claimed.Message); err != nil {
+		failedAt := w.now()
+		status, recordErr := w.repository.FailLiveChatReply(
+			ctx,
+			claimed.LiveChatID,
+			claimed.SourceMessageID,
+			claimed.IntentSlot,
+			workerID,
+			failedAt,
+			options.MaxAttempts,
+			options.RetryDelay,
+			err,
+		)
+		result.Status = status
+		if recordErr != nil {
+			return result, errors.Join(
+				fmt.Errorf("post live chat reply: %w", err),
+				fmt.Errorf("record live chat reply failure: %w", recordErr),
+			)
+		}
+		return result, fmt.Errorf("post live chat reply: %w", err)
+	}
+
+	completedAt := w.now()
+	if err := w.repository.CompleteLiveChatReply(
+		ctx,
+		claimed.LiveChatID,
+		claimed.SourceMessageID,
+		claimed.IntentSlot,
+		workerID,
+		completedAt,
+	); err != nil {
+		return result, fmt.Errorf(
+			"complete live chat reply after external post; delivery may repeat after lease expiry: %w",
+			err,
+		)
+	}
+	result.Status = repository.LiveChatReplyOutboxDelivered
+	return result, nil
+}

--- a/system/core/workspaceapp/live_chat_reply_delivery_test.go
+++ b/system/core/workspaceapp/live_chat_reply_delivery_test.go
@@ -1,0 +1,250 @@
+package workspaceapp
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"app.modules/core/repository"
+)
+
+type fakeLiveChatReplyDeliveryRepository struct {
+	items          []repository.LiveChatReplyOutboxDoc
+	listErr        error
+	claimResult    repository.LiveChatReplyOutboxDoc
+	claimErr       error
+	completeErr    error
+	failStatus     repository.LiveChatReplyOutboxStatus
+	failErr        error
+	listLimit      int
+	claimCalls     int
+	completeCalls  int
+	failCalls      int
+	claimedWorker  string
+	completeWorker string
+	failedWorker   string
+}
+
+func (f *fakeLiveChatReplyDeliveryRepository) ListClaimableLiveChatReplies(
+	_ context.Context,
+	_ string,
+	_ time.Time,
+	limit int,
+) ([]repository.LiveChatReplyOutboxDoc, error) {
+	f.listLimit = limit
+	return f.items, f.listErr
+}
+
+func (f *fakeLiveChatReplyDeliveryRepository) ClaimLiveChatReply(
+	_ context.Context,
+	_, _, _, workerID string,
+	_ time.Time,
+	_ time.Duration,
+	_ int,
+) (repository.LiveChatReplyOutboxDoc, error) {
+	f.claimCalls++
+	f.claimedWorker = workerID
+	return f.claimResult, f.claimErr
+}
+
+func (f *fakeLiveChatReplyDeliveryRepository) CompleteLiveChatReply(
+	_ context.Context,
+	_, _, _, workerID string,
+	_ time.Time,
+) error {
+	f.completeCalls++
+	f.completeWorker = workerID
+	return f.completeErr
+}
+
+func (f *fakeLiveChatReplyDeliveryRepository) FailLiveChatReply(
+	_ context.Context,
+	_, _, _, workerID string,
+	_ time.Time,
+	_ int,
+	_ time.Duration,
+	_ error,
+) (repository.LiveChatReplyOutboxStatus, error) {
+	f.failCalls++
+	f.failedWorker = workerID
+	return f.failStatus, f.failErr
+}
+
+type fakeLiveChatReplySender struct {
+	messages []string
+	err      error
+}
+
+func (f *fakeLiveChatReplySender) PostMessage(_ context.Context, message string) error {
+	f.messages = append(f.messages, message)
+	return f.err
+}
+
+func testReplyIntent() repository.LiveChatReplyOutboxDoc {
+	return repository.LiveChatReplyOutboxDoc{
+		LiveChatID:      "chat-1",
+		SourceMessageID: "message-1",
+		IntentSlot:      "primary",
+		SourceSequence:  7,
+		Message:         "reply text",
+		Status:          repository.LiveChatReplyOutboxPending,
+	}
+}
+
+func testReplyDeliveryOptions() LiveChatReplyDeliveryOptions {
+	return LiveChatReplyDeliveryOptions{
+		LeaseDuration: 30 * time.Second,
+		RetryDelay:    5 * time.Second,
+		MaxAttempts:   3,
+	}
+}
+
+func TestLiveChatReplyDeliveryWorkerNoWork(t *testing.T) {
+	repo := &fakeLiveChatReplyDeliveryRepository{}
+	sender := &fakeLiveChatReplySender{}
+	worker := NewLiveChatReplyDeliveryWorker(repo, sender)
+	worker.now = func() time.Time { return time.Date(2026, 8, 15, 1, 0, 0, 0, time.UTC) }
+
+	result, err := worker.DeliverNext(context.Background(), "chat-1", "worker-a", testReplyDeliveryOptions())
+	require.NoError(t, err)
+	assert.False(t, result.DidWork)
+	assert.Equal(t, 1, repo.listLimit, "only the head reply should be considered per pass")
+	assert.Zero(t, repo.claimCalls)
+	assert.Empty(t, sender.messages)
+}
+
+func TestLiveChatReplyDeliveryWorkerSuccess(t *testing.T) {
+	intent := testReplyIntent()
+	claimed := intent
+	claimed.Status = repository.LiveChatReplyOutboxDelivering
+	repo := &fakeLiveChatReplyDeliveryRepository{
+		items:       []repository.LiveChatReplyOutboxDoc{intent},
+		claimResult: claimed,
+	}
+	sender := &fakeLiveChatReplySender{}
+	worker := NewLiveChatReplyDeliveryWorker(repo, sender)
+	worker.now = func() time.Time { return time.Date(2026, 8, 15, 1, 0, 0, 0, time.UTC) }
+
+	result, err := worker.DeliverNext(context.Background(), "chat-1", "worker-a", testReplyDeliveryOptions())
+	require.NoError(t, err)
+	assert.True(t, result.DidWork)
+	assert.Equal(t, repository.LiveChatReplyOutboxDelivered, result.Status)
+	assert.Equal(t, []string{"reply text"}, sender.messages)
+	assert.Equal(t, 1, repo.claimCalls)
+	assert.Equal(t, 1, repo.completeCalls)
+	assert.Zero(t, repo.failCalls)
+	assert.Equal(t, "worker-a", repo.claimedWorker)
+	assert.Equal(t, "worker-a", repo.completeWorker)
+}
+
+func TestLiveChatReplyDeliveryWorkerRecordsSendFailureAndStops(t *testing.T) {
+	intent := testReplyIntent()
+	claimed := intent
+	claimed.Status = repository.LiveChatReplyOutboxDelivering
+	repo := &fakeLiveChatReplyDeliveryRepository{
+		items:       []repository.LiveChatReplyOutboxDoc{intent},
+		claimResult: claimed,
+		failStatus:  repository.LiveChatReplyOutboxPending,
+	}
+	senderErr := errors.New("youtube unavailable")
+	sender := &fakeLiveChatReplySender{err: senderErr}
+	worker := NewLiveChatReplyDeliveryWorker(repo, sender)
+	worker.now = func() time.Time { return time.Date(2026, 8, 15, 1, 0, 0, 0, time.UTC) }
+
+	result, err := worker.DeliverNext(context.Background(), "chat-1", "worker-a", testReplyDeliveryOptions())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, senderErr)
+	assert.True(t, result.DidWork)
+	assert.Equal(t, repository.LiveChatReplyOutboxPending, result.Status)
+	assert.Equal(t, 1, repo.failCalls)
+	assert.Zero(t, repo.completeCalls)
+	assert.Equal(t, "worker-a", repo.failedWorker)
+}
+
+func TestLiveChatReplyDeliveryWorkerReturnsBothSendAndFailureRecordErrors(t *testing.T) {
+	intent := testReplyIntent()
+	claimed := intent
+	claimed.Status = repository.LiveChatReplyOutboxDelivering
+	senderErr := errors.New("youtube unavailable")
+	recordErr := errors.New("firestore unavailable")
+	repo := &fakeLiveChatReplyDeliveryRepository{
+		items:       []repository.LiveChatReplyOutboxDoc{intent},
+		claimResult: claimed,
+		failErr:     recordErr,
+	}
+	sender := &fakeLiveChatReplySender{err: senderErr}
+	worker := NewLiveChatReplyDeliveryWorker(repo, sender)
+	worker.now = time.Now
+
+	_, err := worker.DeliverNext(context.Background(), "chat-1", "worker-a", testReplyDeliveryOptions())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, senderErr)
+	assert.ErrorIs(t, err, recordErr)
+}
+
+func TestLiveChatReplyDeliveryWorkerTreatsClaimRaceAsNoWork(t *testing.T) {
+	intent := testReplyIntent()
+	repo := &fakeLiveChatReplyDeliveryRepository{
+		items:    []repository.LiveChatReplyOutboxDoc{intent},
+		claimErr: repository.ErrLiveChatReplyNotClaimable,
+	}
+	sender := &fakeLiveChatReplySender{}
+	worker := NewLiveChatReplyDeliveryWorker(repo, sender)
+	worker.now = time.Now
+
+	result, err := worker.DeliverNext(context.Background(), "chat-1", "worker-a", testReplyDeliveryOptions())
+	require.NoError(t, err)
+	assert.False(t, result.DidWork)
+	assert.Empty(t, sender.messages)
+}
+
+func TestLiveChatReplyDeliveryWorkerSurfacesDeadLetterOnExhaustedClaim(t *testing.T) {
+	intent := testReplyIntent()
+	repo := &fakeLiveChatReplyDeliveryRepository{
+		items:    []repository.LiveChatReplyOutboxDoc{intent},
+		claimErr: repository.ErrLiveChatReplyRetryExhausted,
+	}
+	worker := NewLiveChatReplyDeliveryWorker(repo, &fakeLiveChatReplySender{})
+	worker.now = time.Now
+
+	result, err := worker.DeliverNext(context.Background(), "chat-1", "worker-a", testReplyDeliveryOptions())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, repository.ErrLiveChatReplyRetryExhausted)
+	assert.True(t, result.DidWork)
+	assert.Equal(t, repository.LiveChatReplyOutboxDeadLettered, result.Status)
+}
+
+func TestLiveChatReplyDeliveryWorkerWarnsWhenCompletionFailsAfterPost(t *testing.T) {
+	intent := testReplyIntent()
+	claimed := intent
+	claimed.Status = repository.LiveChatReplyOutboxDelivering
+	completeErr := errors.New("commit lost")
+	repo := &fakeLiveChatReplyDeliveryRepository{
+		items:       []repository.LiveChatReplyOutboxDoc{intent},
+		claimResult: claimed,
+		completeErr: completeErr,
+	}
+	worker := NewLiveChatReplyDeliveryWorker(repo, &fakeLiveChatReplySender{})
+	worker.now = time.Now
+
+	result, err := worker.DeliverNext(context.Background(), "chat-1", "worker-a", testReplyDeliveryOptions())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, completeErr)
+	assert.ErrorContains(t, err, "delivery may repeat")
+	assert.True(t, result.DidWork)
+	assert.Equal(t, repository.LiveChatReplyOutboxDelivering, result.Status)
+}
+
+func TestLiveChatReplyDeliveryWorkerRejectsInvalidOptionsBeforeRepositoryAccess(t *testing.T) {
+	repo := &fakeLiveChatReplyDeliveryRepository{}
+	worker := NewLiveChatReplyDeliveryWorker(repo, &fakeLiveChatReplySender{})
+	worker.now = time.Now
+
+	_, err := worker.DeliverNext(context.Background(), "chat-1", "worker-a", LiveChatReplyDeliveryOptions{})
+	require.Error(t, err)
+	assert.Zero(t, repo.listLimit)
+}


### PR DESCRIPTION
## 概要

P1 durable chat migration の Outbox 配送側を実行可能にします。

`live-chat-reply-outbox` の既存 lease / retry / dead-letter APIを使い、YouTube live chatへ返信を配送する小さなworkerを追加します。runtime loopへの起動接続はこのPRでは行いません。

## 設計

`LiveChatReplyDeliveryWorker.DeliverNext` は1回に最大1件だけ扱います。

1. claimable repliesを `limit=1` で取得
2. transactional claim
3. `PostMessage`
4. 成功: Deliveredをcommit
5. 失敗: Pending + retry delay または DeadLetteredをcommit

listはadvisory、claimが競合時の最終権限です。別workerにclaimを取られた場合はno-workとして終了します。

## Reply ordering

一度に先頭1件だけ扱うことで、1 worker内で後続replyを失敗itemより先に送らない構造にします。

## 外部APIのexactly-once境界

YouTube live-chat insert APIにはidempotency keyがないため、outbound replyは厳密には at-least-once です。

`PostMessage` 成功後にプロセスが落ちる、または `CompleteLiveChatReply` がcommitできない場合、lease失効後に同じreplyが再送される可能性があります。そのケースのerrorには `delivery may repeat after lease expiry` を明示します。

Inbound domain effectsについてはInbox effect ledger + Firestore atomic transactionでexactly-once相当を維持し、外部YouTube配送だけをこの既知境界として分離します。

## Tests

- no-work
- successful claim/post/complete
- YouTube送信失敗 → retry記録
- 送信失敗 + failure-state記録失敗の両error保持
- concurrent claim race → no-work
- exhausted claim → dead-letter surfaced
- post成功後のcomplete失敗 → duplicate riskを明示
- invalid optionsをrepository access前に拒否

## Acceptance criteria

- System Go Test成功
- Go Lint成功
- CI Gate成功
- runtime挙動変更なし
