### PR TITLE
Harden GCS raw chat purge target guards

### DIFF
--- a/docs/privacy/gcs-raw-chat-cleanup.md
+++ b/docs/privacy/gcs-raw-chat-cleanup.md
@@ -44,25 +44,40 @@ This deliberately sacrifices old copies of other collections inside the affected
 
 ## Guarded operator command
 
+Every invocation must identify the target environment, expected GCP project ID, and expected GCS bucket. The command resolves the project ID from the active credentials and the bucket name from Firestore configuration, then refuses to continue if either differs from the operator-supplied target.
+
 Preview is read-only:
 
 ```bash
 cd system
-go run ./cmd/privacy-gcs-admin preview
+go run ./cmd/privacy-gcs-admin preview \
+  development <development-project-id> <development-bucket-name>
 ```
 
-The preview reports candidate prefix count, candidate object count/bytes, newest raw-chat snapshot, clean snapshots after it, safety checks, and an exact confirmation token.
+The preview reports the target environment/project/bucket, candidate prefix count, candidate object count/bytes, newest raw-chat snapshot, clean snapshots after it, safety checks, and an exact target-bound confirmation token.
 
-Only when every safety check passes can the destructive command run:
+Only when every safety check passes can the destructive development command run:
 
 ```bash
 go run ./cmd/privacy-gcs-admin apply \
+  development <development-project-id> <development-bucket-name> \
   --expected-prefixes <preview value> \
   --expected-objects <preview value> \
   --confirm '<exact preview token>'
 ```
 
-The command re-scans the bucket immediately before deletion. A changed prefix/object count or confirmation token stops the operation.
+Production apply additionally requires the explicit production switch:
+
+```bash
+go run ./cmd/privacy-gcs-admin apply \
+  production <production-project-id> <production-bucket-name> \
+  --expected-prefixes <preview value> \
+  --expected-objects <preview value> \
+  --confirm '<exact preview token>' \
+  --allow-production
+```
+
+The command re-scans the bucket immediately before deletion. A changed target, prefix/object count, or confirmation token stops the operation. Production deletion remains a manual operator action.
 
 Within each candidate prefix, non-raw objects are deleted before raw-chat objects. This ordering keeps at least one raw marker present until the rest of that snapshot has been deleted, so a retry after a partial failure can still rediscover the snapshot as a cleanup candidate.
 

--- a/docs/privacy/gcs-raw-chat-cleanup.md
+++ b/docs/privacy/gcs-raw-chat-cleanup.md
@@ -1,0 +1,77 @@
+# GCS raw YouTube chat snapshot cleanup
+
+## Production finding
+
+The 2026-08-14 read-only retention audit found that the configured Firestore export bucket contains long-lived mixed snapshots rather than a disposable transfer-only staging area.
+
+Observed production values:
+
+- bucket: `firestore-backup-test-youtube-study-space`
+- live objects: 18,910
+- live bytes: about 1.53 GB
+- live objects older than the 30-day raw YouTube data cutoff: 18,640
+- oldest live object: 2022-03-19
+- newest live object: 2026-08-13
+- top-level Firestore export prefixes: 1,614
+- object versioning: disabled
+- soft delete: 7 days
+- bucket lifecycle: none
+
+The bucket contains export artifacts for at least:
+
+- `live-chat-history`
+- `users`
+- `user-activities`
+- `order-history`
+
+Therefore a blanket short lifecycle on the entire bucket would also shorten recovery history for Study Space-owned data.
+
+## Cleanup strategy
+
+Do not delete only `kind_live-chat-history/**` from a mixed Firestore export snapshot. That would leave a partially missing snapshot whose overall export metadata may no longer describe a complete recoverable export.
+
+Instead, treat the top-level Firestore export prefix as the deletion unit:
+
+1. identify every snapshot prefix that contains `kind_live-chat-history`;
+2. require every such snapshot to be older than 30 days;
+3. require at least seven newer clean snapshot prefixes after the newest raw-chat snapshot;
+4. require the newest overall snapshot to be recent;
+5. require object versioning to be disabled;
+6. delete the complete old snapshot prefixes that contain raw chat;
+7. verify that no live GCS snapshot prefix containing raw chat remains.
+
+This deliberately sacrifices old copies of other collections inside the affected mixed snapshots. Newer clean snapshots remain available for disaster recovery.
+
+## Guarded operator command
+
+Preview is read-only:
+
+```bash
+cd system
+go run ./cmd/privacy-gcs-admin preview
+```
+
+The preview reports candidate prefix count, candidate object count/bytes, newest raw-chat snapshot, clean snapshots after it, safety checks, and an exact confirmation token.
+
+Only when every safety check passes can the destructive command run:
+
+```bash
+go run ./cmd/privacy-gcs-admin apply \
+  --expected-prefixes <preview value> \
+  --expected-objects <preview value> \
+  --confirm '<exact preview token>'
+```
+
+The command re-scans the bucket immediately before deletion. A changed prefix/object count or confirmation token stops the operation.
+
+Within each candidate prefix, non-raw objects are deleted before raw-chat objects. This ordering keeps at least one raw marker present until the rest of that snapshot has been deleted, so a retry after a partial failure can still rediscover the snapshot as a cleanup candidate.
+
+## Soft delete
+
+The production bucket currently has a seven-day soft-delete policy. Deleting a live object therefore does not immediately hard-delete it. The object becomes soft-deleted and recoverable until the soft-delete retention expires.
+
+The cleanup command reports this explicitly and only verifies removal from the live object namespace. Permanent hard deletion follows the bucket soft-delete policy.
+
+## Follow-up
+
+The durable fix is to ensure future Firestore exports do not include raw live-chat data at all. BigQuery raw-chat archival is also being retired separately. The general backup retention policy for Study Space-owned data should be decided independently from YouTube raw-data retention.

--- a/system/cmd/privacy-gcs-admin/main.go
+++ b/system/cmd/privacy-gcs-admin/main.go
@@ -55,27 +55,27 @@ type safetyCheck struct {
 }
 
 type previewOutput struct {
-	GeneratedAt                    time.Time     `json:"generated_at"`
-	Cutoff                         time.Time     `json:"cutoff"`
-	BucketName                     string        `json:"bucket_name"`
-	VersioningEnabled              bool          `json:"versioning_enabled"`
-	SoftDeleteRetention            string        `json:"soft_delete_retention,omitempty"`
-	TotalSnapshotPrefixes          int           `json:"total_snapshot_prefixes"`
-	RawChatSnapshotPrefixes        int           `json:"raw_chat_snapshot_prefixes"`
-	ExpiredRawChatSnapshotPrefixes int           `json:"expired_raw_chat_snapshot_prefixes"`
-	CandidateObjectCount           int64         `json:"candidate_object_count"`
-	CandidateBytes                 int64         `json:"candidate_bytes"`
-	OldestRawChatPrefix            string        `json:"oldest_raw_chat_prefix,omitempty"`
-	NewestRawChatPrefix            string        `json:"newest_raw_chat_prefix,omitempty"`
-	NewestRawChatCreatedAt         string        `json:"newest_raw_chat_created_at,omitempty"`
-	CleanSnapshotsAfterNewestRaw   int           `json:"clean_snapshots_after_newest_raw"`
-	NewestCleanPrefix              string        `json:"newest_clean_prefix,omitempty"`
-	LatestSnapshotPrefix           string        `json:"latest_snapshot_prefix,omitempty"`
-	LatestSnapshotCreatedAt        string        `json:"latest_snapshot_created_at,omitempty"`
-	SafetyChecks                   []safetyCheck `json:"safety_checks"`
-	ReadyToApply                   bool          `json:"ready_to_apply"`
-	RequiredConfirmation           string        `json:"required_confirmation,omitempty"`
-	Notes                          []string      `json:"notes,omitempty"`
+	GeneratedAt                    time.Time      `json:"generated_at"`
+	Target                         gcsPurgeTarget `json:"target"`
+	Cutoff                         time.Time      `json:"cutoff"`
+	VersioningEnabled              bool           `json:"versioning_enabled"`
+	SoftDeleteRetention            string         `json:"soft_delete_retention,omitempty"`
+	TotalSnapshotPrefixes          int            `json:"total_snapshot_prefixes"`
+	RawChatSnapshotPrefixes        int            `json:"raw_chat_snapshot_prefixes"`
+	ExpiredRawChatSnapshotPrefixes int            `json:"expired_raw_chat_snapshot_prefixes"`
+	CandidateObjectCount           int64          `json:"candidate_object_count"`
+	CandidateBytes                 int64          `json:"candidate_bytes"`
+	OldestRawChatPrefix            string         `json:"oldest_raw_chat_prefix,omitempty"`
+	NewestRawChatPrefix            string         `json:"newest_raw_chat_prefix,omitempty"`
+	NewestRawChatCreatedAt         string         `json:"newest_raw_chat_created_at,omitempty"`
+	CleanSnapshotsAfterNewestRaw   int            `json:"clean_snapshots_after_newest_raw"`
+	NewestCleanPrefix              string         `json:"newest_clean_prefix,omitempty"`
+	LatestSnapshotPrefix           string         `json:"latest_snapshot_prefix,omitempty"`
+	LatestSnapshotCreatedAt        string         `json:"latest_snapshot_created_at,omitempty"`
+	SafetyChecks                   []safetyCheck  `json:"safety_checks"`
+	ReadyToApply                   bool           `json:"ready_to_apply"`
+	RequiredConfirmation           string         `json:"required_confirmation,omitempty"`
+	Notes                          []string       `json:"notes,omitempty"`
 }
 
 func main() {
@@ -86,7 +86,18 @@ func main() {
 }
 
 func run(ctx context.Context, args []string) error {
-	if len(args) < 2 {
+	if len(args) < 5 {
+		return usageError()
+	}
+
+	command := strings.TrimSpace(args[1])
+	environment := strings.TrimSpace(args[2])
+	expectedProjectID := strings.TrimSpace(args[3])
+	expectedBucketName := strings.TrimSpace(args[4])
+	if command == "preview" && len(args) != 5 {
+		return usageError()
+	}
+	if command != "preview" && command != "apply" {
 		return usageError()
 	}
 
@@ -112,9 +123,20 @@ func run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("read system constants: %w", err)
 	}
-	bucketName := strings.TrimSpace(constants.GcsFirestoreExportBucketName)
-	if bucketName == "" {
-		return errors.New("gcs-firestore-export-bucket-name is empty")
+	actualProjectID, err := utils.GetGcpProjectID(ctx, clientOption)
+	if err != nil {
+		return fmt.Errorf("resolve GCP project ID: %w", err)
+	}
+	configuredBucketName := strings.TrimSpace(constants.GcsFirestoreExportBucketName)
+	target, err := buildGCSPurgeTarget(
+		environment,
+		expectedProjectID,
+		actualProjectID,
+		expectedBucketName,
+		configuredBucketName,
+	)
+	if err != nil {
+		return err
 	}
 
 	storageClient, err := storage.NewClient(ctx, clientOption)
@@ -126,30 +148,31 @@ func run(ctx context.Context, args []string) error {
 			fmt.Fprintln(os.Stderr, "privacy-gcs-admin: close GCS client:", err)
 		}
 	}()
-	bucket := storageClient.Bucket(bucketName)
+	bucket := storageClient.Bucket(target.BucketName)
 
 	now := time.Now().UTC()
 	inventory, err := inspectBucket(ctx, bucket)
 	if err != nil {
 		return err
 	}
-	preview := buildPreview(now, bucketName, inventory)
+	preview := buildPreview(now, target, inventory)
 
-	switch args[1] {
+	switch command {
 	case "preview":
-		if len(args) != 2 {
-			return usageError()
-		}
 		return writeJSON(preview)
 	case "apply":
-		return apply(ctx, bucket, preview, inventory, args[2:])
+		return apply(ctx, bucket, preview, inventory, args[5:])
 	default:
 		return usageError()
 	}
 }
 
 func usageError() error {
-	return errors.New("usage: privacy-gcs-admin preview | privacy-gcs-admin apply --expected-prefixes <count> --expected-objects <count> --confirm <token>")
+	return errors.New(
+		"usage: privacy-gcs-admin preview <development|production> <expected-project-id> <expected-bucket-name> OR " +
+			"privacy-gcs-admin apply <development|production> <expected-project-id> <expected-bucket-name> " +
+			"--expected-prefixes <count> --expected-objects <count> --confirm <token> [--allow-production]",
+	)
 }
 
 func inspectBucket(ctx context.Context, bucket *storage.BucketHandle) (bucketInventory, error) {
@@ -213,12 +236,12 @@ func inspectBucket(ctx context.Context, bucket *storage.BucketHandle) (bucketInv
 	}, nil
 }
 
-func buildPreview(now time.Time, bucketName string, inventory bucketInventory) previewOutput {
+func buildPreview(now time.Time, target gcsPurgeTarget, inventory bucketInventory) previewOutput {
 	cutoff := now.AddDate(0, 0, -rawYouTubeDataRetentionDays)
 	out := previewOutput{
 		GeneratedAt:           now,
+		Target:                target,
 		Cutoff:                cutoff,
-		BucketName:            bucketName,
 		VersioningEnabled:     inventory.VersioningEnabled,
 		TotalSnapshotPrefixes: len(inventory.Prefixes),
 	}
@@ -318,11 +341,15 @@ func apply(
 	expectedPrefixes := flags.Int("expected-prefixes", -1, "expected expired raw-chat snapshot prefix count")
 	expectedObjects := flags.Int64("expected-objects", -1, "expected object count across candidate prefixes")
 	confirm := flags.String("confirm", "", "exact confirmation token returned by preview")
+	allowProduction := flags.Bool("allow-production", false, "explicitly allow a production apply")
 	if err := flags.Parse(args); err != nil {
 		return fmt.Errorf("parse apply flags: %w", err)
 	}
 	if flags.NArg() != 0 || *expectedPrefixes < 0 || *expectedObjects < 0 || *confirm == "" {
 		return usageError()
+	}
+	if err := validateGCSApplyTarget(preview.Target, *allowProduction); err != nil {
+		return err
 	}
 	if !preview.ReadyToApply {
 		return errors.New("refusing GCS deletion because preview safety checks are not all satisfied")
@@ -358,20 +385,20 @@ func apply(
 	if err != nil {
 		return fmt.Errorf("post-delete bucket inspection: %w", err)
 	}
-	postPreview := buildPreview(time.Now().UTC(), preview.BucketName, postInventory)
+	postPreview := buildPreview(time.Now().UTC(), preview.Target, postInventory)
 	if postPreview.RawChatSnapshotPrefixes != 0 {
 		return fmt.Errorf("post-delete verification failed: %d live raw-chat snapshot prefixes remain", postPreview.RawChatSnapshotPrefixes)
 	}
 
 	return writeJSON(struct {
 		Status              string        `json:"status"`
-		BucketName          string        `json:"bucket_name"`
+		Target              gcsPurgeTarget `json:"target"`
 		DeletedLiveObjects  int64         `json:"deleted_live_objects"`
 		SoftDeleteRetention string        `json:"soft_delete_retention,omitempty"`
 		PostCheck           previewOutput `json:"post_check"`
 	}{
 		Status:              "deleted live raw-chat snapshot prefixes",
-		BucketName:          preview.BucketName,
+		Target:              preview.Target,
 		DeletedLiveObjects:  deletedObjects,
 		SoftDeleteRetention: preview.SoftDeleteRetention,
 		PostCheck:           postPreview,
@@ -393,10 +420,12 @@ func deletionOrder(objects []objectRef) []objectRef {
 
 func confirmationToken(preview previewOutput) string {
 	return fmt.Sprintf(
-		"DELETE %d GCS FIRESTORE EXPORT SNAPSHOTS CONTAINING RAW YOUTUBE CHAT (%d OBJECTS) FROM %s THROUGH %s",
+		"DELETE %d GCS FIRESTORE EXPORT SNAPSHOTS CONTAINING RAW YOUTUBE CHAT (%d OBJECTS) FROM %s PROJECT %s BUCKET %s THROUGH %s",
 		preview.ExpiredRawChatSnapshotPrefixes,
 		preview.CandidateObjectCount,
-		preview.BucketName,
+		strings.ToUpper(preview.Target.Environment),
+		preview.Target.ProjectID,
+		preview.Target.BucketName,
 		strings.TrimSuffix(preview.NewestRawChatPrefix, "/"),
 	)
 }

--- a/system/cmd/privacy-gcs-admin/main.go
+++ b/system/cmd/privacy-gcs-admin/main.go
@@ -391,11 +391,11 @@ func apply(
 	}
 
 	return writeJSON(struct {
-		Status              string        `json:"status"`
+		Status              string         `json:"status"`
 		Target              gcsPurgeTarget `json:"target"`
-		DeletedLiveObjects  int64         `json:"deleted_live_objects"`
-		SoftDeleteRetention string        `json:"soft_delete_retention,omitempty"`
-		PostCheck           previewOutput `json:"post_check"`
+		DeletedLiveObjects  int64          `json:"deleted_live_objects"`
+		SoftDeleteRetention string         `json:"soft_delete_retention,omitempty"`
+		PostCheck           previewOutput  `json:"post_check"`
 	}{
 		Status:              "deleted live raw-chat snapshot prefixes",
 		Target:              preview.Target,

--- a/system/cmd/privacy-gcs-admin/main.go
+++ b/system/cmd/privacy-gcs-admin/main.go
@@ -1,0 +1,426 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+
+	"app.modules/core/repository"
+	"app.modules/core/utils"
+)
+
+const (
+	rawLiveChatPathMarker          = "/all_namespaces/kind_live-chat-history/"
+	rawYouTubeDataRetentionDays   = 30
+	minimumCleanSnapshotsAfterRaw = 7
+	maximumLatestSnapshotAge      = 72 * time.Hour
+)
+
+type objectRef struct {
+	Name       string
+	Generation int64
+	Size       int64
+	Created    time.Time
+}
+
+type prefixInventory struct {
+	Prefix          string
+	Objects         []objectRef
+	ObjectCount     int64
+	Bytes           int64
+	LatestCreatedAt time.Time
+	ContainsRawChat bool
+}
+
+type bucketInventory struct {
+	Prefixes          []prefixInventory
+	VersioningEnabled bool
+	SoftDelete        time.Duration
+}
+
+type safetyCheck struct {
+	Name   string `json:"name"`
+	Passed bool   `json:"passed"`
+	Detail string `json:"detail"`
+}
+
+type previewOutput struct {
+	GeneratedAt                   time.Time     `json:"generated_at"`
+	Cutoff                        time.Time     `json:"cutoff"`
+	BucketName                    string        `json:"bucket_name"`
+	VersioningEnabled             bool          `json:"versioning_enabled"`
+	SoftDeleteRetention           string        `json:"soft_delete_retention,omitempty"`
+	TotalSnapshotPrefixes         int           `json:"total_snapshot_prefixes"`
+	RawChatSnapshotPrefixes       int           `json:"raw_chat_snapshot_prefixes"`
+	ExpiredRawChatSnapshotPrefixes int          `json:"expired_raw_chat_snapshot_prefixes"`
+	CandidateObjectCount          int64         `json:"candidate_object_count"`
+	CandidateBytes                int64         `json:"candidate_bytes"`
+	OldestRawChatPrefix           string        `json:"oldest_raw_chat_prefix,omitempty"`
+	NewestRawChatPrefix           string        `json:"newest_raw_chat_prefix,omitempty"`
+	NewestRawChatCreatedAt        string        `json:"newest_raw_chat_created_at,omitempty"`
+	CleanSnapshotsAfterNewestRaw  int           `json:"clean_snapshots_after_newest_raw"`
+	NewestCleanPrefix             string        `json:"newest_clean_prefix,omitempty"`
+	LatestSnapshotPrefix          string        `json:"latest_snapshot_prefix,omitempty"`
+	LatestSnapshotCreatedAt       string        `json:"latest_snapshot_created_at,omitempty"`
+	SafetyChecks                  []safetyCheck `json:"safety_checks"`
+	ReadyToApply                  bool          `json:"ready_to_apply"`
+	RequiredConfirmation          string        `json:"required_confirmation,omitempty"`
+	Notes                         []string      `json:"notes,omitempty"`
+}
+
+func main() {
+	if err := run(context.Background(), os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, "privacy-gcs-admin:", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args []string) error {
+	if len(args) < 2 {
+		return usageError()
+	}
+
+	utils.LoadEnv(".env")
+	credentialFilePath := strings.TrimSpace(os.Getenv("CREDENTIAL_FILE_LOCATION"))
+	if credentialFilePath == "" {
+		return errors.New("CREDENTIAL_FILE_LOCATION is required")
+	}
+	//nolint:staticcheck // Operator-controlled service-account JSON used only by this admin command.
+	clientOption := option.WithCredentialsFile(credentialFilePath)
+
+	repo, err := repository.NewFirestoreController(ctx, clientOption)
+	if err != nil {
+		return fmt.Errorf("initialize Firestore: %w", err)
+	}
+	defer func() {
+		if err := repo.FirestoreClient().Close(); err != nil {
+			fmt.Fprintln(os.Stderr, "privacy-gcs-admin: close Firestore:", err)
+		}
+	}()
+
+	constants, err := repo.ReadSystemConstantsConfig(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("read system constants: %w", err)
+	}
+	bucketName := strings.TrimSpace(constants.GcsFirestoreExportBucketName)
+	if bucketName == "" {
+		return errors.New("gcs-firestore-export-bucket-name is empty")
+	}
+
+	storageClient, err := storage.NewClient(ctx, clientOption)
+	if err != nil {
+		return fmt.Errorf("initialize GCS client: %w", err)
+	}
+	defer func() {
+		if err := storageClient.Close(); err != nil {
+			fmt.Fprintln(os.Stderr, "privacy-gcs-admin: close GCS client:", err)
+		}
+	}()
+	bucket := storageClient.Bucket(bucketName)
+
+	now := time.Now().UTC()
+	inventory, err := inspectBucket(ctx, bucket)
+	if err != nil {
+		return err
+	}
+	preview := buildPreview(now, bucketName, inventory)
+
+	switch args[1] {
+	case "preview":
+		if len(args) != 2 {
+			return usageError()
+		}
+		return writeJSON(preview)
+	case "apply":
+		return apply(ctx, bucket, preview, inventory, args[2:])
+	default:
+		return usageError()
+	}
+}
+
+func usageError() error {
+	return errors.New("usage: privacy-gcs-admin preview | privacy-gcs-admin apply --expected-prefixes <count> --expected-objects <count> --confirm <token>")
+}
+
+func inspectBucket(ctx context.Context, bucket *storage.BucketHandle) (bucketInventory, error) {
+	attrs, err := bucket.Attrs(ctx)
+	if err != nil {
+		return bucketInventory{}, fmt.Errorf("read bucket attributes: %w", err)
+	}
+
+	byPrefix := make(map[string]*prefixInventory)
+	it := bucket.Objects(ctx, nil)
+	for {
+		attrs, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return bucketInventory{}, fmt.Errorf("list GCS objects: %w", err)
+		}
+		prefix := topLevelPrefix(attrs.Name)
+		entry, ok := byPrefix[prefix]
+		if !ok {
+			entry = &prefixInventory{Prefix: prefix}
+			byPrefix[prefix] = entry
+		}
+		entry.Objects = append(entry.Objects, objectRef{
+			Name:       attrs.Name,
+			Generation: attrs.Generation,
+			Size:       attrs.Size,
+			Created:    attrs.Created,
+		})
+		entry.ObjectCount++
+		entry.Bytes += attrs.Size
+		if attrs.Created.After(entry.LatestCreatedAt) {
+			entry.LatestCreatedAt = attrs.Created
+		}
+		if strings.Contains(attrs.Name, rawLiveChatPathMarker) {
+			entry.ContainsRawChat = true
+		}
+	}
+
+	prefixes := make([]prefixInventory, 0, len(byPrefix))
+	for _, entry := range byPrefix {
+		prefixes = append(prefixes, *entry)
+	}
+	sort.Slice(prefixes, func(i, j int) bool {
+		if prefixes[i].LatestCreatedAt.Equal(prefixes[j].LatestCreatedAt) {
+			return prefixes[i].Prefix < prefixes[j].Prefix
+		}
+		return prefixes[i].LatestCreatedAt.Before(prefixes[j].LatestCreatedAt)
+	})
+
+	var softDelete time.Duration
+	if attrs.SoftDeletePolicy != nil {
+		softDelete = attrs.SoftDeletePolicy.RetentionDuration
+	}
+
+	return bucketInventory{
+		Prefixes:          prefixes,
+		VersioningEnabled: attrs.VersioningEnabled,
+		SoftDelete:        softDelete,
+	}, nil
+}
+
+func buildPreview(now time.Time, bucketName string, inventory bucketInventory) previewOutput {
+	cutoff := now.AddDate(0, 0, -rawYouTubeDataRetentionDays)
+	out := previewOutput{
+		GeneratedAt:         now,
+		Cutoff:              cutoff,
+		BucketName:          bucketName,
+		VersioningEnabled:   inventory.VersioningEnabled,
+		TotalSnapshotPrefixes: len(inventory.Prefixes),
+	}
+	if inventory.SoftDelete > 0 {
+		out.SoftDeleteRetention = inventory.SoftDelete.String()
+	}
+
+	var newestRaw time.Time
+	var latestSnapshot time.Time
+	for _, prefix := range inventory.Prefixes {
+		if prefix.LatestCreatedAt.After(latestSnapshot) {
+			latestSnapshot = prefix.LatestCreatedAt
+			out.LatestSnapshotPrefix = prefix.Prefix
+			out.LatestSnapshotCreatedAt = formatTime(prefix.LatestCreatedAt)
+		}
+		if !prefix.ContainsRawChat {
+			continue
+		}
+		out.RawChatSnapshotPrefixes++
+		if out.OldestRawChatPrefix == "" {
+			out.OldestRawChatPrefix = prefix.Prefix
+		}
+		if prefix.LatestCreatedAt.After(newestRaw) {
+			newestRaw = prefix.LatestCreatedAt
+			out.NewestRawChatPrefix = prefix.Prefix
+			out.NewestRawChatCreatedAt = formatTime(prefix.LatestCreatedAt)
+		}
+		if prefix.LatestCreatedAt.Before(cutoff) {
+			out.ExpiredRawChatSnapshotPrefixes++
+			out.CandidateObjectCount += prefix.ObjectCount
+			out.CandidateBytes += prefix.Bytes
+		}
+	}
+
+	for _, prefix := range inventory.Prefixes {
+		if prefix.ContainsRawChat || newestRaw.IsZero() || !prefix.LatestCreatedAt.After(newestRaw) {
+			continue
+		}
+		out.CleanSnapshotsAfterNewestRaw++
+		out.NewestCleanPrefix = prefix.Prefix
+	}
+
+	allRawExpired := out.RawChatSnapshotPrefixes > 0 && out.RawChatSnapshotPrefixes == out.ExpiredRawChatSnapshotPrefixes
+	latestRecent := !latestSnapshot.IsZero() && now.Sub(latestSnapshot) <= maximumLatestSnapshotAge
+	checks := []safetyCheck{
+		{
+			Name:   "object_versioning_disabled",
+			Passed: !inventory.VersioningEnabled,
+			Detail: fmt.Sprintf("versioning_enabled=%t", inventory.VersioningEnabled),
+		},
+		{
+			Name:   "all_raw_chat_snapshots_expired",
+			Passed: allRawExpired,
+			Detail: fmt.Sprintf("raw=%d expired=%d", out.RawChatSnapshotPrefixes, out.ExpiredRawChatSnapshotPrefixes),
+		},
+		{
+			Name:   "clean_snapshots_exist_after_raw",
+			Passed: out.CleanSnapshotsAfterNewestRaw >= minimumCleanSnapshotsAfterRaw,
+			Detail: fmt.Sprintf("clean_after_raw=%d required=%d", out.CleanSnapshotsAfterNewestRaw, minimumCleanSnapshotsAfterRaw),
+		},
+		{
+			Name:   "latest_snapshot_is_recent",
+			Passed: latestRecent,
+			Detail: fmt.Sprintf("latest=%s max_age=%s", out.LatestSnapshotCreatedAt, maximumLatestSnapshotAge),
+		},
+	}
+	out.SafetyChecks = checks
+	out.ReadyToApply = true
+	for _, check := range checks {
+		if !check.Passed {
+			out.ReadyToApply = false
+		}
+	}
+	if out.ReadyToApply {
+		out.RequiredConfirmation = confirmationToken(out)
+	}
+	out.Notes = []string{
+		"preview is read-only",
+		"apply deletes complete Firestore export prefixes that contain raw live-chat data; it does not partially edit snapshots",
+		"clean snapshots newer than the newest raw-chat snapshot are preserved",
+	}
+	if inventory.SoftDelete > 0 {
+		out.Notes = append(out.Notes, "deleted objects remain recoverable in GCS soft delete until the configured retention expires")
+	}
+	return out
+}
+
+func apply(
+	ctx context.Context,
+	bucket *storage.BucketHandle,
+	preview previewOutput,
+	inventory bucketInventory,
+	args []string,
+) error {
+	flags := flag.NewFlagSet("apply", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	expectedPrefixes := flags.Int("expected-prefixes", -1, "expected expired raw-chat snapshot prefix count")
+	expectedObjects := flags.Int64("expected-objects", -1, "expected object count across candidate prefixes")
+	confirm := flags.String("confirm", "", "exact confirmation token returned by preview")
+	if err := flags.Parse(args); err != nil {
+		return fmt.Errorf("parse apply flags: %w", err)
+	}
+	if flags.NArg() != 0 || *expectedPrefixes < 0 || *expectedObjects < 0 || *confirm == "" {
+		return usageError()
+	}
+	if !preview.ReadyToApply {
+		return errors.New("refusing GCS deletion because preview safety checks are not all satisfied")
+	}
+	if *expectedPrefixes != preview.ExpiredRawChatSnapshotPrefixes {
+		return fmt.Errorf("candidate prefix count changed: expected=%d actual=%d", *expectedPrefixes, preview.ExpiredRawChatSnapshotPrefixes)
+	}
+	if *expectedObjects != preview.CandidateObjectCount {
+		return fmt.Errorf("candidate object count changed: expected=%d actual=%d", *expectedObjects, preview.CandidateObjectCount)
+	}
+	if *confirm != confirmationToken(preview) {
+		return errors.New("confirmation token does not match current preview")
+	}
+
+	deletedObjects := int64(0)
+	for _, prefix := range inventory.Prefixes {
+		if !prefix.ContainsRawChat || !prefix.LatestCreatedAt.Before(preview.Cutoff) {
+			continue
+		}
+		for _, object := range deletionOrder(prefix.Objects) {
+			objectHandle := bucket.Object(object.Name)
+			if object.Generation != 0 {
+				objectHandle = objectHandle.Generation(object.Generation)
+			}
+			if err := objectHandle.Delete(ctx); err != nil && !errors.Is(err, storage.ErrObjectNotExist) {
+				return fmt.Errorf("delete GCS object %q: %w", object.Name, err)
+			}
+			deletedObjects++
+		}
+	}
+
+	postInventory, err := inspectBucket(ctx, bucket)
+	if err != nil {
+		return fmt.Errorf("post-delete bucket inspection: %w", err)
+	}
+	postPreview := buildPreview(time.Now().UTC(), preview.BucketName, postInventory)
+	if postPreview.RawChatSnapshotPrefixes != 0 {
+		return fmt.Errorf("post-delete verification failed: %d live raw-chat snapshot prefixes remain", postPreview.RawChatSnapshotPrefixes)
+	}
+
+	return writeJSON(struct {
+		Status              string        `json:"status"`
+		BucketName          string        `json:"bucket_name"`
+		DeletedLiveObjects  int64         `json:"deleted_live_objects"`
+		SoftDeleteRetention string        `json:"soft_delete_retention,omitempty"`
+		PostCheck           previewOutput `json:"post_check"`
+	}{
+		Status:              "deleted live raw-chat snapshot prefixes",
+		BucketName:          preview.BucketName,
+		DeletedLiveObjects:  deletedObjects,
+		SoftDeleteRetention: preview.SoftDeleteRetention,
+		PostCheck:           postPreview,
+	})
+}
+
+func deletionOrder(objects []objectRef) []objectRef {
+	ordered := append([]objectRef(nil), objects...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		iRaw := strings.Contains(ordered[i].Name, rawLiveChatPathMarker)
+		jRaw := strings.Contains(ordered[j].Name, rawLiveChatPathMarker)
+		if iRaw != jRaw {
+			return !iRaw
+		}
+		return ordered[i].Name < ordered[j].Name
+	})
+	return ordered
+}
+
+func confirmationToken(preview previewOutput) string {
+	return fmt.Sprintf(
+		"DELETE %d GCS FIRESTORE EXPORT SNAPSHOTS CONTAINING RAW YOUTUBE CHAT (%d OBJECTS) FROM %s THROUGH %s",
+		preview.ExpiredRawChatSnapshotPrefixes,
+		preview.CandidateObjectCount,
+		preview.BucketName,
+		strings.TrimSuffix(preview.NewestRawChatPrefix, "/"),
+	)
+}
+
+func topLevelPrefix(objectName string) string {
+	index := strings.IndexByte(objectName, '/')
+	if index < 0 {
+		return "(root)"
+	}
+	return objectName[:index+1]
+}
+
+func formatTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func writeJSON(value any) error {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(value); err != nil {
+		return fmt.Errorf("encode JSON: %w", err)
+	}
+	return nil
+}

--- a/system/cmd/privacy-gcs-admin/main.go
+++ b/system/cmd/privacy-gcs-admin/main.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	rawLiveChatPathMarker          = "/all_namespaces/kind_live-chat-history/"
+	rawLiveChatPathMarker         = "/all_namespaces/kind_live-chat-history/"
 	rawYouTubeDataRetentionDays   = 30
 	minimumCleanSnapshotsAfterRaw = 7
 	maximumLatestSnapshotAge      = 72 * time.Hour
@@ -55,27 +55,27 @@ type safetyCheck struct {
 }
 
 type previewOutput struct {
-	GeneratedAt                   time.Time     `json:"generated_at"`
-	Cutoff                        time.Time     `json:"cutoff"`
-	BucketName                    string        `json:"bucket_name"`
-	VersioningEnabled             bool          `json:"versioning_enabled"`
-	SoftDeleteRetention           string        `json:"soft_delete_retention,omitempty"`
-	TotalSnapshotPrefixes         int           `json:"total_snapshot_prefixes"`
-	RawChatSnapshotPrefixes       int           `json:"raw_chat_snapshot_prefixes"`
-	ExpiredRawChatSnapshotPrefixes int          `json:"expired_raw_chat_snapshot_prefixes"`
-	CandidateObjectCount          int64         `json:"candidate_object_count"`
-	CandidateBytes                int64         `json:"candidate_bytes"`
-	OldestRawChatPrefix           string        `json:"oldest_raw_chat_prefix,omitempty"`
-	NewestRawChatPrefix           string        `json:"newest_raw_chat_prefix,omitempty"`
-	NewestRawChatCreatedAt        string        `json:"newest_raw_chat_created_at,omitempty"`
-	CleanSnapshotsAfterNewestRaw  int           `json:"clean_snapshots_after_newest_raw"`
-	NewestCleanPrefix             string        `json:"newest_clean_prefix,omitempty"`
-	LatestSnapshotPrefix          string        `json:"latest_snapshot_prefix,omitempty"`
-	LatestSnapshotCreatedAt       string        `json:"latest_snapshot_created_at,omitempty"`
-	SafetyChecks                  []safetyCheck `json:"safety_checks"`
-	ReadyToApply                  bool          `json:"ready_to_apply"`
-	RequiredConfirmation          string        `json:"required_confirmation,omitempty"`
-	Notes                         []string      `json:"notes,omitempty"`
+	GeneratedAt                    time.Time     `json:"generated_at"`
+	Cutoff                         time.Time     `json:"cutoff"`
+	BucketName                     string        `json:"bucket_name"`
+	VersioningEnabled              bool          `json:"versioning_enabled"`
+	SoftDeleteRetention            string        `json:"soft_delete_retention,omitempty"`
+	TotalSnapshotPrefixes          int           `json:"total_snapshot_prefixes"`
+	RawChatSnapshotPrefixes        int           `json:"raw_chat_snapshot_prefixes"`
+	ExpiredRawChatSnapshotPrefixes int           `json:"expired_raw_chat_snapshot_prefixes"`
+	CandidateObjectCount           int64         `json:"candidate_object_count"`
+	CandidateBytes                 int64         `json:"candidate_bytes"`
+	OldestRawChatPrefix            string        `json:"oldest_raw_chat_prefix,omitempty"`
+	NewestRawChatPrefix            string        `json:"newest_raw_chat_prefix,omitempty"`
+	NewestRawChatCreatedAt         string        `json:"newest_raw_chat_created_at,omitempty"`
+	CleanSnapshotsAfterNewestRaw   int           `json:"clean_snapshots_after_newest_raw"`
+	NewestCleanPrefix              string        `json:"newest_clean_prefix,omitempty"`
+	LatestSnapshotPrefix           string        `json:"latest_snapshot_prefix,omitempty"`
+	LatestSnapshotCreatedAt        string        `json:"latest_snapshot_created_at,omitempty"`
+	SafetyChecks                   []safetyCheck `json:"safety_checks"`
+	ReadyToApply                   bool          `json:"ready_to_apply"`
+	RequiredConfirmation           string        `json:"required_confirmation,omitempty"`
+	Notes                          []string      `json:"notes,omitempty"`
 }
 
 func main() {
@@ -216,10 +216,10 @@ func inspectBucket(ctx context.Context, bucket *storage.BucketHandle) (bucketInv
 func buildPreview(now time.Time, bucketName string, inventory bucketInventory) previewOutput {
 	cutoff := now.AddDate(0, 0, -rawYouTubeDataRetentionDays)
 	out := previewOutput{
-		GeneratedAt:         now,
-		Cutoff:              cutoff,
-		BucketName:          bucketName,
-		VersioningEnabled:   inventory.VersioningEnabled,
+		GeneratedAt:           now,
+		Cutoff:                cutoff,
+		BucketName:            bucketName,
+		VersioningEnabled:     inventory.VersioningEnabled,
 		TotalSnapshotPrefixes: len(inventory.Prefixes),
 	}
 	if inventory.SoftDelete > 0 {

--- a/system/cmd/privacy-gcs-admin/main_test.go
+++ b/system/cmd/privacy-gcs-admin/main_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildPreviewReadyWhenRawSnapshotsAreOldAndCleanSnapshotsFollow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 14, 14, 15, 0, 0, time.UTC)
+	oldRaw := time.Date(2026, time.June, 23, 15, 0, 0, 0, time.UTC)
+
+	prefixes := []prefixInventory{
+		{
+			Prefix:          "2026-06-23T15:00:00_1/",
+			ObjectCount:     12,
+			Bytes:           120,
+			LatestCreatedAt: oldRaw,
+			ContainsRawChat: true,
+		},
+	}
+	for day := 1; day <= minimumCleanSnapshotsAfterRaw; day++ {
+		prefixes = append(prefixes, prefixInventory{
+			Prefix:          "clean-" + time.Date(2026, time.August, day+6, 15, 0, 0, 0, time.UTC).Format("2006-01-02") + "/",
+			ObjectCount:     9,
+			Bytes:           90,
+			LatestCreatedAt: time.Date(2026, time.August, day+6, 15, 0, 0, 0, time.UTC),
+		})
+	}
+
+	got := buildPreview(now, "backup-bucket", bucketInventory{Prefixes: prefixes})
+
+	if !got.ReadyToApply {
+		t.Fatalf("ReadyToApply = false, safety checks = %#v", got.SafetyChecks)
+	}
+	if got.RawChatSnapshotPrefixes != 1 || got.ExpiredRawChatSnapshotPrefixes != 1 {
+		t.Fatalf("raw prefix counts = %d/%d, want 1/1", got.RawChatSnapshotPrefixes, got.ExpiredRawChatSnapshotPrefixes)
+	}
+	if got.CandidateObjectCount != 12 || got.CandidateBytes != 120 {
+		t.Fatalf("candidate objects/bytes = %d/%d, want 12/120", got.CandidateObjectCount, got.CandidateBytes)
+	}
+	if got.CleanSnapshotsAfterNewestRaw != minimumCleanSnapshotsAfterRaw {
+		t.Fatalf("CleanSnapshotsAfterNewestRaw = %d, want %d", got.CleanSnapshotsAfterNewestRaw, minimumCleanSnapshotsAfterRaw)
+	}
+	if got.RequiredConfirmation == "" {
+		t.Fatal("RequiredConfirmation is empty")
+	}
+}
+
+func TestBuildPreviewRefusesWhenRecentSnapshotStillContainsRawChat(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 14, 14, 15, 0, 0, time.UTC)
+	inventory := bucketInventory{Prefixes: []prefixInventory{
+		{
+			Prefix:          "2026-08-13T15:00:00_1/",
+			ObjectCount:     9,
+			LatestCreatedAt: now.Add(-23 * time.Hour),
+			ContainsRawChat: true,
+		},
+	}}
+
+	got := buildPreview(now, "backup-bucket", inventory)
+	if got.ReadyToApply {
+		t.Fatalf("ReadyToApply = true, want false")
+	}
+	if got.ExpiredRawChatSnapshotPrefixes != 0 {
+		t.Fatalf("ExpiredRawChatSnapshotPrefixes = %d, want 0", got.ExpiredRawChatSnapshotPrefixes)
+	}
+	if got.RequiredConfirmation != "" {
+		t.Fatalf("RequiredConfirmation = %q, want empty", got.RequiredConfirmation)
+	}
+}
+
+func TestBuildPreviewRefusesWhenVersioningEnabled(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 14, 14, 15, 0, 0, time.UTC)
+	prefixes := []prefixInventory{{
+		Prefix:          "raw/",
+		ObjectCount:     3,
+		LatestCreatedAt: now.AddDate(0, 0, -60),
+		ContainsRawChat: true,
+	}}
+	for day := 1; day <= minimumCleanSnapshotsAfterRaw; day++ {
+		prefixes = append(prefixes, prefixInventory{
+			Prefix:          "clean-" + time.Date(2026, time.August, day+6, 15, 0, 0, 0, time.UTC).Format("2006-01-02") + "/",
+			LatestCreatedAt: time.Date(2026, time.August, day+6, 15, 0, 0, 0, time.UTC),
+		})
+	}
+
+	got := buildPreview(now, "backup-bucket", bucketInventory{
+		Prefixes:          prefixes,
+		VersioningEnabled: true,
+	})
+	if got.ReadyToApply {
+		t.Fatal("ReadyToApply = true with versioning enabled")
+	}
+}
+
+func TestDeletionOrderKeepsRawObjectsUntilLast(t *testing.T) {
+	t.Parallel()
+
+	objects := []objectRef{
+		{Name: "snapshot/all_namespaces/kind_live-chat-history/output-0"},
+		{Name: "snapshot/all_namespaces/kind_users/output-0"},
+		{Name: "snapshot/snapshot.overall_export_metadata"},
+		{Name: "snapshot/all_namespaces/kind_live-chat-history/all_namespaces_kind_live-chat-history.export_metadata"},
+	}
+
+	ordered := deletionOrder(objects)
+	seenRaw := false
+	for _, object := range ordered {
+		isRaw := strings.Contains(object.Name, rawLiveChatPathMarker)
+		if isRaw {
+			seenRaw = true
+			continue
+		}
+		if seenRaw {
+			t.Fatalf("non-raw object %q appears after raw object", object.Name)
+		}
+	}
+}
+
+func TestTopLevelPrefix(t *testing.T) {
+	t.Parallel()
+
+	if got := topLevelPrefix("2026-08-13T15:00:06_83201/all_namespaces/kind_users/output-0"); got != "2026-08-13T15:00:06_83201/" {
+		t.Fatalf("topLevelPrefix() = %q", got)
+	}
+}

--- a/system/cmd/privacy-gcs-admin/main_test.go
+++ b/system/cmd/privacy-gcs-admin/main_test.go
@@ -6,6 +6,14 @@ import (
 	"time"
 )
 
+func testGCSTarget(bucketName string) gcsPurgeTarget {
+	return gcsPurgeTarget{
+		Environment: developmentEnvironment,
+		ProjectID:   "youtube-study-space-dev",
+		BucketName:  bucketName,
+	}
+}
+
 func TestBuildPreviewReadyWhenRawSnapshotsAreOldAndCleanSnapshotsFollow(t *testing.T) {
 	t.Parallel()
 
@@ -30,7 +38,7 @@ func TestBuildPreviewReadyWhenRawSnapshotsAreOldAndCleanSnapshotsFollow(t *testi
 		})
 	}
 
-	got := buildPreview(now, "backup-bucket", bucketInventory{Prefixes: prefixes})
+	got := buildPreview(now, testGCSTarget("backup-bucket"), bucketInventory{Prefixes: prefixes})
 
 	if !got.ReadyToApply {
 		t.Fatalf("ReadyToApply = false, safety checks = %#v", got.SafetyChecks)
@@ -47,6 +55,9 @@ func TestBuildPreviewReadyWhenRawSnapshotsAreOldAndCleanSnapshotsFollow(t *testi
 	if got.RequiredConfirmation == "" {
 		t.Fatal("RequiredConfirmation is empty")
 	}
+	if !strings.Contains(got.RequiredConfirmation, "DEVELOPMENT PROJECT youtube-study-space-dev BUCKET backup-bucket") {
+		t.Fatalf("RequiredConfirmation does not bind target: %q", got.RequiredConfirmation)
+	}
 }
 
 func TestBuildPreviewRefusesWhenRecentSnapshotStillContainsRawChat(t *testing.T) {
@@ -62,7 +73,7 @@ func TestBuildPreviewRefusesWhenRecentSnapshotStillContainsRawChat(t *testing.T)
 		},
 	}}
 
-	got := buildPreview(now, "backup-bucket", inventory)
+	got := buildPreview(now, testGCSTarget("backup-bucket"), inventory)
 	if got.ReadyToApply {
 		t.Fatalf("ReadyToApply = true, want false")
 	}
@@ -91,7 +102,7 @@ func TestBuildPreviewRefusesWhenVersioningEnabled(t *testing.T) {
 		})
 	}
 
-	got := buildPreview(now, "backup-bucket", bucketInventory{
+	got := buildPreview(now, testGCSTarget("backup-bucket"), bucketInventory{
 		Prefixes:          prefixes,
 		VersioningEnabled: true,
 	})

--- a/system/cmd/privacy-gcs-admin/target_guard.go
+++ b/system/cmd/privacy-gcs-admin/target_guard.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	developmentEnvironment = "development"
+	productionEnvironment  = "production"
+)
+
+type gcsPurgeTarget struct {
+	Environment string `json:"environment"`
+	ProjectID   string `json:"project_id"`
+	BucketName  string `json:"bucket_name"`
+}
+
+func buildGCSPurgeTarget(
+	environment string,
+	expectedProjectID string,
+	actualProjectID string,
+	expectedBucketName string,
+	configuredBucketName string,
+) (gcsPurgeTarget, error) {
+	environment = strings.TrimSpace(environment)
+	expectedProjectID = strings.TrimSpace(expectedProjectID)
+	actualProjectID = strings.TrimSpace(actualProjectID)
+	expectedBucketName = strings.TrimSpace(expectedBucketName)
+	configuredBucketName = strings.TrimSpace(configuredBucketName)
+
+	if environment != developmentEnvironment && environment != productionEnvironment {
+		return gcsPurgeTarget{}, fmt.Errorf(
+			"environment must be %q or %q: %q",
+			developmentEnvironment,
+			productionEnvironment,
+			environment,
+		)
+	}
+	if expectedProjectID == "" {
+		return gcsPurgeTarget{}, errors.New("expected GCP project ID is required")
+	}
+	if actualProjectID == "" {
+		return gcsPurgeTarget{}, errors.New("credential GCP project ID is empty")
+	}
+	if expectedProjectID != actualProjectID {
+		return gcsPurgeTarget{}, fmt.Errorf(
+			"GCP project mismatch: expected=%q credential=%q; refusing to inspect or mutate",
+			expectedProjectID,
+			actualProjectID,
+		)
+	}
+	if expectedBucketName == "" {
+		return gcsPurgeTarget{}, errors.New("expected GCS bucket name is required")
+	}
+	if configuredBucketName == "" {
+		return gcsPurgeTarget{}, errors.New("configured GCS bucket name is empty")
+	}
+	if expectedBucketName != configuredBucketName {
+		return gcsPurgeTarget{}, fmt.Errorf(
+			"GCS bucket mismatch: expected=%q configured=%q; refusing to inspect or mutate",
+			expectedBucketName,
+			configuredBucketName,
+		)
+	}
+
+	return gcsPurgeTarget{
+		Environment: environment,
+		ProjectID:   actualProjectID,
+		BucketName:  configuredBucketName,
+	}, nil
+}
+
+func validateGCSApplyTarget(target gcsPurgeTarget, allowProduction bool) error {
+	if target.Environment == productionEnvironment && !allowProduction {
+		return errors.New("production apply requires --allow-production")
+	}
+	if target.Environment == developmentEnvironment && allowProduction {
+		return errors.New("--allow-production is only valid with environment=production")
+	}
+	return nil
+}

--- a/system/cmd/privacy-gcs-admin/target_guard_test.go
+++ b/system/cmd/privacy-gcs-admin/target_guard_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildGCSPurgeTarget(t *testing.T) {
+	t.Parallel()
+
+	target, err := buildGCSPurgeTarget(
+		productionEnvironment,
+		"youtube-study-space-prod",
+		"youtube-study-space-prod",
+		"firestore-backup-prod",
+		"firestore-backup-prod",
+	)
+	if err != nil {
+		t.Fatalf("buildGCSPurgeTarget() error = %v", err)
+	}
+	if target.Environment != productionEnvironment || target.ProjectID != "youtube-study-space-prod" || target.BucketName != "firestore-backup-prod" {
+		t.Fatalf("unexpected target: %#v", target)
+	}
+}
+
+func TestBuildGCSPurgeTargetRejectsProjectMismatch(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildGCSPurgeTarget(
+		developmentEnvironment,
+		"expected-dev",
+		"different-project",
+		"backup-dev",
+		"backup-dev",
+	)
+	if err == nil || !strings.Contains(err.Error(), "GCP project mismatch") {
+		t.Fatalf("error = %v, want project mismatch", err)
+	}
+}
+
+func TestBuildGCSPurgeTargetRejectsBucketMismatch(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildGCSPurgeTarget(
+		developmentEnvironment,
+		"project-dev",
+		"project-dev",
+		"expected-bucket",
+		"configured-bucket",
+	)
+	if err == nil || !strings.Contains(err.Error(), "GCS bucket mismatch") {
+		t.Fatalf("error = %v, want bucket mismatch", err)
+	}
+}
+
+func TestBuildGCSPurgeTargetRejectsUnknownEnvironment(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildGCSPurgeTarget("staging", "project", "project", "bucket", "bucket")
+	if err == nil || !strings.Contains(err.Error(), "environment must be") {
+		t.Fatalf("error = %v, want environment validation error", err)
+	}
+}
+
+func TestValidateGCSApplyTarget(t *testing.T) {
+	t.Parallel()
+
+	if err := validateGCSApplyTarget(gcsPurgeTarget{Environment: developmentEnvironment}, false); err != nil {
+		t.Fatalf("development apply rejected: %v", err)
+	}
+	if err := validateGCSApplyTarget(gcsPurgeTarget{Environment: developmentEnvironment}, true); err == nil {
+		t.Fatal("development apply accepted --allow-production")
+	}
+	if err := validateGCSApplyTarget(gcsPurgeTarget{Environment: productionEnvironment}, false); err == nil {
+		t.Fatal("production apply accepted without --allow-production")
+	}
+	if err := validateGCSApplyTarget(gcsPurgeTarget{Environment: productionEnvironment}, true); err != nil {
+		t.Fatalf("production apply rejected with --allow-production: %v", err)
+	}
+}


### PR DESCRIPTION
## Superseded

この stacked PR は、専用統合ブランチ `feature/raw-chat-archive-retirement` を基準に履歴を整理した #1034 に置き換えました。

#1034 はこのPRの target identity guard と後続 #1032 の Firestore drain / clean snapshot gate を最終形としてまとめ、CI成功後に専用統合ブランチへ取り込み済みです。

このPR自体は `dev` へマージしません。