### PR TITLE
Add read-only Firestore raw chat drain audit

### DIFF
--- a/system/cmd/raw-chat-drain-audit/main.go
+++ b/system/cmd/raw-chat-drain-audit/main.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/firestore/apiv1/firestorepb"
+	"google.golang.org/api/option"
+
+	"app.modules/core/repository"
+	"app.modules/core/utils"
+)
+
+const firestoreCountAlias = "row_count"
+
+type auditTarget struct {
+	Environment string `json:"environment"`
+	ProjectID   string `json:"project_id"`
+	Collection  string `json:"collection"`
+}
+
+type auditOutput struct {
+	GeneratedAt time.Time   `json:"generated_at"`
+	Target      auditTarget `json:"target"`
+	TotalRows   int64       `json:"total_rows"`
+	Drained     bool        `json:"drained"`
+}
+
+func main() {
+	if err := run(context.Background(), os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, "raw-chat-drain-audit:", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args []string) error {
+	if len(args) != 3 {
+		return usageError()
+	}
+	environment := strings.TrimSpace(args[1])
+	expectedProjectID := strings.TrimSpace(args[2])
+	if environment != "development" && environment != "production" {
+		return fmt.Errorf("environment must be development or production: %q", environment)
+	}
+	if expectedProjectID == "" {
+		return errors.New("expected GCP project ID is required")
+	}
+
+	utils.LoadEnv(".env")
+	credentialFilePath := strings.TrimSpace(os.Getenv("CREDENTIAL_FILE_LOCATION"))
+	if credentialFilePath == "" {
+		return errors.New("CREDENTIAL_FILE_LOCATION is required")
+	}
+	//nolint:staticcheck // Operator-controlled credential file for this read-only audit.
+	clientOption := option.WithCredentialsFile(credentialFilePath)
+
+	actualProjectID, err := utils.GetGcpProjectID(ctx, clientOption)
+	if err != nil {
+		return fmt.Errorf("resolve GCP project ID: %w", err)
+	}
+	if actualProjectID != expectedProjectID {
+		return fmt.Errorf(
+			"GCP project mismatch: expected=%q credential=%q; refusing to audit",
+			expectedProjectID,
+			actualProjectID,
+		)
+	}
+
+	repo, err := repository.NewFirestoreController(ctx, clientOption)
+	if err != nil {
+		return fmt.Errorf("initialize Firestore: %w", err)
+	}
+	defer func() {
+		if err := repo.FirestoreClient().Close(); err != nil {
+			fmt.Fprintln(os.Stderr, "raw-chat-drain-audit: close Firestore:", err)
+		}
+	}()
+
+	totalRows, err := countRawLiveChatRows(ctx, repo.FirestoreClient())
+	if err != nil {
+		return err
+	}
+
+	output := auditOutput{
+		GeneratedAt: time.Now().UTC(),
+		Target: auditTarget{
+			Environment: environment,
+			ProjectID:   actualProjectID,
+			Collection:  repository.LiveChatHistory,
+		},
+		TotalRows: totalRows,
+		Drained:   totalRows == 0,
+	}
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(output); err != nil {
+		return fmt.Errorf("encode audit output: %w", err)
+	}
+	return nil
+}
+
+func countRawLiveChatRows(ctx context.Context, client repository.DBClient) (int64, error) {
+	query := client.Collection(repository.LiveChatHistory).Query
+	result, err := query.NewAggregationQuery().WithCount(firestoreCountAlias).Get(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("count Firestore raw live chat rows: %w", err)
+	}
+	rawCount, ok := result[firestoreCountAlias]
+	if !ok {
+		return 0, fmt.Errorf("count aggregation missing alias %q", firestoreCountAlias)
+	}
+	countValue, ok := rawCount.(*firestorepb.Value)
+	if !ok {
+		return 0, fmt.Errorf("count aggregation has unexpected type %T", rawCount)
+	}
+	return countValue.GetIntegerValue(), nil
+}
+
+func usageError() error {
+	return errors.New("usage: raw-chat-drain-audit <development|production> <expected-project-id>")
+}

--- a/system/cmd/raw-chat-drain-audit/main_test.go
+++ b/system/cmd/raw-chat-drain-audit/main_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRunRejectsUnknownEnvironmentBeforeCredentialAccess(t *testing.T) {
+	t.Setenv("CREDENTIAL_FILE_LOCATION", "")
+
+	err := run(context.Background(), []string{"raw-chat-drain-audit", "staging", "project-id"})
+	if err == nil {
+		t.Fatal("run() error = nil, want environment validation error")
+	}
+}
+
+func TestRunRequiresExplicitTarget(t *testing.T) {
+	err := run(context.Background(), []string{"raw-chat-drain-audit"})
+	if err == nil {
+		t.Fatal("run() error = nil, want usage error")
+	}
+}


### PR DESCRIPTION
## 概要

- Firestore `live-chat-history` の残存件数を確認する読み取り専用コマンド `raw-chat-drain-audit` を追加する
- 対象環境（`development` / `production`）と期待する GCP project ID の明示を必須にする
- 実際に使用している credential の project ID と期待値が一致することを確認してから読み取る
- raw chat の総件数と、collection が完全に drain したかどうかを出力する

## 背景

raw chat producer を停止しても、既存の Firestore 行は現在の短期 retention が処理するまでしばらく残ります。GCS の clean snapshot を整理対象として扱う前に、Firestore `live-chat-history` が本当に0件まで減ったことを直接確認する手段が必要です。

このコマンドはその移行判定だけを行う読み取り専用 audit です。

## 使い方

### development

```bash
cd system
go run ./cmd/raw-chat-drain-audit development <development-project-id>
```

### production

```bash
cd system
go run ./cmd/raw-chat-drain-audit production <production-project-id>
```

出力される総件数が0で `drained` が true になったことを、次の GCS clean snapshot 待機フェーズへ進む条件とします。

## 対象外・安全境界

- Firestore aggregation の読み取りのみ
- BigQuery / GCS を変更しない
- production deploy や production data の削除は行わない
- 一度限りの削除機能を将来撤去した後も、有用な読み取り専用 audit として残せる

## 検証

GitHub Actions の CI を実行結果の確認元とします。