### PR TITLE
Add raw live chat archive retirement runbook

### DIFF
--- a/docs/privacy/raw-live-chat-archive-environment-operations.md
+++ b/docs/privacy/raw-live-chat-archive-environment-operations.md
@@ -1,0 +1,311 @@
+# Raw live-chat archive retirement: environment operations
+
+This document records the non-secret environment values and the actual operator workflow used for the raw live-chat archive retirement. It supplements `raw-live-chat-archive-retirement-runbook.md` and intentionally does not contain service-account JSON paths, credentials, tokens, or other secrets.
+
+## Confirmed environment targets
+
+| Environment | GCP project ID | BigQuery dataset | Raw table | Firestore backup GCS bucket |
+| --- | --- | --- | --- | --- |
+| development | `test-youtube-study-space` | `firestore_export` | `live-chat-history` | `firestore-backup-test-youtube-study-space` |
+| production | `youtube-study-space` | `firestore_export` | `live-chat-history` | `firestore-backup-youtube-study-space` |
+
+These values are operator-confirmed. The destructive admin commands still resolve the project from the selected service-account credential and refuse to continue when it differs from the explicit expected project. The GCS command also checks the bucket configured in Firestore system constants against the explicit expected bucket.
+
+## Local operator environment
+
+The long-running `youtube-bot` runs on the same PC as the OBS / youtube-monitor streaming setup.
+
+The normal backend startup is:
+
+```bash
+cd system
+go run ./cmd/youtube-bot
+```
+
+The Go process loads `system/.env`. `CREDENTIAL_FILE_LOCATION` points to a service-account JSON stored outside the repository. Development / production selection is currently performed by changing which environment-specific entry is active in `.env`.
+
+Do not commit the service-account path or JSON. Do not infer the active target only from which line appears uncommented in `.env`.
+
+### Mandatory project check before answering `yes`
+
+`youtube-bot` resolves the actual project ID from the selected credential and prints it before startup. It then asks for an explicit `yes` confirmation.
+
+For development, the only expected value is:
+
+```text
+Project ID: test-youtube-study-space
+```
+
+For production, the only expected value is:
+
+```text
+Project ID: youtube-study-space
+```
+
+If any other project ID is printed, answer anything other than `yes` and correct `.env` before retrying.
+
+This startup check is part of the environment-switch safety boundary. The `.env` comment-out state alone is not sufficient evidence of the selected environment.
+
+## Development Day 0 procedure
+
+The Firestore producer change and the BigQuery archive change run in different places and must both be represented in the development environment before the migration wait window is treated as started.
+
+### A. Streaming PC: update and start the development youtube-bot
+
+Use a checkout that contains the raw Firestore writer removal from #1028.
+
+Before startup:
+
+1. configure `.env` to select the development service-account credential;
+2. run the bot from `system/`;
+3. verify the printed project ID is exactly `test-youtube-study-space`;
+4. only then answer `yes`.
+
+```bash
+cd system
+go run ./cmd/youtube-bot
+```
+
+Use an actual development live chat to verify representative command processing still works. Development live-chat testing is available, so this is a required smoke test rather than a theoretical check.
+
+Recommended smoke set:
+
+- one ordinary chat message;
+- one read-only command such as `!info`;
+- one state-changing command such as `!in` followed by `!out`, using a test user / seat where safe;
+- any normal moderation path that can be exercised without intentionally creating harmful content.
+
+The purpose is to verify that fetched chat messages are still processed in memory even though raw `live-chat-history` persistence has stopped.
+
+### B. AWS development environment: deploy the daily-batch archive exclusion
+
+#1002 changes the `transfer-bq` code used by the ECS Fargate daily batch. Updating the streaming-PC bot does not update this batch runtime.
+
+Use the repository's normal development AWS CDK flow from `aws-cdk/`:
+
+```bash
+pnpm cdk:diff --profile <development-aws-profile>
+pnpm cdk:deploy --profile <development-aws-profile>
+```
+
+Use the existing development AWS profile. Do not substitute the production profile.
+
+The migration's development Day 0 should be recorded only after both A and B are complete and the development bot smoke test has succeeded. Record the timestamp in JST and UTC if convenient.
+
+## Development read-only checks
+
+All Go admin / audit commands below load the same `system/.env` and resolve the credential project. They do not require changing the active `gcloud` project.
+
+Before each development command, select the development credential in `.env`. The command must refuse to continue if the credential project is not `test-youtube-study-space`.
+
+### Firestore drain
+
+```bash
+cd system
+go run ./cmd/raw-chat-drain-audit \
+  development test-youtube-study-space
+```
+
+Expected target section:
+
+```json
+{
+  "environment": "development",
+  "project_id": "test-youtube-study-space",
+  "collection": "live-chat-history"
+}
+```
+
+Immediately after Day 0, `total_rows` can be greater than zero. Continue the migration only after it reaches zero and `drained` is `true`.
+
+### GCS readiness preview
+
+```bash
+cd system
+go run ./cmd/privacy-gcs-admin preview \
+  development \
+  test-youtube-study-space \
+  firestore-backup-test-youtube-study-space
+```
+
+The preview itself is read-only. It must remain `ready_to_apply: false` until all migration gates are satisfied, including zero Firestore raw rows and at least seven clean snapshot generations after the newest raw-containing snapshot.
+
+### BigQuery purge preview
+
+Choose the cutoff at execution time and keep the same exact value for the immediately following apply.
+
+```bash
+cd system
+go run ./cmd/privacy-retention-admin preview-bigquery \
+  development \
+  test-youtube-study-space \
+  <cutoff-rfc3339>
+```
+
+The preview target must identify:
+
+```text
+environment: development
+project: test-youtube-study-space
+dataset: firestore_export
+table: live-chat-history
+```
+
+### Development destructive apply
+
+Actual BigQuery and GCS deletion remains a manual operator action. Use only values returned by the immediately preceding preview.
+
+BigQuery:
+
+```bash
+cd system
+go run ./cmd/privacy-retention-admin apply-bigquery \
+  development \
+  test-youtube-study-space \
+  <same-cutoff-rfc3339> \
+  --expected-rows <preview-count> \
+  --confirm '<exact-preview-token>'
+```
+
+GCS:
+
+```bash
+cd system
+go run ./cmd/privacy-gcs-admin apply \
+  development \
+  test-youtube-study-space \
+  firestore-backup-test-youtube-study-space \
+  --expected-prefixes <preview-value> \
+  --expected-objects <preview-value> \
+  --confirm '<exact-preview-token>'
+```
+
+Never partially delete `kind_live-chat-history/**` inside a mixed export. The tool operates on whole raw-containing snapshot prefixes only.
+
+## Production release and Day 0
+
+Production is not updated directly from `dev`.
+
+The normal release boundary is:
+
+1. create / merge the normal release from `dev` to `main`;
+2. update the streaming PC checkout from the released `main` state (`git pull` as normally operated);
+3. deploy AWS/CDK changes as required for the released daily-batch code;
+4. only then start the production youtube-bot with the production credential.
+
+The raw-chat migration follows the same release process. Development must have completed its producer cutover, drain, clean-snapshot wait, manual cleanup, and verification before beginning the production producer cutover.
+
+### Streaming PC production startup
+
+Before startup, switch `.env` to the production service-account credential.
+
+```bash
+cd system
+go run ./cmd/youtube-bot
+```
+
+The printed project ID must be exactly:
+
+```text
+Project ID: youtube-study-space
+```
+
+Only then answer `yes`.
+
+### AWS production deployment
+
+Use the normal production AWS profile after the `dev` to `main` release has been completed:
+
+```bash
+cd aws-cdk
+pnpm cdk:diff --profile <production-aws-profile>
+pnpm cdk:deploy --profile <production-aws-profile>
+```
+
+Production Day 0 is recorded only after the released production bot and production daily-batch archive exclusion are both active.
+
+## Production read-only checks
+
+Before these commands, `.env` must select the production service-account credential. Each command also receives the expected production project explicitly.
+
+### Firestore drain
+
+```bash
+cd system
+go run ./cmd/raw-chat-drain-audit \
+  production youtube-study-space
+```
+
+### GCS readiness preview
+
+```bash
+cd system
+go run ./cmd/privacy-gcs-admin preview \
+  production \
+  youtube-study-space \
+  firestore-backup-youtube-study-space
+```
+
+### BigQuery purge preview
+
+```bash
+cd system
+go run ./cmd/privacy-retention-admin preview-bigquery \
+  production \
+  youtube-study-space \
+  <cutoff-rfc3339>
+```
+
+## Production destructive apply
+
+Production BigQuery / GCS applies remain explicit manual operator actions and additionally require `--allow-production`.
+
+BigQuery:
+
+```bash
+cd system
+go run ./cmd/privacy-retention-admin apply-bigquery \
+  production \
+  youtube-study-space \
+  <same-cutoff-rfc3339> \
+  --expected-rows <preview-count> \
+  --confirm '<exact-preview-token>' \
+  --allow-production
+```
+
+GCS:
+
+```bash
+cd system
+go run ./cmd/privacy-gcs-admin apply \
+  production \
+  youtube-study-space \
+  firestore-backup-youtube-study-space \
+  --expected-prefixes <preview-value> \
+  --expected-objects <preview-value> \
+  --confirm '<exact-preview-token>' \
+  --allow-production
+```
+
+Do not execute either production apply until the production Firestore drain and GCS clean-snapshot gates have independently passed.
+
+## `gcloud` inventory is separate from the normal operator path
+
+The normal Study Space operator workflow does not rely on direct local GCP CLI use. The repository inventory helper under `scripts/gcp/` uses GCP command-line inventory APIs and is intended for the later dedicated-resource cleanup phase, not as a prerequisite for starting Day 0.
+
+The Firestore drain, BigQuery preview/apply, and GCS preview/apply commands above use the service-account credential selected through `system/.env` and perform their own explicit target checks.
+
+When cloud-resource cleanup is reached, run the read-only inventory from an environment with authenticated GCP CLI access, or perform equivalent read-only inventory through the Google Cloud console. Do not delete a resource solely because its name contains `live-chat` or `raw-chat`.
+
+## Values intentionally not fixed in this document
+
+The following values are runtime/operator values and should not be hard-coded:
+
+- service-account JSON file paths;
+- confirmation tokens returned by previews;
+- preview candidate row / object / prefix counts;
+- BigQuery cutoff RFC3339 timestamp;
+- Day 0 timestamps;
+- AWS CLI profile names until confirmed from the operator environment.
+
+All destructive values must come from a fresh preview or from the explicitly selected operator environment.

--- a/docs/privacy/raw-live-chat-archive-retirement-runbook.md
+++ b/docs/privacy/raw-live-chat-archive-retirement-runbook.md
@@ -1,0 +1,346 @@
+# Raw live-chat archive retirement runbook
+
+## Goal
+
+Retire persistent raw YouTube live-chat archival while preserving Study Space domain data and the normal in-memory command/moderation path.
+
+Target end state:
+
+```text
+YouTube Live Chat API
+  -> process in memory
+  -> command / moderation
+  -> Study Space domain data
+
+raw live-chat-history
+  -> no persistent archive
+```
+
+This runbook applies only to the raw `live-chat-history` archive. It does not delete or migrate `users`, seats, work segments, study time, RP, orders, user activities, membership data, or other Study Space domain data. Existing raw chat is not converted into new work history before deletion.
+
+## Non-negotiable safety rules
+
+1. Validate the full sequence in `development` before producer cutover or destructive cleanup in `production`.
+2. Never partially delete `kind_live-chat-history/**` from a mixed Firestore export snapshot. GCS deletion uses the complete top-level snapshot prefix.
+3. Never delete the mixed Firestore backup bucket or the `firestore_export` BigQuery dataset.
+4. Preserve `firestore_export.user-activity-history` and `firestore_export.order-history`.
+5. Every destructive preview/apply must identify the target environment, GCP project ID, and exact BigQuery table or GCS bucket.
+6. Production BigQuery/GCS apply commands are manual operator actions. Do not automate them as part of deploy/CI.
+7. Do not classify a GCP resource as removable from its name alone. Confirm that no retained data flow uses it.
+8. After both environments are complete, remove one-shot DELETE capabilities from the repository. Useful read-only audits may remain.
+
+## Migration components
+
+The migration is intentionally split into small changes:
+
+- #1002 prevents future GCS-to-BigQuery import of `live-chat-history`.
+- #1028 stops the youtube-bot runtime from writing raw messages to Firestore `live-chat-history`.
+- #997 provides the one-shot BigQuery raw-row purge capability.
+- #1029 strengthens the BigQuery purge with environment/project/table-bound guards.
+- #1001 provides guarded whole-prefix cleanup for mixed GCS Firestore export snapshots.
+- #1030 strengthens the GCS purge with environment/project/bucket-bound guards.
+- #1032 gates GCS cleanup on Firestore drain plus multiple newer clean snapshots.
+- #1031 provides a permanent read-only Firestore drain audit.
+
+Do not use a destructive command until the guard changes it depends on are present in the deployed/operator checkout.
+
+## Record the environment targets
+
+Before any deploy or deletion, record the actual values from read-only inventory. Do not copy project IDs or bucket names from memory.
+
+| Environment | GCP project ID | BigQuery dataset | Raw table | GCS Firestore export bucket |
+| --- | --- | --- | --- | --- |
+| development | `<fill from inventory>` | `firestore_export` | `live-chat-history` | `<fill from config/inventory>` |
+| production | `<fill from inventory>` | `firestore_export` | `live-chat-history` | `<fill from config/inventory>` |
+
+Run the repository inventory helper for both environments before cleanup planning:
+
+```bash
+scripts/gcp/raw-chat-resource-inventory.sh development <development-project-id> \
+  > /tmp/raw-chat-development-inventory.txt
+
+scripts/gcp/raw-chat-resource-inventory.sh production <production-project-id> \
+  > /tmp/raw-chat-production-inventory.txt
+```
+
+This is read-only. Review Cloud Asset Inventory, Scheduler, Functions, Cloud Run services/jobs, Pub/Sub, Eventarc, service accounts/IAM, Firestore indexes, GCS buckets, and BigQuery resources. Save the output with the migration record rather than committing environment-specific credentials or sensitive configuration.
+
+## Phase 1: development producer cutover
+
+### 1. Preflight
+
+Confirm the development deployment contains:
+
+- the `live-chat-history` BigQuery archive exclusion from #1002;
+- the Firestore raw-write removal from #1028;
+- the read-only drain audit from #1031.
+
+Do not treat a merge to `dev` as proof that the development runtime has been deployed.
+
+### 2. Deploy to development only
+
+Deploy the producer/archive changes to the development environment. Record the exact deployment timestamp as **Day 0**.
+
+Do not deploy the producer cutover to production yet.
+
+### 3. Verify the service path still works
+
+Confirm representative live-chat commands/moderation behavior still operates. The message-processing path must continue to use the fetched in-memory YouTube message; it must not depend on a successful raw history write.
+
+### 4. Verify Firestore raw rows stop growing
+
+Run:
+
+```bash
+cd system
+go run ./cmd/raw-chat-drain-audit development <development-project-id>
+```
+
+Immediately after Day 0, `total_rows` may still be non-zero because pre-cutover rows remain. Re-run the audit after normal chat activity. The total must not increase from newly persisted raw messages and should decrease as the existing retention cleanup runs.
+
+If raw rows increase after the producer cutover, stop the migration and find the remaining writer before proceeding.
+
+## Phase 2: development wait window
+
+The current Firestore history retention is five days. Existing rows therefore do not disappear immediately after the producer stops.
+
+Expected sequence:
+
+```text
+Day 0
+  raw Firestore producer stops
+
+approximately Day 5-7
+  Firestore live-chat-history reaches 0
+
+then subsequent daily Firestore exports
+  begin producing raw-free GCS snapshots
+
+then preserve multiple clean generations
+  at least 7 clean snapshots newer than the newest raw snapshot
+```
+
+With daily exports this can commonly require roughly **12-14 days from Day 0**, but calendar age is not the authority. The read-only Firestore count and GCS preview safety gates are authoritative.
+
+### Firestore drain gate
+
+Do not proceed to GCS apply until:
+
+```json
+{
+  "total_rows": 0,
+  "drained": true
+}
+```
+
+is reported for development.
+
+### GCS clean-snapshot gate
+
+Use the final guarded GCS command only in preview mode:
+
+```bash
+cd system
+go run ./cmd/privacy-gcs-admin preview \
+  development <development-project-id> <development-bucket-name>
+```
+
+Do not apply until `ready_to_apply` is true. The command must verify at least:
+
+- Firestore raw row count is zero;
+- the expected project and configured bucket match the operator target;
+- object versioning is disabled;
+- raw-containing snapshot prefixes exist;
+- at least seven clean snapshot prefixes are newer than the newest raw snapshot;
+- the latest overall snapshot is recent.
+
+## Phase 3: development purge rehearsal and manual apply
+
+### BigQuery preview
+
+Use only the target-bound command from #1029:
+
+```bash
+cd system
+go run ./cmd/privacy-retention-admin preview-bigquery \
+  development <development-project-id> <cutoff-rfc3339>
+```
+
+Check the preview target contains exactly:
+
+- `environment = development`;
+- the expected development project ID;
+- dataset `firestore_export`;
+- table `live-chat-history`.
+
+### BigQuery apply
+
+The operator manually copies the candidate count and exact token from the immediately preceding preview:
+
+```bash
+go run ./cmd/privacy-retention-admin apply-bigquery \
+  development <development-project-id> <cutoff-rfc3339> \
+  --expected-rows <preview-count> \
+  --confirm '<exact-preview-token>'
+```
+
+Do not reuse a token from another environment or an earlier preview.
+
+### GCS preview and apply
+
+Run a fresh GCS preview immediately before apply. If any gate changed, stop and re-evaluate.
+
+```bash
+go run ./cmd/privacy-gcs-admin preview \
+  development <development-project-id> <development-bucket-name>
+```
+
+The operator then manually uses only the values from that preview:
+
+```bash
+go run ./cmd/privacy-gcs-admin apply \
+  development <development-project-id> <development-bucket-name> \
+  --expected-prefixes <preview-value> \
+  --expected-objects <preview-value> \
+  --confirm '<exact-preview-token>'
+```
+
+GCS soft delete means removal from the live namespace is not immediate hard deletion. Record the configured soft-delete retention and the expected hard-delete window.
+
+### Development verification
+
+Before production cutover, verify:
+
+- `raw-chat-drain-audit` still reports zero Firestore rows;
+- BigQuery raw purge post-check reports no candidate rows for the selected cutoff;
+- GCS post-check reports zero live raw-containing snapshot prefixes;
+- retained BigQuery tables and the mixed GCS bucket still exist;
+- representative Study Space functionality still works.
+
+## Phase 4: production producer cutover
+
+Only after the development sequence has been validated:
+
+1. confirm #1002 and #1028 are included in the production deployment artifact;
+2. deploy the producer/archive changes to production;
+3. record a separate production **Day 0** timestamp;
+4. do not run BigQuery/GCS apply immediately after deployment;
+5. monitor the raw Firestore count with the production target explicitly supplied.
+
+```bash
+cd system
+go run ./cmd/raw-chat-drain-audit production <production-project-id>
+```
+
+## Phase 5: production wait window
+
+Repeat the same gates used in development:
+
+1. wait for Firestore `live-chat-history` to reach zero, normally after the existing short retention window;
+2. wait for subsequent raw-free daily Firestore exports;
+3. retain at least seven clean snapshots newer than the final raw-containing snapshot;
+4. require the GCS preview to report `ready_to_apply = true`.
+
+Do not shorten this sequence merely because development succeeded.
+
+## Phase 6: production manual purge
+
+Production destructive operations are manual only.
+
+### BigQuery
+
+```bash
+cd system
+go run ./cmd/privacy-retention-admin preview-bigquery \
+  production <production-project-id> <cutoff-rfc3339>
+```
+
+After checking the exact target and candidate count, the operator may run:
+
+```bash
+go run ./cmd/privacy-retention-admin apply-bigquery \
+  production <production-project-id> <cutoff-rfc3339> \
+  --expected-rows <preview-count> \
+  --confirm '<exact-preview-token>' \
+  --allow-production
+```
+
+### GCS
+
+```bash
+go run ./cmd/privacy-gcs-admin preview \
+  production <production-project-id> <production-bucket-name>
+```
+
+Only when the fresh preview is ready may the operator run:
+
+```bash
+go run ./cmd/privacy-gcs-admin apply \
+  production <production-project-id> <production-bucket-name> \
+  --expected-prefixes <preview-value> \
+  --expected-objects <preview-value> \
+  --confirm '<exact-preview-token>' \
+  --allow-production
+```
+
+Record the before/after JSON from both tools.
+
+## Phase 7: GCP resource cleanup
+
+After raw data cleanup has completed in **both** environments, rerun the read-only resource inventory for development and production.
+
+Classify each candidate as `dedicated`, `shared`, or `uncertain`.
+
+Potential dedicated cleanup candidates:
+
+- BigQuery `firestore_export.live-chat-history` table;
+- Scheduler jobs used only for raw chat archival;
+- raw-chat-only Cloud Functions or Cloud Run jobs/services;
+- raw-chat-only Pub/Sub topics/subscriptions or Eventarc triggers;
+- service accounts used only by the retired raw archive;
+- IAM grants needed only by those dedicated resources;
+- Firestore indexes used only by retired raw history operations.
+
+Resources that remain:
+
+- BigQuery `firestore_export` dataset;
+- `user-activity-history`;
+- `order-history`;
+- the mixed Firestore backup GCS bucket;
+- any export/scheduler/function/service account/IAM resource also used by retained Study Space data.
+
+Do not delete an `uncertain` or shared resource. First inspect its target, trigger, code, IAM bindings, and consumers.
+
+Delete the obsolete BigQuery raw table itself only during this resource-cleanup phase, after confirming there is no retained consumer and both environment migrations are complete.
+
+## Phase 8: repository deletion-tool cleanup
+
+Once both environment migrations and cloud resource cleanup are complete, create a final cleanup PR. It should remove temporary destructive capabilities rather than leave dormant DELETE paths in the repository.
+
+Remove or reduce at least:
+
+- `privacy-retention-admin` BigQuery DELETE/apply capability;
+- `privacy-gcs-admin` GCS DELETE/apply capability;
+- one-shot purge helpers used only by this migration;
+- one-shot purge tests that no longer protect retained behavior;
+- migration-only code and documentation that is no longer operationally needed.
+
+Keep useful read-only checks, including Firestore raw-row drain/reappearance auditing and broader retention/resource inventory where they remain useful.
+
+## Final verification checklist
+
+The migration is complete only when all of the following are true for development and production:
+
+- [ ] youtube-bot no longer persists fetched raw messages to Firestore `live-chat-history`.
+- [ ] Firestore `live-chat-history` total row count is zero.
+- [ ] GCS-to-BigQuery transfer does not import `live-chat-history`.
+- [ ] no live GCS Firestore export snapshot contains `kind_live-chat-history`.
+- [ ] GCS soft-delete timing has been recorded and allowed to expire as required for hard deletion verification.
+- [ ] BigQuery `firestore_export.live-chat-history` has been removed in the final resource-cleanup phase.
+- [ ] `firestore_export.user-activity-history` remains.
+- [ ] `firestore_export.order-history` remains.
+- [ ] the `firestore_export` dataset remains.
+- [ ] the mixed GCS backup bucket remains.
+- [ ] raw-chat-only cloud resources/IAM/indexes identified by inventory have been removed, with shared resources preserved.
+- [ ] one-shot DELETE capabilities have been removed from the repository.
+- [ ] retained read-only audits still pass and do not expose a new raw persistence path.

--- a/scripts/gcp/raw-chat-resource-inventory.sh
+++ b/scripts/gcp/raw-chat-resource-inventory.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/gcp/raw-chat-resource-inventory.sh <development|production> <gcp-project-id>
+
+Read-only inventory for resources that may participate in raw live-chat archival.
+The script only uses describe/get/list/search/show operations. It does not deploy,
+update, delete, or change the active gcloud project.
+EOF
+}
+
+if [[ $# -ne 2 ]]; then
+  usage >&2
+  exit 2
+fi
+
+TARGET_ENVIRONMENT="$1"
+PROJECT_ID="$2"
+
+case "$TARGET_ENVIRONMENT" in
+  development|production) ;;
+  *)
+    echo "environment must be development or production: $TARGET_ENVIRONMENT" >&2
+    exit 2
+    ;;
+esac
+
+if [[ -z "$PROJECT_ID" ]]; then
+  echo "gcp-project-id must not be empty" >&2
+  exit 2
+fi
+
+if ! command -v gcloud >/dev/null 2>&1; then
+  echo "gcloud is required" >&2
+  exit 1
+fi
+
+section() {
+  printf '\n\n===== %s =====\n' "$1"
+}
+
+run_read_only() {
+  printf '\n+ '
+  printf '%q ' "$@"
+  printf '\n'
+  if ! "$@"; then
+    printf 'WARN: command failed; continuing read-only inventory\n' >&2
+  fi
+}
+
+section "TARGET"
+printf 'environment: %s\n' "$TARGET_ENVIRONMENT"
+printf 'project_id: %s\n' "$PROJECT_ID"
+run_read_only gcloud auth list --filter=status:ACTIVE --format='value(account)'
+run_read_only gcloud config get-value project
+run_read_only gcloud projects describe "$PROJECT_ID" --format=json
+
+PROJECT_NUMBER="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)' 2>/dev/null || true)"
+if [[ -z "$PROJECT_NUMBER" ]]; then
+  echo "Unable to resolve project number; Cloud Asset Inventory section will be skipped." >&2
+else
+  section "CLOUD ASSET INVENTORY - RAW CHAT NAME SEARCH"
+  for term in live-chat-history raw-chat live-chat; do
+    run_read_only gcloud asset search-all-resources \
+      --scope="projects/${PROJECT_NUMBER}" \
+      --query="$term" \
+      --format=json
+  done
+fi
+
+section "CLOUD SCHEDULER"
+run_read_only gcloud scheduler jobs list --project="$PROJECT_ID" --format=json
+
+section "CLOUD FUNCTIONS"
+run_read_only gcloud functions list --project="$PROJECT_ID" --format=json
+
+section "CLOUD RUN SERVICES"
+run_read_only gcloud run services list --project="$PROJECT_ID" --format=json
+
+section "CLOUD RUN JOBS"
+run_read_only gcloud run jobs list --project="$PROJECT_ID" --format=json
+
+section "PUB/SUB TOPICS"
+run_read_only gcloud pubsub topics list --project="$PROJECT_ID" --format=json
+
+section "PUB/SUB SUBSCRIPTIONS"
+run_read_only gcloud pubsub subscriptions list --project="$PROJECT_ID" --format=json
+
+section "EVENTARC TRIGGERS"
+run_read_only gcloud eventarc triggers list --project="$PROJECT_ID" --format=json
+
+section "SERVICE ACCOUNTS"
+run_read_only gcloud iam service-accounts list --project="$PROJECT_ID" --format=json
+
+section "PROJECT IAM POLICY"
+run_read_only gcloud projects get-iam-policy "$PROJECT_ID" --format=json
+
+section "FIRESTORE COMPOSITE INDEXES"
+run_read_only gcloud firestore indexes composite list \
+  --project="$PROJECT_ID" \
+  --database='(default)' \
+  --format=json
+
+section "FIRESTORE SINGLE-FIELD INDEX OVERRIDES"
+run_read_only gcloud firestore indexes fields list \
+  --project="$PROJECT_ID" \
+  --database='(default)' \
+  --format=json
+
+section "GCS BUCKETS"
+run_read_only gcloud storage buckets list --project="$PROJECT_ID" --format=json
+
+section "BIGQUERY"
+if command -v bq >/dev/null 2>&1; then
+  run_read_only bq --project_id="$PROJECT_ID" ls --format=prettyjson
+  run_read_only bq --project_id="$PROJECT_ID" show --format=prettyjson "${PROJECT_ID}:firestore_export"
+  run_read_only bq --project_id="$PROJECT_ID" show --format=prettyjson "${PROJECT_ID}:firestore_export.live-chat-history"
+  run_read_only bq --project_id="$PROJECT_ID" show --format=prettyjson "${PROJECT_ID}:firestore_export.user-activity-history"
+  run_read_only bq --project_id="$PROJECT_ID" show --format=prettyjson "${PROJECT_ID}:firestore_export.order-history"
+else
+  echo "WARN: bq is not installed; BigQuery details were not collected." >&2
+fi
+
+section "INVENTORY REVIEW"
+cat <<EOF
+Target environment: ${TARGET_ENVIRONMENT}
+Target project:     ${PROJECT_ID}
+
+Review the output for resources dedicated only to raw live-chat archival. Do not
+classify a resource as removable merely because its name contains 'chat'. Confirm
+its targets, triggers, service account permissions, and whether Study Space domain
+data also depends on it.
+
+Potential retirement candidates after the migration completes:
+- BigQuery firestore_export.live-chat-history table
+- raw-chat-only Scheduler / Function / Cloud Run Job / Pub/Sub / Eventarc resources
+- raw-chat-only service accounts or IAM grants
+- raw-chat-only Firestore indexes
+
+Resources that must remain when shared by other data flows include:
+- BigQuery firestore_export dataset
+- user-activity-history and order-history tables
+- mixed Firestore export GCS bucket
+- shared Firestore export infrastructure
+EOF


### PR DESCRIPTION
## 概要

- raw live-chat archive 廃止を最後まで進めるための end-to-end runbook を追加する
- development での検証完了を、production cutover と destructive cleanup の前提にする
- Day 0 → Firestore drain → clean GCS snapshot 世代の蓄積という待機手順を明文化する
- BigQuery / GCS の preview / apply を、明示的な target guard と手動操作を前提として文書化する
- 移行完了後の GCP resource cleanup と、repository 側の一時的な delete tool cleanup を整理する
- Cloud Asset、Scheduler、Functions、Cloud Run、Pub/Sub、Eventarc、service account / IAM、Firestore index、GCS、BigQuery を対象とした読み取り専用 inventory script を追加する
- operator-confirmed の development / production Project ID、GCS bucket、配信PC上の `youtube-bot` 起動方式、`.env` の credential 切替、`dev → main` production release 運用を環境別手順として記録する

## 背景

今回の raw live-chat archive 廃止は、application code、短期保持中の Firestore data、historical mixed GCS snapshot、BigQuery、さらに手動管理されている可能性のある GCP resource まで複数層にまたがります。

特に sequencing が重要です。Firestore producer を止め、既存 raw row が drain しない限り、raw chat を含まない clean GCS snapshot は十分に蓄積しません。

この runbook では、その待機期間と destructive operation の境界を明示し、cloud resource を不要と判断する前に読み取り専用 inventory を再現可能な形で取得できるようにします。

## ブランチ運用

この作業は複数PRに分かれるため、各 migration PR は専用ブランチ `feature/raw-chat-archive-retirement` に集約します。`dev` 直向きの migration PR はマージしません。

専用ブランチ内で migration stack を完成させ、最終的な `feature/raw-chat-archive-retirement → dev` は別の統合境界として扱います。

## 基本方針

1. 関連 PR を `feature/raw-chat-archive-retirement` へ取り込む
2. development へ producer 停止を deploy し、その時点を Day 0 とする
3. Firestore `live-chat-history` が0件になるまで待ち、read-only audit で確認する
4. その後に clean GCS snapshot が必要世代数蓄積したことを確認する
5. development で BigQuery / GCS の preview を行い、条件を確認して手動 cleanup する
6. development の結果を検証してから production でも同じ順序を繰り返す
7. 両環境の移行完了後、read-only inventory で専用 GCP resource と shared resource を分類する
8. 不要 resource の削除と、migration-only delete capability の repository cleanup を最後に行う

## 確定した環境値

| Environment | GCP project ID | BigQuery dataset | Raw table | GCS bucket |
| --- | --- | --- | --- | --- |
| development | `test-youtube-study-space` | `firestore_export` | `live-chat-history` | `firestore-backup-test-youtube-study-space` |
| production | `youtube-study-space` | `firestore_export` | `live-chat-history` | `firestore-backup-youtube-study-space` |

詳細な operator 手順は `docs/privacy/raw-live-chat-archive-environment-operations.md` に記録しています。service-account JSON pathやcredential自体は記録しません。

## 対象外・安全境界

- この PR 自体ではデータを削除しない
- deploy を実行しない
- GCP resource を変更しない
- inventory script は読み取り専用 operation のみに限定する
- production BigQuery / GCS apply は手動 operator action のままとする
- `firestore_export` dataset 全体、`user-activity-history`、`order-history`、共有 GCS bucket など Study Space の shared resource は raw chat cleanup の理由だけでは削除しない
- 既存 raw chat を別形式の作業履歴へ変換・backfill しない

## 読み取り専用 inventory

`scripts/gcp/raw-chat-resource-inventory.sh` は以下を棚卸しします。

- Cloud Asset resource search
- Cloud Scheduler
- Cloud Functions
- Cloud Run services / jobs
- Pub/Sub topics / subscriptions
- Eventarc
- service accounts
- project IAM policy
- Firestore composite / field indexes
- GCS buckets
- BigQuery datasets と `firestore_export.live-chat-history`

通常の Study Space 運用は direct GCP CLI を前提としていません。この inventory helper は Day 0 の必須条件ではなく、後段の dedicated-resource cleanup で使います。Firestore / BigQuery / GCS の migration command は `system/.env` の service-account credential を使い、自身で target identity を検証します。

## 関連

- #1002 BigQuery raw chat archive の新規生成停止
- #1028 Firestore raw chat producer 停止
- #997 / #1029 BigQuery one-shot purge と target guard
- #1001 / #1030 / #1032 GCS whole-prefix purge、target guard、Firestore drain / clean snapshot gate
- #1031 Firestore drain の読み取り専用 audit

## 検証

inventory script は `describe` / `get` / `list` / `search` / `show` などの読み取り操作のみを許可する方針とし、GitHub Actions の CI で変更全体を確認します。