### PR TITLE
Stop persisting raw live chat history

### DIFF
--- a/system/cmd/youtube-bot/main.go
+++ b/system/cmd/youtube-bot/main.go
@@ -163,23 +163,6 @@ func Bot(ctx context.Context, clientOption option.ClientOption) {
 			}
 		}
 
-		// chatMessagesを保存
-		for _, chatMessage := range chatMessages {
-			// only if chatMessage has a text message
-			if !youtubebot.HasTextMessageByAuthor(chatMessage) {
-				continue
-			}
-
-			if err = app.AddLiveChatHistoryDoc(ctx, chatMessage); err != nil {
-				app.MessageToOwnerWithError(ctx, "(1回目) failed to add live chat history", err)
-				time.Sleep(2 * time.Second)
-				if err2 := app.AddLiveChatHistoryDoc(ctx, chatMessage); err2 != nil {
-					app.MessageToOwnerWithError(ctx, "(2回目) failed to add live chat history", err2)
-					// pass
-				}
-			}
-		}
-
 		// process the command (includes not command)
 		for _, chatMessage := range chatMessages {
 			if youtubebot.IsFanFundingEvent(chatMessage) {

--- a/system/cmd/youtube-bot/main_test.go
+++ b/system/cmd/youtube-bot/main_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCalculateRetryIntervalSec(t *testing.T) {
@@ -70,4 +72,12 @@ func TestCalculateRetryIntervalSec(t *testing.T) {
 			)
 		})
 	}
+}
+
+func TestYoutubeBotDoesNotPersistRawLiveChatHistory(t *testing.T) {
+	source, err := os.ReadFile("main.go")
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(source), "AddLiveChatHistoryDoc(")
+	assert.NotContains(t, string(source), "failed to add live chat history")
 }


### PR DESCRIPTION
## 概要

- YouTube から取得した text message を Firestore `live-chat-history` へ保存する処理を停止する
- 取得済みメッセージに対するコマンド処理・モデレーション処理は、従来どおりメモリ上で実行する
- youtube-bot の実行経路へ `AddLiveChatHistoryDoc` が再導入されないよう回帰テストを追加する

## 背景

現在のサービス機能では、生チャット本文そのものを永続保存する必要がありません。youtube-bot は取得した各メッセージを、その raw history 保存結果とは独立してメモリ上で直接処理しています。

この PR は、生チャット履歴廃止における「新規 raw データ生成を止める」ための変更です。既存の Firestore データはこの PR では削除せず、現在の短期 retention によって自然に減少させます。

## 対象外・安全境界

- この PR では既存 Firestore データを削除しない
- この PR 自体では development / production への deploy を行わない
- `live-chat-history` の cleanup / read helper は移行期間中の確認・整理に必要なため一時的に残す
- Study Space のドメインデータや Discord 通知処理は変更しない
- BigQuery への今後の raw chat archive 停止はマージ済み #1002 で対応済み
- 既存 BigQuery データの整理はマージ済み #997 の guarded operation で別途行う
- GCS の mixed snapshot cleanup は #1001 / #1030 / #1032 の安全条件に従って別途行う

## 導入手順

1. まず development へ deploy する
2. 新しい raw `live-chat-history` が作成されなくなったことを確認する
3. 既存行が現在の短期 Firestore retention で減少するのを待つ
4. Firestore が完全に drain したことと、raw chat を含まない GCS snapshot が複数世代生成されたことを確認する
5. development での確認完了後に production でも同じ producer 停止・待機・確認手順を実施する

## 検証

- 差分を youtube-bot の raw write loop と回帰テストに限定
- GitHub Actions の CI を実行結果の確認元とする