### PR TITLE
Harden raw chat BigQuery purge target guards

### DIFF
--- a/system/cmd/privacy-retention-admin/main.go
+++ b/system/cmd/privacy-retention-admin/main.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -20,10 +20,22 @@ import (
 const (
 	previewBigQueryCommand = "preview-bigquery"
 	applyBigQueryCommand   = "apply-bigquery"
+
+	developmentEnvironment = "development"
+	productionEnvironment  = "production"
 )
+
+type purgeTarget struct {
+	Environment    string `json:"environment"`
+	ProjectID      string `json:"project_id"`
+	Dataset        string `json:"dataset"`
+	Table          string `json:"table"`
+	QualifiedTable string `json:"qualified_table"`
+}
 
 type previewOutput struct {
 	Mode                 string                               `json:"mode"`
+	Target               purgeTarget                          `json:"target"`
 	Cutoff               time.Time                            `json:"cutoff"`
 	Audit                mybigquery.RawLiveChatRetentionAudit `json:"audit"`
 	DeleteCandidates     int64                                `json:"delete_candidates"`
@@ -32,11 +44,18 @@ type previewOutput struct {
 
 type applyOutput struct {
 	Mode             string                               `json:"mode"`
+	Target           purgeTarget                          `json:"target"`
 	Cutoff           time.Time                            `json:"cutoff"`
 	ConfirmedRows    int64                                `json:"confirmed_rows"`
 	Before           mybigquery.RawLiveChatRetentionAudit `json:"before"`
 	After            mybigquery.RawLiveChatRetentionAudit `json:"after"`
 	DeleteCandidates int64                                `json:"delete_candidates"`
+}
+
+type applyArgs struct {
+	ExpectedRows    int64
+	Confirmation    string
+	AllowProduction bool
 }
 
 func main() {
@@ -47,15 +66,32 @@ func main() {
 }
 
 func run(ctx context.Context, args []string) error {
-	if len(args) < 3 {
+	if len(args) < 5 {
 		return usageError()
 	}
 
-	cutoff, err := time.Parse(time.RFC3339, strings.TrimSpace(args[2]))
+	command := args[1]
+	environment := strings.TrimSpace(args[2])
+	expectedProjectID := strings.TrimSpace(args[3])
+	cutoff, err := time.Parse(time.RFC3339, strings.TrimSpace(args[4]))
 	if err != nil {
 		return fmt.Errorf("parse cutoff as RFC3339: %w", err)
 	}
 	cutoff = cutoff.UTC()
+
+	if command == previewBigQueryCommand && len(args) != 5 {
+		return usageError()
+	}
+
+	var parsedApplyArgs applyArgs
+	if command == applyBigQueryCommand {
+		parsedApplyArgs, err = parseApplyArgs(args[5:])
+		if err != nil {
+			return err
+		}
+	} else if command != previewBigQueryCommand {
+		return usageError()
+	}
 
 	utils.LoadEnv(".env")
 	credentialFilePath := strings.TrimSpace(os.Getenv("CREDENTIAL_FILE_LOCATION"))
@@ -79,13 +115,18 @@ func run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("read system constants: %w", err)
 	}
-	projectID, err := utils.GetGcpProjectID(ctx, clientOption)
+	actualProjectID, err := utils.GetGcpProjectID(ctx, clientOption)
 	if err != nil {
 		return fmt.Errorf("resolve GCP project ID: %w", err)
 	}
+	target, err := buildPurgeTarget(environment, expectedProjectID, actualProjectID)
+	if err != nil {
+		return err
+	}
+
 	bqClient, err := mybigquery.NewBigqueryClient(
 		ctx,
-		projectID,
+		actualProjectID,
 		clientOption,
 		constants.GcpRegion,
 	)
@@ -94,29 +135,99 @@ func run(ctx context.Context, args []string) error {
 	}
 	defer bqClient.CloseClient()
 
-	switch args[1] {
+	switch command {
 	case previewBigQueryCommand:
-		if len(args) != 3 {
-			return usageError()
-		}
-		return previewBigQuery(ctx, bqClient, cutoff)
+		return previewBigQuery(ctx, bqClient, target, cutoff)
 	case applyBigQueryCommand:
-		if len(args) != 7 || args[3] != "--expected-rows" || args[5] != "--confirm" {
-			return usageError()
+		if err := validateApplyTarget(target, parsedApplyArgs.AllowProduction); err != nil {
+			return err
 		}
-		expectedRows, err := strconv.ParseInt(args[4], 10, 64)
-		if err != nil || expectedRows <= 0 {
-			return fmt.Errorf("expected rows must be a positive integer: %q", args[4])
-		}
-		return applyBigQuery(ctx, bqClient, cutoff, expectedRows, args[6])
+		return applyBigQuery(
+			ctx,
+			bqClient,
+			target,
+			cutoff,
+			parsedApplyArgs.ExpectedRows,
+			parsedApplyArgs.Confirmation,
+		)
 	default:
 		return usageError()
 	}
 }
 
+func parseApplyArgs(args []string) (applyArgs, error) {
+	flags := flag.NewFlagSet(applyBigQueryCommand, flag.ContinueOnError)
+	expectedRows := flags.Int64("expected-rows", 0, "candidate row count from preview")
+	confirmation := flags.String("confirm", "", "exact confirmation token from preview")
+	allowProduction := flags.Bool("allow-production", false, "explicitly allow a production apply")
+	if err := flags.Parse(args); err != nil {
+		return applyArgs{}, usageError()
+	}
+	if flags.NArg() != 0 || *expectedRows <= 0 || strings.TrimSpace(*confirmation) == "" {
+		return applyArgs{}, usageError()
+	}
+	return applyArgs{
+		ExpectedRows:    *expectedRows,
+		Confirmation:    *confirmation,
+		AllowProduction: *allowProduction,
+	}, nil
+}
+
+func buildPurgeTarget(environment, expectedProjectID, actualProjectID string) (purgeTarget, error) {
+	environment = strings.TrimSpace(environment)
+	expectedProjectID = strings.TrimSpace(expectedProjectID)
+	actualProjectID = strings.TrimSpace(actualProjectID)
+
+	if environment != developmentEnvironment && environment != productionEnvironment {
+		return purgeTarget{}, fmt.Errorf(
+			"environment must be %q or %q: %q",
+			developmentEnvironment,
+			productionEnvironment,
+			environment,
+		)
+	}
+	if expectedProjectID == "" {
+		return purgeTarget{}, errors.New("expected GCP project ID is required")
+	}
+	if actualProjectID == "" {
+		return purgeTarget{}, errors.New("credential GCP project ID is empty")
+	}
+	if expectedProjectID != actualProjectID {
+		return purgeTarget{}, fmt.Errorf(
+			"GCP project mismatch: expected=%q credential=%q; refusing to inspect or mutate",
+			expectedProjectID,
+			actualProjectID,
+		)
+	}
+
+	qualifiedTable := strings.Join([]string{
+		actualProjectID,
+		mybigquery.DatasetName,
+		mybigquery.LiveChatHistoryMainTableName,
+	}, ".")
+	return purgeTarget{
+		Environment:    environment,
+		ProjectID:      actualProjectID,
+		Dataset:        mybigquery.DatasetName,
+		Table:          mybigquery.LiveChatHistoryMainTableName,
+		QualifiedTable: qualifiedTable,
+	}, nil
+}
+
+func validateApplyTarget(target purgeTarget, allowProduction bool) error {
+	if target.Environment == productionEnvironment && !allowProduction {
+		return errors.New("production apply requires --allow-production")
+	}
+	if target.Environment == developmentEnvironment && allowProduction {
+		return errors.New("--allow-production is only valid with environment=production")
+	}
+	return nil
+}
+
 func previewBigQuery(
 	ctx context.Context,
 	client *mybigquery.BigqueryController,
+	target purgeTarget,
 	cutoff time.Time,
 ) error {
 	audit, err := client.InspectRawLiveChatRetention(ctx, cutoff)
@@ -126,10 +237,11 @@ func previewBigQuery(
 	candidates := deleteCandidateCount(audit)
 	output := previewOutput{
 		Mode:                 "preview",
+		Target:               target,
 		Cutoff:               cutoff,
 		Audit:                audit,
 		DeleteCandidates:     candidates,
-		RequiredConfirmation: confirmationToken(cutoff, candidates),
+		RequiredConfirmation: confirmationToken(target, cutoff, candidates),
 	}
 	return writeJSON(output)
 }
@@ -137,6 +249,7 @@ func previewBigQuery(
 func applyBigQuery(
 	ctx context.Context,
 	client *mybigquery.BigqueryController,
+	target purgeTarget,
 	cutoff time.Time,
 	expectedRows int64,
 	confirmation string,
@@ -157,7 +270,7 @@ func applyBigQuery(
 		)
 	}
 
-	requiredConfirmation := confirmationToken(cutoff, expectedRows)
+	requiredConfirmation := confirmationToken(target, cutoff, expectedRows)
 	if confirmation != requiredConfirmation {
 		return fmt.Errorf("confirmation mismatch; required exactly %q", requiredConfirmation)
 	}
@@ -176,6 +289,7 @@ func applyBigQuery(
 
 	output := applyOutput{
 		Mode:             "applied",
+		Target:           target,
 		Cutoff:           cutoff,
 		ConfirmedRows:    expectedRows,
 		Before:           before,
@@ -189,10 +303,13 @@ func deleteCandidateCount(audit mybigquery.RawLiveChatRetentionAudit) int64 {
 	return audit.RowsOlderThanCutoff + audit.UndatedRows
 }
 
-func confirmationToken(cutoff time.Time, rows int64) string {
+func confirmationToken(target purgeTarget, cutoff time.Time, rows int64) string {
 	return fmt.Sprintf(
-		"DELETE %d RAW YOUTUBE LIVE CHAT ROWS BEFORE %s",
+		"DELETE %d RAW YOUTUBE LIVE CHAT ROWS FROM %s PROJECT %s TABLE %s BEFORE %s",
 		rows,
+		strings.ToUpper(target.Environment),
+		target.ProjectID,
+		target.QualifiedTable,
 		cutoff.UTC().Format(time.RFC3339),
 	)
 }
@@ -208,8 +325,8 @@ func writeJSON(value any) error {
 
 func usageError() error {
 	return errors.New(
-		"usage: privacy-retention-admin preview-bigquery <cutoff-rfc3339> OR " +
-			"privacy-retention-admin apply-bigquery <cutoff-rfc3339> " +
-			"--expected-rows <count> --confirm <exact-preview-token>",
+		"usage: privacy-retention-admin preview-bigquery <development|production> <expected-project-id> <cutoff-rfc3339> OR " +
+			"privacy-retention-admin apply-bigquery <development|production> <expected-project-id> <cutoff-rfc3339> " +
+			"--expected-rows <count> --confirm <exact-preview-token> [--allow-production]",
 	)
 }

--- a/system/cmd/privacy-retention-admin/main_test.go
+++ b/system/cmd/privacy-retention-admin/main_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"app.modules/core/mybigquery"
 )
@@ -17,11 +18,55 @@ func TestDeleteCandidateCount(t *testing.T) {
 	assert.EqualValues(t, 47_454, deleteCandidateCount(audit))
 }
 
+func TestBuildPurgeTarget(t *testing.T) {
+	t.Parallel()
+
+	target, err := buildPurgeTarget("production", "youtube-study-space-prod", "youtube-study-space-prod")
+	require.NoError(t, err)
+	assert.Equal(t, productionEnvironment, target.Environment)
+	assert.Equal(t, "youtube-study-space-prod", target.ProjectID)
+	assert.Equal(t, mybigquery.DatasetName, target.Dataset)
+	assert.Equal(t, mybigquery.LiveChatHistoryMainTableName, target.Table)
+	assert.Equal(t, "youtube-study-space-prod.firestore_export.live-chat-history", target.QualifiedTable)
+}
+
+func TestBuildPurgeTargetRejectsWrongProject(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildPurgeTarget("development", "expected-dev", "different-project")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GCP project mismatch")
+}
+
+func TestBuildPurgeTargetRejectsUnknownEnvironment(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildPurgeTarget("staging", "project", "project")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "environment must be")
+}
+
+func TestValidateApplyTarget(t *testing.T) {
+	t.Parallel()
+
+	assert.NoError(t, validateApplyTarget(purgeTarget{Environment: developmentEnvironment}, false))
+	assert.Error(t, validateApplyTarget(purgeTarget{Environment: developmentEnvironment}, true))
+	assert.Error(t, validateApplyTarget(purgeTarget{Environment: productionEnvironment}, false))
+	assert.NoError(t, validateApplyTarget(purgeTarget{Environment: productionEnvironment}, true))
+}
+
 func TestConfirmationToken(t *testing.T) {
 	cutoff := time.Date(2026, 7, 15, 13, 52, 23, 0, time.FixedZone("JST-ish", 9*60*60))
+	target := purgeTarget{
+		Environment:    productionEnvironment,
+		ProjectID:      "youtube-study-space-prod",
+		Dataset:        mybigquery.DatasetName,
+		Table:          mybigquery.LiveChatHistoryMainTableName,
+		QualifiedTable: "youtube-study-space-prod.firestore_export.live-chat-history",
+	}
 	assert.Equal(
 		t,
-		"DELETE 47451 RAW YOUTUBE LIVE CHAT ROWS BEFORE 2026-07-15T04:52:23Z",
-		confirmationToken(cutoff, 47_451),
+		"DELETE 47451 RAW YOUTUBE LIVE CHAT ROWS FROM PRODUCTION PROJECT youtube-study-space-prod TABLE youtube-study-space-prod.firestore_export.live-chat-history BEFORE 2026-07-15T04:52:23Z",
+		confirmationToken(target, cutoff, 47_451),
 	)
 }


### PR DESCRIPTION
## 概要

- BigQuery の raw chat preview / apply で、対象環境（`development` / `production`）と期待する GCP project ID の明示を必須にする
- 実際に使用している credential の project ID と、operator が指定した project ID が完全一致することを確認してから query / mutation を行う
- preview / apply の JSON に environment、project ID、dataset、table、fully qualified table を含める
- environment / project / table を厳密な確認トークンへ組み込む
- production apply では追加で `--allow-production` を必須にする
- project 不一致、無効な environment、production gate、target-bound confirmation token のテストを追加する

## 背景

マージ済み #997 には cutoff、expected row count、transaction 内での再検証、厳密な confirmation、実行後確認といった安全策があります。一方で、正しい操作内容を誤った GCP project の credential で実行してしまうケースに対する識別は十分ではありませんでした。

この PR では、既存の row count / transaction guard を維持したまま、対象環境・project・table の identity を preview と apply の両方へ追加します。

## 使い方

### development preview

```bash
cd system
go run ./cmd/privacy-retention-admin preview-bigquery \
  development <development-project-id> <cutoff-rfc3339>
```

### development apply

apply では直前 preview が返した値だけを使用します。

```bash
go run ./cmd/privacy-retention-admin apply-bigquery \
  development <development-project-id> <cutoff-rfc3339> \
  --expected-rows <preview-count> \
  --confirm '<exact-preview-token>'
```

### production apply

production ではさらに明示的な production 許可フラグを要求します。

```bash
go run ./cmd/privacy-retention-admin apply-bigquery \
  production <production-project-id> <cutoff-rfc3339> \
  --expected-rows <preview-count> \
  --confirm '<exact-preview-token>' \
  --allow-production
```

## 対象外・安全境界

- この PR 自体では削除を実行しない
- production deploy や production data の変更は行わない
- BigQuery の対象は `firestore_export.live-chat-history` のみに限定する
- `user-activity-history`、`order-history`、dataset 自体には触れない

## 検証

GitHub Actions の CI を実行結果の確認元とします。