### PR TITLE
Add immutable durable chat processing cutover boundary

### DIFF
--- a/system/core/repository/live_chat_processing_cutover.go
+++ b/system/core/repository/live_chat_processing_cutover.go
@@ -22,9 +22,9 @@ var ErrLiveChatProcessingCutoverCorruptState = errors.New("live chat processing 
 // belong to the legacy-processing era and must never be replayed by the new
 // worker, even when they were captured by durable ingest for observation.
 type LiveChatProcessingCutoverDoc struct {
-	LiveChatID           string    `firestore:"live-chat-id"`
-	ProcessFromSequence  int64     `firestore:"process-from-sequence"`
-	InitializedAt        time.Time `firestore:"initialized-at"`
+	LiveChatID          string    `firestore:"live-chat-id"`
+	ProcessFromSequence int64     `firestore:"process-from-sequence"`
+	InitializedAt       time.Time `firestore:"initialized-at"`
 }
 
 func (c *FirestoreControllerImplements) liveChatProcessingCutoverCollection() *firestore.CollectionRef {

--- a/system/core/repository/live_chat_processing_cutover.go
+++ b/system/core/repository/live_chat_processing_cutover.go
@@ -1,0 +1,169 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/firestore"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const LiveChatProcessingCutover = "live-chat-processing-cutover"
+
+var ErrLiveChatProcessingCutoverCorruptState = errors.New("live chat processing cutover state is inconsistent")
+
+// LiveChatProcessingCutoverDoc freezes the first Inbox sequence that may be
+// executed by the durable command worker. Messages below ProcessFromSequence
+// belong to the legacy-processing era and must never be replayed by the new
+// worker, even when they were captured by durable ingest for observation.
+type LiveChatProcessingCutoverDoc struct {
+	LiveChatID           string    `firestore:"live-chat-id"`
+	ProcessFromSequence  int64     `firestore:"process-from-sequence"`
+	InitializedAt        time.Time `firestore:"initialized-at"`
+}
+
+func (c *FirestoreControllerImplements) liveChatProcessingCutoverCollection() *firestore.CollectionRef {
+	return c.firestoreClient.Collection(LiveChatProcessingCutover)
+}
+
+// EnsureLiveChatProcessingCutover initializes an immutable processing boundary.
+// If durable ingest has already been running in shadow mode, the current
+// StreamState.NextSequence becomes the boundary so all previously captured
+// messages stay owned by the legacy processor. If no StreamState exists yet,
+// durable processing starts from sequence zero.
+//
+// Repeated or concurrent calls return the first committed boundary; it never
+// moves forward after initialization.
+func (c *FirestoreControllerImplements) EnsureLiveChatProcessingCutover(
+	ctx context.Context,
+	liveChatID string,
+	now time.Time,
+) (LiveChatProcessingCutoverDoc, error) {
+	if strings.TrimSpace(liveChatID) == "" {
+		return LiveChatProcessingCutoverDoc{}, errors.New("live chat id is empty")
+	}
+	if now.IsZero() {
+		return LiveChatProcessingCutoverDoc{}, errors.New("cutover initialized at is zero")
+	}
+
+	key, err := LiveChatStreamKey(liveChatID)
+	if err != nil {
+		return LiveChatProcessingCutoverDoc{}, err
+	}
+	cutoverRef := c.liveChatProcessingCutoverCollection().Doc(key)
+	streamRef := c.liveChatStreamStateCollection().Doc(key)
+
+	var result LiveChatProcessingCutoverDoc
+	if err := c.firestoreClient.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
+		doc, err := tx.Get(cutoverRef)
+		if err == nil {
+			if err := doc.DataTo(&result); err != nil {
+				return fmt.Errorf("decode live chat processing cutover: %w", err)
+			}
+			return validateLiveChatProcessingCutover(result, liveChatID)
+		}
+		if status.Code(err) != codes.NotFound {
+			return fmt.Errorf("read live chat processing cutover: %w", err)
+		}
+
+		streamState, streamExists, err := c.readLiveChatStreamState(tx, streamRef)
+		if err != nil {
+			return err
+		}
+		processFromSequence := int64(0)
+		if streamExists {
+			if streamState.LiveChatID != liveChatID || streamState.NextSequence < 0 {
+				return fmt.Errorf("%w: invalid stream state at cutover", ErrLiveChatProcessingCutoverCorruptState)
+			}
+			processFromSequence = streamState.NextSequence
+		}
+
+		result = LiveChatProcessingCutoverDoc{
+			LiveChatID:          liveChatID,
+			ProcessFromSequence: processFromSequence,
+			InitializedAt:       now,
+		}
+		if err := c.create(ctx, tx, cutoverRef, result); err != nil {
+			return fmt.Errorf("create live chat processing cutover: %w", err)
+		}
+		return nil
+	}); err != nil {
+		return LiveChatProcessingCutoverDoc{}, fmt.Errorf("ensure live chat processing cutover transaction: %w", err)
+	}
+	return result, nil
+}
+
+func validateLiveChatProcessingCutover(cutover LiveChatProcessingCutoverDoc, liveChatID string) error {
+	if cutover.LiveChatID != liveChatID {
+		return fmt.Errorf("%w: cutover belongs to a different live chat", ErrLiveChatProcessingCutoverCorruptState)
+	}
+	if cutover.ProcessFromSequence < 0 {
+		return fmt.Errorf("%w: negative process-from sequence", ErrLiveChatProcessingCutoverCorruptState)
+	}
+	if cutover.InitializedAt.IsZero() {
+		return fmt.Errorf("%w: zero initialized-at", ErrLiveChatProcessingCutoverCorruptState)
+	}
+	return nil
+}
+
+// ListClaimableLiveChatInboxMessagesFromSequence is the cutover-aware worker
+// query. It has the same lease semantics as ListClaimableLiveChatInboxMessages
+// but never returns a message from the legacy-processing era.
+func (c *FirestoreControllerImplements) ListClaimableLiveChatInboxMessagesFromSequence(
+	ctx context.Context,
+	liveChatID string,
+	processFromSequence int64,
+	now time.Time,
+	limit int,
+) ([]LiveChatInboxDoc, error) {
+	if strings.TrimSpace(liveChatID) == "" {
+		return nil, errors.New("live chat id is empty")
+	}
+	if processFromSequence < 0 {
+		return nil, fmt.Errorf("process-from sequence must not be negative: %d", processFromSequence)
+	}
+	if now.IsZero() {
+		return nil, errors.New("now is zero")
+	}
+	if limit <= 0 {
+		return nil, fmt.Errorf("limit must be positive: %d", limit)
+	}
+
+	pendingQuery := c.liveChatInboxCollection().
+		Where("live-chat-id", "==", liveChatID).
+		Where("status", "==", LiveChatInboxPending).
+		Where("sequence", ">=", processFromSequence).
+		OrderBy("sequence", firestore.Asc).
+		Limit(limit)
+	pending, err := readLiveChatInboxQuery(ctx, pendingQuery)
+	if err != nil {
+		return nil, fmt.Errorf("list post-cutover pending live chat inbox messages: %w", err)
+	}
+
+	expiredQuery := c.liveChatInboxCollection().
+		Where("live-chat-id", "==", liveChatID).
+		Where("status", "==", LiveChatInboxProcessing).
+		Where("lease-until", "<=", now).
+		Where("sequence", ">=", processFromSequence).
+		OrderBy("lease-until", firestore.Asc).
+		OrderBy("sequence", firestore.Asc).
+		Limit(limit)
+	expired, err := readLiveChatInboxQuery(ctx, expiredQuery)
+	if err != nil {
+		return nil, fmt.Errorf("list post-cutover expired live chat inbox messages: %w", err)
+	}
+
+	messages := append(pending, expired...)
+	sort.SliceStable(messages, func(i, j int) bool {
+		return messages[i].Sequence < messages[j].Sequence
+	})
+	if len(messages) > limit {
+		messages = messages[:limit]
+	}
+	return messages, nil
+}

--- a/system/core/repository/live_chat_processing_cutover_integration_test.go
+++ b/system/core/repository/live_chat_processing_cutover_integration_test.go
@@ -1,0 +1,142 @@
+//go:build integration
+
+package repository_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"app.modules/core/repository"
+	"app.modules/internal/integrationtest"
+)
+
+func TestFirestoreRepository_LiveChatProcessingCutoverStartsAtZeroWithoutShadowState(t *testing.T) {
+	integrationtest.ResetFirestore(t)
+	controller := integrationtest.NewFirestoreController(t)
+	ctx := context.Background()
+	now := time.Date(2026, 8, 15, 2, 0, 0, 0, time.UTC)
+
+	cutover, err := controller.EnsureLiveChatProcessingCutover(ctx, "cutover-empty-chat", now)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), cutover.ProcessFromSequence)
+	assert.Equal(t, "cutover-empty-chat", cutover.LiveChatID)
+	assert.True(t, cutover.InitializedAt.Equal(now))
+}
+
+func TestFirestoreRepository_LiveChatProcessingCutoverSkipsShadowBacklogAndIsImmutable(t *testing.T) {
+	integrationtest.ResetFirestore(t)
+	controller := integrationtest.NewFirestoreController(t)
+	ctx := context.Background()
+	liveChatID := "cutover-shadow-chat"
+	baseTime := time.Date(2026, 8, 15, 2, 10, 0, 0, time.UTC)
+
+	shadowMessages := []repository.LiveChatHistoryDoc{
+		liveChatHistoryDoc(liveChatID, "shadow-1", "author-1", "legacy one", baseTime),
+		liveChatHistoryDoc(liveChatID, "shadow-2", "author-2", "legacy two", baseTime.Add(time.Second)),
+	}
+	require.NoError(t, controller.IngestLiveChatPage(
+		ctx,
+		liveChatID,
+		"",
+		"cursor-shadow",
+		shadowMessages,
+		baseTime.Add(2*time.Second),
+	))
+
+	cutoverAt := baseTime.Add(3 * time.Second)
+	cutover, err := controller.EnsureLiveChatProcessingCutover(ctx, liveChatID, cutoverAt)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), cutover.ProcessFromSequence)
+
+	postCutoverMessage := liveChatHistoryDoc(
+		liveChatID,
+		"durable-1",
+		"author-3",
+		"!info",
+		baseTime.Add(4*time.Second),
+	)
+	require.NoError(t, controller.IngestLiveChatPage(
+		ctx,
+		liveChatID,
+		"cursor-shadow",
+		"cursor-durable",
+		[]repository.LiveChatHistoryDoc{postCutoverMessage},
+		baseTime.Add(5*time.Second),
+	))
+
+	claimable, err := controller.ListClaimableLiveChatInboxMessagesFromSequence(
+		ctx,
+		liveChatID,
+		cutover.ProcessFromSequence,
+		baseTime.Add(6*time.Second),
+		10,
+	)
+	require.NoError(t, err)
+	require.Len(t, claimable, 1)
+	assert.Equal(t, "durable-1", claimable[0].MessageID)
+	assert.Equal(t, int64(2), claimable[0].Sequence)
+
+	// The cutover boundary is immutable even after StreamState advances.
+	again, err := controller.EnsureLiveChatProcessingCutover(ctx, liveChatID, baseTime.Add(time.Hour))
+	require.NoError(t, err)
+	assert.Equal(t, cutover.ProcessFromSequence, again.ProcessFromSequence)
+	assert.True(t, again.InitializedAt.Equal(cutoverAt))
+}
+
+func TestFirestoreRepository_LiveChatProcessingCutoverQueryReclaimsOnlyPostCutoverExpiredLease(t *testing.T) {
+	integrationtest.ResetFirestore(t)
+	controller := integrationtest.NewFirestoreController(t)
+	ctx := context.Background()
+	liveChatID := "cutover-expired-lease-chat"
+	baseTime := time.Date(2026, 8, 15, 2, 20, 0, 0, time.UTC)
+
+	shadow := liveChatHistoryDoc(liveChatID, "shadow-1", "author-1", "legacy", baseTime)
+	require.NoError(t, controller.IngestLiveChatPage(
+		ctx,
+		liveChatID,
+		"",
+		"cursor-shadow",
+		[]repository.LiveChatHistoryDoc{shadow},
+		baseTime.Add(time.Second),
+	))
+	cutover, err := controller.EnsureLiveChatProcessingCutover(ctx, liveChatID, baseTime.Add(2*time.Second))
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), cutover.ProcessFromSequence)
+
+	postCutover := liveChatHistoryDoc(liveChatID, "durable-1", "author-2", "!info", baseTime.Add(3*time.Second))
+	require.NoError(t, controller.IngestLiveChatPage(
+		ctx,
+		liveChatID,
+		"cursor-shadow",
+		"cursor-durable",
+		[]repository.LiveChatHistoryDoc{postCutover},
+		baseTime.Add(4*time.Second),
+	))
+
+	_, err = controller.ClaimLiveChatInboxMessage(
+		ctx,
+		liveChatID,
+		"durable-1",
+		"worker-a",
+		baseTime.Add(5*time.Second),
+		time.Second,
+		3,
+	)
+	require.NoError(t, err)
+
+	claimable, err := controller.ListClaimableLiveChatInboxMessagesFromSequence(
+		ctx,
+		liveChatID,
+		cutover.ProcessFromSequence,
+		baseTime.Add(7*time.Second),
+		10,
+	)
+	require.NoError(t, err)
+	require.Len(t, claimable, 1)
+	assert.Equal(t, "durable-1", claimable[0].MessageID)
+	assert.Equal(t, repository.LiveChatInboxProcessing, claimable[0].Status)
+}


### PR DESCRIPTION
## 概要

P1 durable chat migration の production cutoverで、shadow/legacy期間にdurable Inboxへ観測保存されたメッセージを後から再適用しないための **immutable processing boundary** を追加します。

## Cutover state

新しい `live-chat-processing-cutover` stateに以下を1回だけ固定します。

- live-chat-id
- process-from-sequence
- initialized-at

`EnsureLiveChatProcessingCutover` の初回実行時:
- StreamStateが存在する → 現在の `NextSequence` を process-from にする
- StreamStateが存在しない → 0から開始

一度commitされたboundaryは、その後StreamStateが進んでも変更しません。並行初期化もFirestore transactionで最初のcommitへ収束します。

## なぜ必要か

#1016 のingest flagはdefault OFFですが、cutover前にshadow ingestを使った場合、Inboxにはlegacy `ProcessMessage` が既に扱った可能性のあるメッセージが残ります。

新workerがそれらを無条件にclaimするとdomain effectを再適用する恐れがあります。そこでworkerは `sequence >= process-from-sequence` だけを対象にします。

## Cutover-aware query

`ListClaimableLiveChatInboxMessagesFromSequence` を追加。

- Pending: sequence >= boundary
- lease-expired Processing: sequence >= boundary
- 既存と同じdurable sequence順でmerge
- Claim自体が引き続きtransactional authority

既存Firestore indexのフィールド構成をそのまま使います。

## Emulator tests

- StreamStateなしのclean cutover → process-from=0
- shadow messages sequence 0,1 → cutover=2
- cutover後のsequence 2だけclaimable
- StreamStateが後から進んでもboundary不変
- post-cutover processing leaseの失効回収もboundary内だけ

## 重要な意味

これはmigration ownership boundaryです。cutover未満はlegacy processor所有、cutover以上はdurable worker所有、と明示的に分けます。

## Acceptance criteria

- System Go Test成功
- Go Lint成功
- Firestore Emulator integration test成功
- CI Gate成功
- 既存runtime挙動変更なし
