### PR TITLE
Persist durable command validation replies

### DIFF
--- a/system/core/workspaceapp/durable_message_immediate_reply_integration_test.go
+++ b/system/core/workspaceapp/durable_message_immediate_reply_integration_test.go
@@ -1,0 +1,90 @@
+//go:build integration
+
+package workspaceapp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"app.modules/core/repository"
+	"app.modules/core/timeutil"
+	"app.modules/internal/integrationtest"
+)
+
+func TestProcessClaimedDurableInboxMessage_ValidationReplyCommitsUserOutboxAndProcessed(t *testing.T) {
+	loadWorkspaceAppTestI18n(t)
+	integrationtest.ResetFirestore(t)
+	controller := integrationtest.NewFirestoreController(t)
+	ctx := context.Background()
+	liveChatID := "durable-validation-reply-chat"
+	now := time.Date(2026, 8, 15, 18, 0, 0, 0, timeutil.JapanLocation())
+	history := durableSourceHistory(
+		liveChatID,
+		"message-validation",
+		"author-validation",
+		"@Validation User",
+		"!more 0",
+		now.Add(-time.Minute),
+	)
+	require.NoError(t, controller.IngestLiveChatPage(
+		ctx,
+		liveChatID,
+		"",
+		"cursor-1",
+		[]repository.LiveChatHistoryDoc{history},
+		now.Add(-30*time.Second),
+	))
+	claimed, err := controller.ClaimLiveChatInboxMessage(
+		ctx,
+		liveChatID,
+		history.ID,
+		"worker-validation",
+		now.Add(-10*time.Second),
+		time.Minute,
+		3,
+	)
+	require.NoError(t, err)
+
+	app := WorkspaceApp{
+		Configs: &Configs{
+			Constants:            repository.ConstantsConfigDoc{YoutubeMembershipEnabled: true},
+			LiveChatBotChannelID: "bot-channel",
+		},
+		Repository: controller,
+		nowFunc:    func() time.Time { return now },
+	}
+
+	require.NoError(t, app.ProcessClaimedDurableInboxMessage(ctx, claimed, "worker-validation"))
+
+	user, err := controller.ReadUser(ctx, nil, history.AuthorChannelID)
+	require.NoError(t, err)
+	assert.True(t, user.RegistrationDate.Equal(now))
+
+	messageKey, err := repository.LiveChatMessageKey(liveChatID, history.ID)
+	require.NoError(t, err)
+	inboxSnapshot, err := controller.FirestoreClient().Collection(repository.LiveChatInbox).Doc(messageKey).Get(ctx)
+	require.NoError(t, err)
+	var inbox repository.LiveChatInboxDoc
+	require.NoError(t, inboxSnapshot.DataTo(&inbox))
+	assert.Equal(t, repository.LiveChatInboxProcessed, inbox.Status)
+
+	outboxKey, err := repository.LiveChatReplyOutboxKey(liveChatID, history.ID, durablePrimaryReplyIntentSlot)
+	require.NoError(t, err)
+	outboxSnapshot, err := controller.FirestoreClient().Collection(repository.LiveChatReplyOutbox).Doc(outboxKey).Get(ctx)
+	require.NoError(t, err)
+	var outbox repository.LiveChatReplyOutboxDoc
+	require.NoError(t, outboxSnapshot.DataTo(&outbox))
+	assert.Equal(t, repository.LiveChatReplyOutboxPending, outbox.Status)
+
+	// parseAndValidateMessage is side-effect free. Re-running it after the
+	// processor has populated the actor context gives the exact legacy reply the
+	// durable outbox must preserve.
+	prepared := app.parseAndValidateMessage(history.MessageText, false)
+	require.NotEmpty(t, prepared.ImmediateReply)
+	assert.Equal(t, prepared.ImmediateReply, outbox.Message)
+	assert.Contains(t, outbox.Message, "Validation User")
+}

--- a/system/core/workspaceapp/durable_message_processing.go
+++ b/system/core/workspaceapp/durable_message_processing.go
@@ -40,11 +40,13 @@ type liveChatMessageTransactionRepository interface {
 // reply effects can already be committed atomically:
 //   - bot's own source message: mark Processed, no user/reply effect
 //   - ordinary non-command text: first-use User creation + Processed
+//   - parse/validation failures: first-use User creation + reply intent + Processed
 //   - !info: first-use User creation + reply intent + Processed
 //
-// Unsupported commands return ErrDurableCommandNotSupported before opening a
-// transaction, leaving the caller-owned Inbox lease unchanged. Runtime cutover
-// must not route all commands here until later command slices are supported.
+// Unsupported executable commands return ErrDurableCommandNotSupported before
+// opening a transaction, leaving the caller-owned Inbox lease unchanged.
+// Runtime cutover must not route all commands here until later command slices
+// are supported.
 func (app *WorkspaceApp) ProcessClaimedDurableInboxMessage(
 	ctx context.Context,
 	inbox repository.LiveChatInboxDoc,
@@ -75,11 +77,13 @@ func (app *WorkspaceApp) ProcessClaimedDurableInboxMessage(
 		isChatMember,
 	)
 	prepared := app.parseAndValidateMessage(inbox.MessageText, isChatMember)
-	if prepared.ImmediateReply != "" || prepared.SkipExecution || prepared.CommandDetails == nil {
-		return ErrDurableCommandNotSupported
-	}
-	if prepared.CommandDetails.CommandType != utils.NotCommand && prepared.CommandDetails.CommandType != utils.Info {
-		return ErrDurableCommandNotSupported
+	if prepared.ImmediateReply == "" {
+		if prepared.SkipExecution || prepared.CommandDetails == nil {
+			return ErrDurableCommandNotSupported
+		}
+		if prepared.CommandDetails.CommandType != utils.NotCommand && prepared.CommandDetails.CommandType != utils.Info {
+			return ErrDurableCommandNotSupported
+		}
 	}
 
 	now := app.currentTime()
@@ -100,40 +104,42 @@ func (app *WorkspaceApp) ProcessClaimedDurableInboxMessage(
 			return err
 		}
 
-		var reply string
-		switch prepared.CommandDetails.CommandType {
-		case utils.NotCommand:
-			// Legacy ProcessMessage still registers first-use users for ordinary
-			// text, then performs no command side effect or reply.
-		case utils.Info:
-			var totalStudyDuration time.Duration
-			var dailyTotalStudyDuration time.Duration
-			if userExists {
-				totalStudyDuration, dailyTotalStudyDuration, err = app.GetUserRealtimeTotalStudyDurations(
-					ctx,
-					tx,
-					app.ProcessedUserID,
+		reply := prepared.ImmediateReply
+		if reply == "" {
+			switch prepared.CommandDetails.CommandType {
+			case utils.NotCommand:
+				// Legacy ProcessMessage still registers first-use users for ordinary
+				// text, then performs no command side effect or reply.
+			case utils.Info:
+				var totalStudyDuration time.Duration
+				var dailyTotalStudyDuration time.Duration
+				if userExists {
+					totalStudyDuration, dailyTotalStudyDuration, err = app.GetUserRealtimeTotalStudyDurations(
+						ctx,
+						tx,
+						app.ProcessedUserID,
+					)
+					if err != nil {
+						return fmt.Errorf("read realtime study durations for durable !info: %w", err)
+					}
+				} else {
+					inMemberRoom, inGeneralRoom, roomErr := app.IsUserInRoom(ctx, app.ProcessedUserID)
+					if roomErr != nil {
+						return fmt.Errorf("check room state for unregistered durable user: %w", roomErr)
+					}
+					if inMemberRoom || inGeneralRoom {
+						return errors.New("unregistered user unexpectedly has an active seat")
+					}
+				}
+				reply = app.buildUserInfoReply(
+					userDoc,
+					totalStudyDuration,
+					dailyTotalStudyDuration,
+					&prepared.CommandDetails.InfoOption,
 				)
-				if err != nil {
-					return fmt.Errorf("read realtime study durations for durable !info: %w", err)
-				}
-			} else {
-				inMemberRoom, inGeneralRoom, roomErr := app.IsUserInRoom(ctx, app.ProcessedUserID)
-				if roomErr != nil {
-					return fmt.Errorf("check room state for unregistered durable user: %w", roomErr)
-				}
-				if inMemberRoom || inGeneralRoom {
-					return errors.New("unregistered user unexpectedly has an active seat")
-				}
+			default:
+				return ErrDurableCommandNotSupported
 			}
-			reply = app.buildUserInfoReply(
-				userDoc,
-				totalStudyDuration,
-				dailyTotalStudyDuration,
-				&prepared.CommandDetails.InfoOption,
-			)
-		default:
-			return ErrDurableCommandNotSupported
 		}
 
 		// All reads are complete before this point. Firestore transaction writes


### PR DESCRIPTION
## 概要

P1 durable Inbox processorが、parse/validationで即時返信になるメッセージを安全に処理できるようにします。

これまでは `prepared.ImmediateReply != ""` を `ErrDurableCommandNotSupported` としていました。このPRでは、domain commandを実行しないvalidation replyを durable Outboxへ保存します。

## Atomic behavior

validation replyでもlegacyと同じくfirst-use User登録が先に発生するため、以下を同一Firestore transactionでcommitします。

- first-use User（必要な場合）
- validation reply Outbox intent
- Inbox Processed

外部YouTube postはtransaction内でもprocessor内でも行いません。

## Supported / unsupported boundary

新たに対応:
- parse error reply
- validator error reply（例: `!more 0`）

引き続き未対応:
- validationを通過した実行command（`!out`, `!in`, `!break` 等。`!info` は既対応）

つまり、`ImmediateReply` がある場合だけcommand detailsなしでも安全に処理し、有効な未対応commandは従来どおり `ErrDurableCommandNotSupported` でleaseを残します。

## Emulator test

`!more 0` のfirst-useユーザーについて:
- User作成
- Inbox Processed
- Outbox Pending
- legacy parser/validatorが生成する返信文とOutbox messageが完全一致
- `@` 正規化済みdisplay nameを返信に使用

を実DB上で確認します。

## Acceptance criteria

- System Go Test成功
- Go Lint成功
- Firestore Emulator integration test成功
- CI Gate成功
- 有効な未対応commandの挙動変更なし
