### PR TITLE
Integrate raw live-chat archive retirement

### DIFF
--- a/docs/privacy/gcs-raw-chat-cleanup.md
+++ b/docs/privacy/gcs-raw-chat-cleanup.md
@@ -1,0 +1,77 @@
+# GCS raw YouTube chat snapshot cleanup
+
+## Production finding
+
+The 2026-08-14 read-only retention audit found that the configured Firestore export bucket contains long-lived mixed snapshots rather than a disposable transfer-only staging area.
+
+Observed production values:
+
+- bucket: `firestore-backup-test-youtube-study-space`
+- live objects: 18,910
+- live bytes: about 1.53 GB
+- live objects older than the 30-day raw YouTube data cutoff: 18,640
+- oldest live object: 2022-03-19
+- newest live object: 2026-08-13
+- top-level Firestore export prefixes: 1,614
+- object versioning: disabled
+- soft delete: 7 days
+- bucket lifecycle: none
+
+The bucket contains export artifacts for at least:
+
+- `live-chat-history`
+- `users`
+- `user-activities`
+- `order-history`
+
+Therefore a blanket short lifecycle on the entire bucket would also shorten recovery history for Study Space-owned data.
+
+## Cleanup strategy
+
+Do not delete only `kind_live-chat-history/**` from a mixed Firestore export snapshot. That would leave a partially missing snapshot whose overall export metadata may no longer describe a complete recoverable export.
+
+Instead, treat the top-level Firestore export prefix as the deletion unit:
+
+1. identify every snapshot prefix that contains `kind_live-chat-history`;
+2. require every such snapshot to be older than 30 days;
+3. require at least seven newer clean snapshot prefixes after the newest raw-chat snapshot;
+4. require the newest overall snapshot to be recent;
+5. require object versioning to be disabled;
+6. delete the complete old snapshot prefixes that contain raw chat;
+7. verify that no live GCS snapshot prefix containing raw chat remains.
+
+This deliberately sacrifices old copies of other collections inside the affected mixed snapshots. Newer clean snapshots remain available for disaster recovery.
+
+## Guarded operator command
+
+Preview is read-only:
+
+```bash
+cd system
+go run ./cmd/privacy-gcs-admin preview
+```
+
+The preview reports candidate prefix count, candidate object count/bytes, newest raw-chat snapshot, clean snapshots after it, safety checks, and an exact confirmation token.
+
+Only when every safety check passes can the destructive command run:
+
+```bash
+go run ./cmd/privacy-gcs-admin apply \
+  --expected-prefixes <preview value> \
+  --expected-objects <preview value> \
+  --confirm '<exact preview token>'
+```
+
+The command re-scans the bucket immediately before deletion. A changed prefix/object count or confirmation token stops the operation.
+
+Within each candidate prefix, non-raw objects are deleted before raw-chat objects. This ordering keeps at least one raw marker present until the rest of that snapshot has been deleted, so a retry after a partial failure can still rediscover the snapshot as a cleanup candidate.
+
+## Soft delete
+
+The production bucket currently has a seven-day soft-delete policy. Deleting a live object therefore does not immediately hard-delete it. The object becomes soft-deleted and recoverable until the soft-delete retention expires.
+
+The cleanup command reports this explicitly and only verifies removal from the live object namespace. Permanent hard deletion follows the bucket soft-delete policy.
+
+## Follow-up
+
+The durable fix is to ensure future Firestore exports do not include raw live-chat data at all. BigQuery raw-chat archival is also being retired separately. The general backup retention policy for Study Space-owned data should be decided independently from YouTube raw-data retention.

--- a/docs/privacy/gcs-raw-chat-cleanup.md
+++ b/docs/privacy/gcs-raw-chat-cleanup.md
@@ -1,15 +1,16 @@
 # GCS raw YouTube chat snapshot cleanup
 
-## Production finding
+## 2026-08-14 development bucket finding
 
-The 2026-08-14 read-only retention audit found that the configured Firestore export bucket contains long-lived mixed snapshots rather than a disposable transfer-only staging area.
+The 2026-08-14 read-only retention audit found that the configured Firestore export bucket contained long-lived mixed snapshots rather than a disposable transfer-only staging area.
 
-Observed production values:
+The audited bucket was the **development** bucket:
 
+- GCP project: `test-youtube-study-space`
 - bucket: `firestore-backup-test-youtube-study-space`
 - live objects: 18,910
 - live bytes: about 1.53 GB
-- live objects older than the 30-day raw YouTube data cutoff: 18,640
+- live objects older than the previous raw-data cutoff: 18,640
 - oldest live object: 2022-03-19
 - newest live object: 2026-08-13
 - top-level Firestore export prefixes: 1,614
@@ -17,7 +18,14 @@ Observed production values:
 - soft delete: 7 days
 - bucket lifecycle: none
 
-The bucket contains export artifacts for at least:
+The confirmed production target is separate:
+
+- GCP project: `youtube-study-space`
+- bucket: `firestore-backup-youtube-study-space`
+
+Do not apply the development bucket observations to production by assumption. Every production preview must inspect and report the current attributes of `firestore-backup-youtube-study-space` before any apply is considered.
+
+The audited development bucket contains export artifacts for at least:
 
 - `live-chat-history`
 - `users`
@@ -30,48 +38,82 @@ Therefore a blanket short lifecycle on the entire bucket would also shorten reco
 
 Do not delete only `kind_live-chat-history/**` from a mixed Firestore export snapshot. That would leave a partially missing snapshot whose overall export metadata may no longer describe a complete recoverable export.
 
-Instead, treat the top-level Firestore export prefix as the deletion unit:
+Instead, treat the top-level Firestore export prefix as the deletion unit. GCS cleanup becomes eligible only after the raw producer has stopped and the short Firestore retention window has fully drained:
 
-1. identify every snapshot prefix that contains `kind_live-chat-history`;
-2. require every such snapshot to be older than 30 days;
+1. require Firestore `live-chat-history` to contain zero documents;
+2. identify every snapshot prefix that still contains `kind_live-chat-history`;
 3. require at least seven newer clean snapshot prefixes after the newest raw-chat snapshot;
 4. require the newest overall snapshot to be recent;
 5. require object versioning to be disabled;
-6. delete the complete old snapshot prefixes that contain raw chat;
+6. delete the complete snapshot prefixes that contain raw chat;
 7. verify that no live GCS snapshot prefix containing raw chat remains.
 
 This deliberately sacrifices old copies of other collections inside the affected mixed snapshots. Newer clean snapshots remain available for disaster recovery.
 
+With the current five-day Firestore retention and daily exports, the producer cutover to GCS eligibility may take roughly 12 to 14 days: about five to seven days for Firestore to drain, followed by enough daily clean snapshot generations. Actual timing depends on cleanup and export cadence, so the command gates are authoritative rather than the calendar estimate.
+
 ## Guarded operator command
 
-Preview is read-only:
+Every invocation must identify the target environment, expected GCP project ID, and expected GCS bucket. The command resolves the project ID from the active credentials and the bucket name from Firestore configuration, then refuses to continue if either differs from the operator-supplied target.
+
+Development preview is read-only:
 
 ```bash
 cd system
-go run ./cmd/privacy-gcs-admin preview
+go run ./cmd/privacy-gcs-admin preview \
+  development \
+  test-youtube-study-space \
+  firestore-backup-test-youtube-study-space
 ```
 
-The preview reports candidate prefix count, candidate object count/bytes, newest raw-chat snapshot, clean snapshots after it, safety checks, and an exact confirmation token.
+The preview reports the target environment/project/bucket, current Firestore raw-chat row count, candidate prefix count, candidate object count/bytes, newest raw-chat snapshot, clean snapshots after it, safety checks, and an exact target-bound confirmation token.
 
-Only when every safety check passes can the destructive command run:
+`ready_to_apply` remains false while any Firestore raw-chat document exists or fewer than seven clean snapshots exist after the newest raw snapshot.
+
+Only when every safety check passes can the destructive development command run:
 
 ```bash
 go run ./cmd/privacy-gcs-admin apply \
+  development \
+  test-youtube-study-space \
+  firestore-backup-test-youtube-study-space \
   --expected-prefixes <preview value> \
   --expected-objects <preview value> \
   --confirm '<exact preview token>'
 ```
 
-The command re-scans the bucket immediately before deletion. A changed prefix/object count or confirmation token stops the operation.
+Production preview is also read-only and uses the separately confirmed production target:
+
+```bash
+go run ./cmd/privacy-gcs-admin preview \
+  production \
+  youtube-study-space \
+  firestore-backup-youtube-study-space
+```
+
+Production apply additionally requires the explicit production switch:
+
+```bash
+go run ./cmd/privacy-gcs-admin apply \
+  production \
+  youtube-study-space \
+  firestore-backup-youtube-study-space \
+  --expected-prefixes <preview value> \
+  --expected-objects <preview value> \
+  --confirm '<exact preview token>' \
+  --allow-production
+```
+
+The command re-scans Firestore and the bucket immediately before deletion. A changed target, non-zero Firestore raw-chat count, insufficient clean snapshots, changed prefix/object count, or confirmation token mismatch stops the operation. Production deletion remains a manual operator action.
 
 Within each candidate prefix, non-raw objects are deleted before raw-chat objects. This ordering keeps at least one raw marker present until the rest of that snapshot has been deleted, so a retry after a partial failure can still rediscover the snapshot as a cleanup candidate.
 
 ## Soft delete
 
-The production bucket currently has a seven-day soft-delete policy. Deleting a live object therefore does not immediately hard-delete it. The object becomes soft-deleted and recoverable until the soft-delete retention expires.
+The audited development bucket had a seven-day soft-delete policy on 2026-08-14. Deleting a live object from that bucket therefore does not immediately hard-delete it; the object remains recoverable until the configured soft-delete retention expires.
 
-The cleanup command reports this explicitly and only verifies removal from the live object namespace. Permanent hard deletion follows the bucket soft-delete policy.
+Do not assume the production bucket has the same current policy. The production preview must report the actual `firestore-backup-youtube-study-space` soft-delete retention before any production apply. The cleanup command verifies removal from the live object namespace; permanent hard deletion follows the policy reported for the target bucket.
 
 ## Follow-up
 
-The durable fix is to ensure future Firestore exports do not include raw live-chat data at all. BigQuery raw-chat archival is also being retired separately. The general backup retention policy for Study Space-owned data should be decided independently from YouTube raw-data retention.
+After the raw archive migration is complete in both environments, remove the one-shot deletion capability from the repository. Keep useful read-only audits. The general backup retention policy for Study Space-owned data remains independent from raw live-chat retirement.

--- a/docs/privacy/raw-live-chat-archive-environment-operations.md
+++ b/docs/privacy/raw-live-chat-archive-environment-operations.md
@@ -1,0 +1,311 @@
+# Raw live-chat archive retirement: environment operations
+
+This document records the non-secret environment values and the actual operator workflow used for the raw live-chat archive retirement. It supplements `raw-live-chat-archive-retirement-runbook.md` and intentionally does not contain service-account JSON paths, credentials, tokens, or other secrets.
+
+## Confirmed environment targets
+
+| Environment | GCP project ID | BigQuery dataset | Raw table | Firestore backup GCS bucket |
+| --- | --- | --- | --- | --- |
+| development | `test-youtube-study-space` | `firestore_export` | `live-chat-history` | `firestore-backup-test-youtube-study-space` |
+| production | `youtube-study-space` | `firestore_export` | `live-chat-history` | `firestore-backup-youtube-study-space` |
+
+These values are operator-confirmed. The destructive admin commands still resolve the project from the selected service-account credential and refuse to continue when it differs from the explicit expected project. The GCS command also checks the bucket configured in Firestore system constants against the explicit expected bucket.
+
+## Local operator environment
+
+The long-running `youtube-bot` runs on the same PC as the OBS / youtube-monitor streaming setup.
+
+The normal backend startup is:
+
+```bash
+cd system
+go run ./cmd/youtube-bot
+```
+
+The Go process loads `system/.env`. `CREDENTIAL_FILE_LOCATION` points to a service-account JSON stored outside the repository. Development / production selection is currently performed by changing which environment-specific entry is active in `.env`.
+
+Do not commit the service-account path or JSON. Do not infer the active target only from which line appears uncommented in `.env`.
+
+### Mandatory project check before answering `yes`
+
+`youtube-bot` resolves the actual project ID from the selected credential and prints it before startup. It then asks for an explicit `yes` confirmation.
+
+For development, the only expected value is:
+
+```text
+Project ID: test-youtube-study-space
+```
+
+For production, the only expected value is:
+
+```text
+Project ID: youtube-study-space
+```
+
+If any other project ID is printed, answer anything other than `yes` and correct `.env` before retrying.
+
+This startup check is part of the environment-switch safety boundary. The `.env` comment-out state alone is not sufficient evidence of the selected environment.
+
+## Development Day 0 procedure
+
+The Firestore producer change and the BigQuery archive change run in different places and must both be represented in the development environment before the migration wait window is treated as started.
+
+### A. Streaming PC: update and start the development youtube-bot
+
+Use a checkout that contains the raw Firestore writer removal from #1028.
+
+Before startup:
+
+1. configure `.env` to select the development service-account credential;
+2. run the bot from `system/`;
+3. verify the printed project ID is exactly `test-youtube-study-space`;
+4. only then answer `yes`.
+
+```bash
+cd system
+go run ./cmd/youtube-bot
+```
+
+Use an actual development live chat to verify representative command processing still works. Development live-chat testing is available, so this is a required smoke test rather than a theoretical check.
+
+Recommended smoke set:
+
+- one ordinary chat message;
+- one read-only command such as `!info`;
+- one state-changing command such as `!in` followed by `!out`, using a test user / seat where safe;
+- any normal moderation path that can be exercised without intentionally creating harmful content.
+
+The purpose is to verify that fetched chat messages are still processed in memory even though raw `live-chat-history` persistence has stopped.
+
+### B. AWS development environment: deploy the daily-batch archive exclusion
+
+#1002 changes the `transfer-bq` code used by the ECS Fargate daily batch. Updating the streaming-PC bot does not update this batch runtime.
+
+Use the repository's normal development AWS CDK flow from `aws-cdk/`:
+
+```bash
+pnpm cdk:diff --profile <development-aws-profile>
+pnpm cdk:deploy --profile <development-aws-profile>
+```
+
+Use the existing development AWS profile. Do not substitute the production profile.
+
+The migration's development Day 0 should be recorded only after both A and B are complete and the development bot smoke test has succeeded. Record the timestamp in JST and UTC if convenient.
+
+## Development read-only checks
+
+All Go admin / audit commands below load the same `system/.env` and resolve the credential project. They do not require changing the active `gcloud` project.
+
+Before each development command, select the development credential in `.env`. The command must refuse to continue if the credential project is not `test-youtube-study-space`.
+
+### Firestore drain
+
+```bash
+cd system
+go run ./cmd/raw-chat-drain-audit \
+  development test-youtube-study-space
+```
+
+Expected target section:
+
+```json
+{
+  "environment": "development",
+  "project_id": "test-youtube-study-space",
+  "collection": "live-chat-history"
+}
+```
+
+Immediately after Day 0, `total_rows` can be greater than zero. Continue the migration only after it reaches zero and `drained` is `true`.
+
+### GCS readiness preview
+
+```bash
+cd system
+go run ./cmd/privacy-gcs-admin preview \
+  development \
+  test-youtube-study-space \
+  firestore-backup-test-youtube-study-space
+```
+
+The preview itself is read-only. It must remain `ready_to_apply: false` until all migration gates are satisfied, including zero Firestore raw rows and at least seven clean snapshot generations after the newest raw-containing snapshot.
+
+### BigQuery purge preview
+
+Choose the cutoff at execution time and keep the same exact value for the immediately following apply.
+
+```bash
+cd system
+go run ./cmd/privacy-retention-admin preview-bigquery \
+  development \
+  test-youtube-study-space \
+  <cutoff-rfc3339>
+```
+
+The preview target must identify:
+
+```text
+environment: development
+project: test-youtube-study-space
+dataset: firestore_export
+table: live-chat-history
+```
+
+### Development destructive apply
+
+Actual BigQuery and GCS deletion remains a manual operator action. Use only values returned by the immediately preceding preview.
+
+BigQuery:
+
+```bash
+cd system
+go run ./cmd/privacy-retention-admin apply-bigquery \
+  development \
+  test-youtube-study-space \
+  <same-cutoff-rfc3339> \
+  --expected-rows <preview-count> \
+  --confirm '<exact-preview-token>'
+```
+
+GCS:
+
+```bash
+cd system
+go run ./cmd/privacy-gcs-admin apply \
+  development \
+  test-youtube-study-space \
+  firestore-backup-test-youtube-study-space \
+  --expected-prefixes <preview-value> \
+  --expected-objects <preview-value> \
+  --confirm '<exact-preview-token>'
+```
+
+Never partially delete `kind_live-chat-history/**` inside a mixed export. The tool operates on whole raw-containing snapshot prefixes only.
+
+## Production release and Day 0
+
+Production is not updated directly from `dev`.
+
+The normal release boundary is:
+
+1. create / merge the normal release from `dev` to `main`;
+2. update the streaming PC checkout from the released `main` state (`git pull` as normally operated);
+3. deploy AWS/CDK changes as required for the released daily-batch code;
+4. only then start the production youtube-bot with the production credential.
+
+The raw-chat migration follows the same release process. Development must have completed its producer cutover, drain, clean-snapshot wait, manual cleanup, and verification before beginning the production producer cutover.
+
+### Streaming PC production startup
+
+Before startup, switch `.env` to the production service-account credential.
+
+```bash
+cd system
+go run ./cmd/youtube-bot
+```
+
+The printed project ID must be exactly:
+
+```text
+Project ID: youtube-study-space
+```
+
+Only then answer `yes`.
+
+### AWS production deployment
+
+Use the normal production AWS profile after the `dev` to `main` release has been completed:
+
+```bash
+cd aws-cdk
+pnpm cdk:diff --profile <production-aws-profile>
+pnpm cdk:deploy --profile <production-aws-profile>
+```
+
+Production Day 0 is recorded only after the released production bot and production daily-batch archive exclusion are both active.
+
+## Production read-only checks
+
+Before these commands, `.env` must select the production service-account credential. Each command also receives the expected production project explicitly.
+
+### Firestore drain
+
+```bash
+cd system
+go run ./cmd/raw-chat-drain-audit \
+  production youtube-study-space
+```
+
+### GCS readiness preview
+
+```bash
+cd system
+go run ./cmd/privacy-gcs-admin preview \
+  production \
+  youtube-study-space \
+  firestore-backup-youtube-study-space
+```
+
+### BigQuery purge preview
+
+```bash
+cd system
+go run ./cmd/privacy-retention-admin preview-bigquery \
+  production \
+  youtube-study-space \
+  <cutoff-rfc3339>
+```
+
+## Production destructive apply
+
+Production BigQuery / GCS applies remain explicit manual operator actions and additionally require `--allow-production`.
+
+BigQuery:
+
+```bash
+cd system
+go run ./cmd/privacy-retention-admin apply-bigquery \
+  production \
+  youtube-study-space \
+  <same-cutoff-rfc3339> \
+  --expected-rows <preview-count> \
+  --confirm '<exact-preview-token>' \
+  --allow-production
+```
+
+GCS:
+
+```bash
+cd system
+go run ./cmd/privacy-gcs-admin apply \
+  production \
+  youtube-study-space \
+  firestore-backup-youtube-study-space \
+  --expected-prefixes <preview-value> \
+  --expected-objects <preview-value> \
+  --confirm '<exact-preview-token>' \
+  --allow-production
+```
+
+Do not execute either production apply until the production Firestore drain and GCS clean-snapshot gates have independently passed.
+
+## `gcloud` inventory is separate from the normal operator path
+
+The normal Study Space operator workflow does not rely on direct local GCP CLI use. The repository inventory helper under `scripts/gcp/` uses GCP command-line inventory APIs and is intended for the later dedicated-resource cleanup phase, not as a prerequisite for starting Day 0.
+
+The Firestore drain, BigQuery preview/apply, and GCS preview/apply commands above use the service-account credential selected through `system/.env` and perform their own explicit target checks.
+
+When cloud-resource cleanup is reached, run the read-only inventory from an environment with authenticated GCP CLI access, or perform equivalent read-only inventory through the Google Cloud console. Do not delete a resource solely because its name contains `live-chat` or `raw-chat`.
+
+## Values intentionally not fixed in this document
+
+The following values are runtime/operator values and should not be hard-coded:
+
+- service-account JSON file paths;
+- confirmation tokens returned by previews;
+- preview candidate row / object / prefix counts;
+- BigQuery cutoff RFC3339 timestamp;
+- Day 0 timestamps;
+- AWS CLI profile names until confirmed from the operator environment.
+
+All destructive values must come from a fresh preview or from the explicitly selected operator environment.

--- a/docs/privacy/raw-live-chat-archive-environment-operations.md
+++ b/docs/privacy/raw-live-chat-archive-environment-operations.md
@@ -4,10 +4,10 @@ This document records the non-secret environment values and the actual operator 
 
 ## Confirmed environment targets
 
-| Environment | GCP project ID | BigQuery dataset | Raw table | Firestore backup GCS bucket |
-| --- | --- | --- | --- | --- |
-| development | `test-youtube-study-space` | `firestore_export` | `live-chat-history` | `firestore-backup-test-youtube-study-space` |
-| production | `youtube-study-space` | `firestore_export` | `live-chat-history` | `firestore-backup-youtube-study-space` |
+| Environment | GCP project ID | BigQuery dataset | Raw table | Firestore backup GCS bucket | AWS CLI profile |
+| --- | --- | --- | --- | --- | --- |
+| development | `test-youtube-study-space` | `firestore_export` | `live-chat-history` | `firestore-backup-test-youtube-study-space` | `soraride-dev` |
+| production | `youtube-study-space` | `firestore_export` | `live-chat-history` | `firestore-backup-youtube-study-space` | `soraride-prod` |
 
 These values are operator-confirmed. The destructive admin commands still resolve the project from the selected service-account credential and refuse to continue when it differs from the explicit expected project. The GCS command also checks the bucket configured in Firestore system constants against the explicit expected bucket.
 
@@ -81,14 +81,15 @@ The purpose is to verify that fetched chat messages are still processed in memor
 
 #1002 changes the `transfer-bq` code used by the ECS Fargate daily batch. Updating the streaming-PC bot does not update this batch runtime.
 
-Use the repository's normal development AWS CDK flow from `aws-cdk/`:
+Use the confirmed development AWS profile from `aws-cdk/`:
 
 ```bash
-pnpm cdk:diff --profile <development-aws-profile>
-pnpm cdk:deploy --profile <development-aws-profile>
+cd aws-cdk
+pnpm cdk:diff --profile soraride-dev
+pnpm cdk:deploy --profile soraride-dev
 ```
 
-Use the existing development AWS profile. Do not substitute the production profile.
+Do not substitute the production profile.
 
 The migration's development Day 0 should be recorded only after both A and B are complete and the development bot smoke test has succeeded. Record the timestamp in JST and UTC if convenient.
 
@@ -214,13 +215,15 @@ Only then answer `yes`.
 
 ### AWS production deployment
 
-Use the normal production AWS profile after the `dev` to `main` release has been completed:
+Use the confirmed production AWS profile after the `dev` to `main` release has been completed:
 
 ```bash
 cd aws-cdk
-pnpm cdk:diff --profile <production-aws-profile>
-pnpm cdk:deploy --profile <production-aws-profile>
+pnpm cdk:diff --profile soraride-prod
+pnpm cdk:deploy --profile soraride-prod
 ```
+
+Do not substitute the development profile.
 
 Production Day 0 is recorded only after the released production bot and production daily-batch archive exclusion are both active.
 
@@ -305,7 +308,8 @@ The following values are runtime/operator values and should not be hard-coded:
 - confirmation tokens returned by previews;
 - preview candidate row / object / prefix counts;
 - BigQuery cutoff RFC3339 timestamp;
-- Day 0 timestamps;
-- AWS CLI profile names until confirmed from the operator environment.
+- Day 0 timestamps.
+
+The AWS CLI profile names are now confirmed and fixed in this document as `soraride-dev` for development and `soraride-prod` for production.
 
 All destructive values must come from a fresh preview or from the explicitly selected operator environment.

--- a/docs/privacy/raw-live-chat-archive-retirement-runbook.md
+++ b/docs/privacy/raw-live-chat-archive-retirement-runbook.md
@@ -1,0 +1,346 @@
+# Raw live-chat archive retirement runbook
+
+## Goal
+
+Retire persistent raw YouTube live-chat archival while preserving Study Space domain data and the normal in-memory command/moderation path.
+
+Target end state:
+
+```text
+YouTube Live Chat API
+  -> process in memory
+  -> command / moderation
+  -> Study Space domain data
+
+raw live-chat-history
+  -> no persistent archive
+```
+
+This runbook applies only to the raw `live-chat-history` archive. It does not delete or migrate `users`, seats, work segments, study time, RP, orders, user activities, membership data, or other Study Space domain data. Existing raw chat is not converted into new work history before deletion.
+
+## Non-negotiable safety rules
+
+1. Validate the full sequence in `development` before producer cutover or destructive cleanup in `production`.
+2. Never partially delete `kind_live-chat-history/**` from a mixed Firestore export snapshot. GCS deletion uses the complete top-level snapshot prefix.
+3. Never delete the mixed Firestore backup bucket or the `firestore_export` BigQuery dataset.
+4. Preserve `firestore_export.user-activity-history` and `firestore_export.order-history`.
+5. Every destructive preview/apply must identify the target environment, GCP project ID, and exact BigQuery table or GCS bucket.
+6. Production BigQuery/GCS apply commands are manual operator actions. Do not automate them as part of deploy/CI.
+7. Do not classify a GCP resource as removable from its name alone. Confirm that no retained data flow uses it.
+8. After both environments are complete, remove one-shot DELETE capabilities from the repository. Useful read-only audits may remain.
+
+## Migration components
+
+The migration is intentionally split into small changes:
+
+- #1002 prevents future GCS-to-BigQuery import of `live-chat-history`.
+- #1028 stops the youtube-bot runtime from writing raw messages to Firestore `live-chat-history`.
+- #997 provides the one-shot BigQuery raw-row purge capability.
+- #1029 strengthens the BigQuery purge with environment/project/table-bound guards.
+- #1001 provides guarded whole-prefix cleanup for mixed GCS Firestore export snapshots.
+- #1030 strengthens the GCS purge with environment/project/bucket-bound guards.
+- #1032 gates GCS cleanup on Firestore drain plus multiple newer clean snapshots.
+- #1031 provides a permanent read-only Firestore drain audit.
+
+Do not use a destructive command until the guard changes it depends on are present in the deployed/operator checkout.
+
+## Record the environment targets
+
+Before any deploy or deletion, record the actual values from read-only inventory. Do not copy project IDs or bucket names from memory.
+
+| Environment | GCP project ID | BigQuery dataset | Raw table | GCS Firestore export bucket |
+| --- | --- | --- | --- | --- |
+| development | `<fill from inventory>` | `firestore_export` | `live-chat-history` | `<fill from config/inventory>` |
+| production | `<fill from inventory>` | `firestore_export` | `live-chat-history` | `<fill from config/inventory>` |
+
+Run the repository inventory helper for both environments before cleanup planning:
+
+```bash
+scripts/gcp/raw-chat-resource-inventory.sh development <development-project-id> \
+  > /tmp/raw-chat-development-inventory.txt
+
+scripts/gcp/raw-chat-resource-inventory.sh production <production-project-id> \
+  > /tmp/raw-chat-production-inventory.txt
+```
+
+This is read-only. Review Cloud Asset Inventory, Scheduler, Functions, Cloud Run services/jobs, Pub/Sub, Eventarc, service accounts/IAM, Firestore indexes, GCS buckets, and BigQuery resources. Save the output with the migration record rather than committing environment-specific credentials or sensitive configuration.
+
+## Phase 1: development producer cutover
+
+### 1. Preflight
+
+Confirm the development deployment contains:
+
+- the `live-chat-history` BigQuery archive exclusion from #1002;
+- the Firestore raw-write removal from #1028;
+- the read-only drain audit from #1031.
+
+Do not treat a merge to `dev` as proof that the development runtime has been deployed.
+
+### 2. Deploy to development only
+
+Deploy the producer/archive changes to the development environment. Record the exact deployment timestamp as **Day 0**.
+
+Do not deploy the producer cutover to production yet.
+
+### 3. Verify the service path still works
+
+Confirm representative live-chat commands/moderation behavior still operates. The message-processing path must continue to use the fetched in-memory YouTube message; it must not depend on a successful raw history write.
+
+### 4. Verify Firestore raw rows stop growing
+
+Run:
+
+```bash
+cd system
+go run ./cmd/raw-chat-drain-audit development <development-project-id>
+```
+
+Immediately after Day 0, `total_rows` may still be non-zero because pre-cutover rows remain. Re-run the audit after normal chat activity. The total must not increase from newly persisted raw messages and should decrease as the existing retention cleanup runs.
+
+If raw rows increase after the producer cutover, stop the migration and find the remaining writer before proceeding.
+
+## Phase 2: development wait window
+
+The current Firestore history retention is five days. Existing rows therefore do not disappear immediately after the producer stops.
+
+Expected sequence:
+
+```text
+Day 0
+  raw Firestore producer stops
+
+approximately Day 5-7
+  Firestore live-chat-history reaches 0
+
+then subsequent daily Firestore exports
+  begin producing raw-free GCS snapshots
+
+then preserve multiple clean generations
+  at least 7 clean snapshots newer than the newest raw snapshot
+```
+
+With daily exports this can commonly require roughly **12-14 days from Day 0**, but calendar age is not the authority. The read-only Firestore count and GCS preview safety gates are authoritative.
+
+### Firestore drain gate
+
+Do not proceed to GCS apply until:
+
+```json
+{
+  "total_rows": 0,
+  "drained": true
+}
+```
+
+is reported for development.
+
+### GCS clean-snapshot gate
+
+Use the final guarded GCS command only in preview mode:
+
+```bash
+cd system
+go run ./cmd/privacy-gcs-admin preview \
+  development <development-project-id> <development-bucket-name>
+```
+
+Do not apply until `ready_to_apply` is true. The command must verify at least:
+
+- Firestore raw row count is zero;
+- the expected project and configured bucket match the operator target;
+- object versioning is disabled;
+- raw-containing snapshot prefixes exist;
+- at least seven clean snapshot prefixes are newer than the newest raw snapshot;
+- the latest overall snapshot is recent.
+
+## Phase 3: development purge rehearsal and manual apply
+
+### BigQuery preview
+
+Use only the target-bound command from #1029:
+
+```bash
+cd system
+go run ./cmd/privacy-retention-admin preview-bigquery \
+  development <development-project-id> <cutoff-rfc3339>
+```
+
+Check the preview target contains exactly:
+
+- `environment = development`;
+- the expected development project ID;
+- dataset `firestore_export`;
+- table `live-chat-history`.
+
+### BigQuery apply
+
+The operator manually copies the candidate count and exact token from the immediately preceding preview:
+
+```bash
+go run ./cmd/privacy-retention-admin apply-bigquery \
+  development <development-project-id> <cutoff-rfc3339> \
+  --expected-rows <preview-count> \
+  --confirm '<exact-preview-token>'
+```
+
+Do not reuse a token from another environment or an earlier preview.
+
+### GCS preview and apply
+
+Run a fresh GCS preview immediately before apply. If any gate changed, stop and re-evaluate.
+
+```bash
+go run ./cmd/privacy-gcs-admin preview \
+  development <development-project-id> <development-bucket-name>
+```
+
+The operator then manually uses only the values from that preview:
+
+```bash
+go run ./cmd/privacy-gcs-admin apply \
+  development <development-project-id> <development-bucket-name> \
+  --expected-prefixes <preview-value> \
+  --expected-objects <preview-value> \
+  --confirm '<exact-preview-token>'
+```
+
+GCS soft delete means removal from the live namespace is not immediate hard deletion. Record the configured soft-delete retention and the expected hard-delete window.
+
+### Development verification
+
+Before production cutover, verify:
+
+- `raw-chat-drain-audit` still reports zero Firestore rows;
+- BigQuery raw purge post-check reports no candidate rows for the selected cutoff;
+- GCS post-check reports zero live raw-containing snapshot prefixes;
+- retained BigQuery tables and the mixed GCS bucket still exist;
+- representative Study Space functionality still works.
+
+## Phase 4: production producer cutover
+
+Only after the development sequence has been validated:
+
+1. confirm #1002 and #1028 are included in the production deployment artifact;
+2. deploy the producer/archive changes to production;
+3. record a separate production **Day 0** timestamp;
+4. do not run BigQuery/GCS apply immediately after deployment;
+5. monitor the raw Firestore count with the production target explicitly supplied.
+
+```bash
+cd system
+go run ./cmd/raw-chat-drain-audit production <production-project-id>
+```
+
+## Phase 5: production wait window
+
+Repeat the same gates used in development:
+
+1. wait for Firestore `live-chat-history` to reach zero, normally after the existing short retention window;
+2. wait for subsequent raw-free daily Firestore exports;
+3. retain at least seven clean snapshots newer than the final raw-containing snapshot;
+4. require the GCS preview to report `ready_to_apply = true`.
+
+Do not shorten this sequence merely because development succeeded.
+
+## Phase 6: production manual purge
+
+Production destructive operations are manual only.
+
+### BigQuery
+
+```bash
+cd system
+go run ./cmd/privacy-retention-admin preview-bigquery \
+  production <production-project-id> <cutoff-rfc3339>
+```
+
+After checking the exact target and candidate count, the operator may run:
+
+```bash
+go run ./cmd/privacy-retention-admin apply-bigquery \
+  production <production-project-id> <cutoff-rfc3339> \
+  --expected-rows <preview-count> \
+  --confirm '<exact-preview-token>' \
+  --allow-production
+```
+
+### GCS
+
+```bash
+go run ./cmd/privacy-gcs-admin preview \
+  production <production-project-id> <production-bucket-name>
+```
+
+Only when the fresh preview is ready may the operator run:
+
+```bash
+go run ./cmd/privacy-gcs-admin apply \
+  production <production-project-id> <production-bucket-name> \
+  --expected-prefixes <preview-value> \
+  --expected-objects <preview-value> \
+  --confirm '<exact-preview-token>' \
+  --allow-production
+```
+
+Record the before/after JSON from both tools.
+
+## Phase 7: GCP resource cleanup
+
+After raw data cleanup has completed in **both** environments, rerun the read-only resource inventory for development and production.
+
+Classify each candidate as `dedicated`, `shared`, or `uncertain`.
+
+Potential dedicated cleanup candidates:
+
+- BigQuery `firestore_export.live-chat-history` table;
+- Scheduler jobs used only for raw chat archival;
+- raw-chat-only Cloud Functions or Cloud Run jobs/services;
+- raw-chat-only Pub/Sub topics/subscriptions or Eventarc triggers;
+- service accounts used only by the retired raw archive;
+- IAM grants needed only by those dedicated resources;
+- Firestore indexes used only by retired raw history operations.
+
+Resources that remain:
+
+- BigQuery `firestore_export` dataset;
+- `user-activity-history`;
+- `order-history`;
+- the mixed Firestore backup GCS bucket;
+- any export/scheduler/function/service account/IAM resource also used by retained Study Space data.
+
+Do not delete an `uncertain` or shared resource. First inspect its target, trigger, code, IAM bindings, and consumers.
+
+Delete the obsolete BigQuery raw table itself only during this resource-cleanup phase, after confirming there is no retained consumer and both environment migrations are complete.
+
+## Phase 8: repository deletion-tool cleanup
+
+Once both environment migrations and cloud resource cleanup are complete, create a final cleanup PR. It should remove temporary destructive capabilities rather than leave dormant DELETE paths in the repository.
+
+Remove or reduce at least:
+
+- `privacy-retention-admin` BigQuery DELETE/apply capability;
+- `privacy-gcs-admin` GCS DELETE/apply capability;
+- one-shot purge helpers used only by this migration;
+- one-shot purge tests that no longer protect retained behavior;
+- migration-only code and documentation that is no longer operationally needed.
+
+Keep useful read-only checks, including Firestore raw-row drain/reappearance auditing and broader retention/resource inventory where they remain useful.
+
+## Final verification checklist
+
+The migration is complete only when all of the following are true for development and production:
+
+- [ ] youtube-bot no longer persists fetched raw messages to Firestore `live-chat-history`.
+- [ ] Firestore `live-chat-history` total row count is zero.
+- [ ] GCS-to-BigQuery transfer does not import `live-chat-history`.
+- [ ] no live GCS Firestore export snapshot contains `kind_live-chat-history`.
+- [ ] GCS soft-delete timing has been recorded and allowed to expire as required for hard deletion verification.
+- [ ] BigQuery `firestore_export.live-chat-history` has been removed in the final resource-cleanup phase.
+- [ ] `firestore_export.user-activity-history` remains.
+- [ ] `firestore_export.order-history` remains.
+- [ ] the `firestore_export` dataset remains.
+- [ ] the mixed GCS backup bucket remains.
+- [ ] raw-chat-only cloud resources/IAM/indexes identified by inventory have been removed, with shared resources preserved.
+- [ ] one-shot DELETE capabilities have been removed from the repository.
+- [ ] retained read-only audits still pass and do not expose a new raw persistence path.

--- a/scripts/gcp/raw-chat-resource-inventory.sh
+++ b/scripts/gcp/raw-chat-resource-inventory.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/gcp/raw-chat-resource-inventory.sh <development|production> <gcp-project-id>
+
+Read-only inventory for resources that may participate in raw live-chat archival.
+The script only uses describe/get/list/search/show operations. It does not deploy,
+update, delete, or change the active gcloud project.
+EOF
+}
+
+if [[ $# -ne 2 ]]; then
+  usage >&2
+  exit 2
+fi
+
+TARGET_ENVIRONMENT="$1"
+PROJECT_ID="$2"
+
+case "$TARGET_ENVIRONMENT" in
+  development|production) ;;
+  *)
+    echo "environment must be development or production: $TARGET_ENVIRONMENT" >&2
+    exit 2
+    ;;
+esac
+
+if [[ -z "$PROJECT_ID" ]]; then
+  echo "gcp-project-id must not be empty" >&2
+  exit 2
+fi
+
+if ! command -v gcloud >/dev/null 2>&1; then
+  echo "gcloud is required" >&2
+  exit 1
+fi
+
+section() {
+  printf '\n\n===== %s =====\n' "$1"
+}
+
+run_read_only() {
+  printf '\n+ '
+  printf '%q ' "$@"
+  printf '\n'
+  if ! "$@"; then
+    printf 'WARN: command failed; continuing read-only inventory\n' >&2
+  fi
+}
+
+section "TARGET"
+printf 'environment: %s\n' "$TARGET_ENVIRONMENT"
+printf 'project_id: %s\n' "$PROJECT_ID"
+run_read_only gcloud auth list --filter=status:ACTIVE --format='value(account)'
+run_read_only gcloud config get-value project
+run_read_only gcloud projects describe "$PROJECT_ID" --format=json
+
+PROJECT_NUMBER="$(gcloud projects describe "$PROJECT_ID" --format='value(projectNumber)' 2>/dev/null || true)"
+if [[ -z "$PROJECT_NUMBER" ]]; then
+  echo "Unable to resolve project number; Cloud Asset Inventory section will be skipped." >&2
+else
+  section "CLOUD ASSET INVENTORY - RAW CHAT NAME SEARCH"
+  for term in live-chat-history raw-chat live-chat; do
+    run_read_only gcloud asset search-all-resources \
+      --scope="projects/${PROJECT_NUMBER}" \
+      --query="$term" \
+      --format=json
+  done
+fi
+
+section "CLOUD SCHEDULER"
+run_read_only gcloud scheduler jobs list --project="$PROJECT_ID" --format=json
+
+section "CLOUD FUNCTIONS"
+run_read_only gcloud functions list --project="$PROJECT_ID" --format=json
+
+section "CLOUD RUN SERVICES"
+run_read_only gcloud run services list --project="$PROJECT_ID" --format=json
+
+section "CLOUD RUN JOBS"
+run_read_only gcloud run jobs list --project="$PROJECT_ID" --format=json
+
+section "PUB/SUB TOPICS"
+run_read_only gcloud pubsub topics list --project="$PROJECT_ID" --format=json
+
+section "PUB/SUB SUBSCRIPTIONS"
+run_read_only gcloud pubsub subscriptions list --project="$PROJECT_ID" --format=json
+
+section "EVENTARC TRIGGERS"
+run_read_only gcloud eventarc triggers list --project="$PROJECT_ID" --format=json
+
+section "SERVICE ACCOUNTS"
+run_read_only gcloud iam service-accounts list --project="$PROJECT_ID" --format=json
+
+section "PROJECT IAM POLICY"
+run_read_only gcloud projects get-iam-policy "$PROJECT_ID" --format=json
+
+section "FIRESTORE COMPOSITE INDEXES"
+run_read_only gcloud firestore indexes composite list \
+  --project="$PROJECT_ID" \
+  --database='(default)' \
+  --format=json
+
+section "FIRESTORE SINGLE-FIELD INDEX OVERRIDES"
+run_read_only gcloud firestore indexes fields list \
+  --project="$PROJECT_ID" \
+  --database='(default)' \
+  --format=json
+
+section "GCS BUCKETS"
+run_read_only gcloud storage buckets list --project="$PROJECT_ID" --format=json
+
+section "BIGQUERY"
+if command -v bq >/dev/null 2>&1; then
+  run_read_only bq --project_id="$PROJECT_ID" ls --format=prettyjson
+  run_read_only bq --project_id="$PROJECT_ID" show --format=prettyjson "${PROJECT_ID}:firestore_export"
+  run_read_only bq --project_id="$PROJECT_ID" show --format=prettyjson "${PROJECT_ID}:firestore_export.live-chat-history"
+  run_read_only bq --project_id="$PROJECT_ID" show --format=prettyjson "${PROJECT_ID}:firestore_export.user-activity-history"
+  run_read_only bq --project_id="$PROJECT_ID" show --format=prettyjson "${PROJECT_ID}:firestore_export.order-history"
+else
+  echo "WARN: bq is not installed; BigQuery details were not collected." >&2
+fi
+
+section "INVENTORY REVIEW"
+cat <<EOF
+Target environment: ${TARGET_ENVIRONMENT}
+Target project:     ${PROJECT_ID}
+
+Review the output for resources dedicated only to raw live-chat archival. Do not
+classify a resource as removable merely because its name contains 'chat'. Confirm
+its targets, triggers, service account permissions, and whether Study Space domain
+data also depends on it.
+
+Potential retirement candidates after the migration completes:
+- BigQuery firestore_export.live-chat-history table
+- raw-chat-only Scheduler / Function / Cloud Run Job / Pub/Sub / Eventarc resources
+- raw-chat-only service accounts or IAM grants
+- raw-chat-only Firestore indexes
+
+Resources that must remain when shared by other data flows include:
+- BigQuery firestore_export dataset
+- user-activity-history and order-history tables
+- mixed Firestore export GCS bucket
+- shared Firestore export infrastructure
+EOF

--- a/system/cmd/privacy-gcs-admin/main.go
+++ b/system/cmd/privacy-gcs-admin/main.go
@@ -1,0 +1,426 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"google.golang.org/api/iterator"
+	"google.golang.org/api/option"
+
+	"app.modules/core/repository"
+	"app.modules/core/utils"
+)
+
+const (
+	rawLiveChatPathMarker         = "/all_namespaces/kind_live-chat-history/"
+	rawYouTubeDataRetentionDays   = 30
+	minimumCleanSnapshotsAfterRaw = 7
+	maximumLatestSnapshotAge      = 72 * time.Hour
+)
+
+type objectRef struct {
+	Name       string
+	Generation int64
+	Size       int64
+	Created    time.Time
+}
+
+type prefixInventory struct {
+	Prefix          string
+	Objects         []objectRef
+	ObjectCount     int64
+	Bytes           int64
+	LatestCreatedAt time.Time
+	ContainsRawChat bool
+}
+
+type bucketInventory struct {
+	Prefixes          []prefixInventory
+	VersioningEnabled bool
+	SoftDelete        time.Duration
+}
+
+type safetyCheck struct {
+	Name   string `json:"name"`
+	Passed bool   `json:"passed"`
+	Detail string `json:"detail"`
+}
+
+type previewOutput struct {
+	GeneratedAt                    time.Time     `json:"generated_at"`
+	Cutoff                         time.Time     `json:"cutoff"`
+	BucketName                     string        `json:"bucket_name"`
+	VersioningEnabled              bool          `json:"versioning_enabled"`
+	SoftDeleteRetention            string        `json:"soft_delete_retention,omitempty"`
+	TotalSnapshotPrefixes          int           `json:"total_snapshot_prefixes"`
+	RawChatSnapshotPrefixes        int           `json:"raw_chat_snapshot_prefixes"`
+	ExpiredRawChatSnapshotPrefixes int           `json:"expired_raw_chat_snapshot_prefixes"`
+	CandidateObjectCount           int64         `json:"candidate_object_count"`
+	CandidateBytes                 int64         `json:"candidate_bytes"`
+	OldestRawChatPrefix            string        `json:"oldest_raw_chat_prefix,omitempty"`
+	NewestRawChatPrefix            string        `json:"newest_raw_chat_prefix,omitempty"`
+	NewestRawChatCreatedAt         string        `json:"newest_raw_chat_created_at,omitempty"`
+	CleanSnapshotsAfterNewestRaw   int           `json:"clean_snapshots_after_newest_raw"`
+	NewestCleanPrefix              string        `json:"newest_clean_prefix,omitempty"`
+	LatestSnapshotPrefix           string        `json:"latest_snapshot_prefix,omitempty"`
+	LatestSnapshotCreatedAt        string        `json:"latest_snapshot_created_at,omitempty"`
+	SafetyChecks                   []safetyCheck `json:"safety_checks"`
+	ReadyToApply                   bool          `json:"ready_to_apply"`
+	RequiredConfirmation           string        `json:"required_confirmation,omitempty"`
+	Notes                          []string      `json:"notes,omitempty"`
+}
+
+func main() {
+	if err := run(context.Background(), os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, "privacy-gcs-admin:", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args []string) error {
+	if len(args) < 2 {
+		return usageError()
+	}
+
+	utils.LoadEnv(".env")
+	credentialFilePath := strings.TrimSpace(os.Getenv("CREDENTIAL_FILE_LOCATION"))
+	if credentialFilePath == "" {
+		return errors.New("CREDENTIAL_FILE_LOCATION is required")
+	}
+	//nolint:staticcheck // Operator-controlled service-account JSON used only by this admin command.
+	clientOption := option.WithCredentialsFile(credentialFilePath)
+
+	repo, err := repository.NewFirestoreController(ctx, clientOption)
+	if err != nil {
+		return fmt.Errorf("initialize Firestore: %w", err)
+	}
+	defer func() {
+		if err := repo.FirestoreClient().Close(); err != nil {
+			fmt.Fprintln(os.Stderr, "privacy-gcs-admin: close Firestore:", err)
+		}
+	}()
+
+	constants, err := repo.ReadSystemConstantsConfig(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("read system constants: %w", err)
+	}
+	bucketName := strings.TrimSpace(constants.GcsFirestoreExportBucketName)
+	if bucketName == "" {
+		return errors.New("gcs-firestore-export-bucket-name is empty")
+	}
+
+	storageClient, err := storage.NewClient(ctx, clientOption)
+	if err != nil {
+		return fmt.Errorf("initialize GCS client: %w", err)
+	}
+	defer func() {
+		if err := storageClient.Close(); err != nil {
+			fmt.Fprintln(os.Stderr, "privacy-gcs-admin: close GCS client:", err)
+		}
+	}()
+	bucket := storageClient.Bucket(bucketName)
+
+	now := time.Now().UTC()
+	inventory, err := inspectBucket(ctx, bucket)
+	if err != nil {
+		return err
+	}
+	preview := buildPreview(now, bucketName, inventory)
+
+	switch args[1] {
+	case "preview":
+		if len(args) != 2 {
+			return usageError()
+		}
+		return writeJSON(preview)
+	case "apply":
+		return apply(ctx, bucket, preview, inventory, args[2:])
+	default:
+		return usageError()
+	}
+}
+
+func usageError() error {
+	return errors.New("usage: privacy-gcs-admin preview | privacy-gcs-admin apply --expected-prefixes <count> --expected-objects <count> --confirm <token>")
+}
+
+func inspectBucket(ctx context.Context, bucket *storage.BucketHandle) (bucketInventory, error) {
+	attrs, err := bucket.Attrs(ctx)
+	if err != nil {
+		return bucketInventory{}, fmt.Errorf("read bucket attributes: %w", err)
+	}
+
+	byPrefix := make(map[string]*prefixInventory)
+	it := bucket.Objects(ctx, nil)
+	for {
+		attrs, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		}
+		if err != nil {
+			return bucketInventory{}, fmt.Errorf("list GCS objects: %w", err)
+		}
+		prefix := topLevelPrefix(attrs.Name)
+		entry, ok := byPrefix[prefix]
+		if !ok {
+			entry = &prefixInventory{Prefix: prefix}
+			byPrefix[prefix] = entry
+		}
+		entry.Objects = append(entry.Objects, objectRef{
+			Name:       attrs.Name,
+			Generation: attrs.Generation,
+			Size:       attrs.Size,
+			Created:    attrs.Created,
+		})
+		entry.ObjectCount++
+		entry.Bytes += attrs.Size
+		if attrs.Created.After(entry.LatestCreatedAt) {
+			entry.LatestCreatedAt = attrs.Created
+		}
+		if strings.Contains(attrs.Name, rawLiveChatPathMarker) {
+			entry.ContainsRawChat = true
+		}
+	}
+
+	prefixes := make([]prefixInventory, 0, len(byPrefix))
+	for _, entry := range byPrefix {
+		prefixes = append(prefixes, *entry)
+	}
+	sort.Slice(prefixes, func(i, j int) bool {
+		if prefixes[i].LatestCreatedAt.Equal(prefixes[j].LatestCreatedAt) {
+			return prefixes[i].Prefix < prefixes[j].Prefix
+		}
+		return prefixes[i].LatestCreatedAt.Before(prefixes[j].LatestCreatedAt)
+	})
+
+	var softDelete time.Duration
+	if attrs.SoftDeletePolicy != nil {
+		softDelete = attrs.SoftDeletePolicy.RetentionDuration
+	}
+
+	return bucketInventory{
+		Prefixes:          prefixes,
+		VersioningEnabled: attrs.VersioningEnabled,
+		SoftDelete:        softDelete,
+	}, nil
+}
+
+func buildPreview(now time.Time, bucketName string, inventory bucketInventory) previewOutput {
+	cutoff := now.AddDate(0, 0, -rawYouTubeDataRetentionDays)
+	out := previewOutput{
+		GeneratedAt:           now,
+		Cutoff:                cutoff,
+		BucketName:            bucketName,
+		VersioningEnabled:     inventory.VersioningEnabled,
+		TotalSnapshotPrefixes: len(inventory.Prefixes),
+	}
+	if inventory.SoftDelete > 0 {
+		out.SoftDeleteRetention = inventory.SoftDelete.String()
+	}
+
+	var newestRaw time.Time
+	var latestSnapshot time.Time
+	for _, prefix := range inventory.Prefixes {
+		if prefix.LatestCreatedAt.After(latestSnapshot) {
+			latestSnapshot = prefix.LatestCreatedAt
+			out.LatestSnapshotPrefix = prefix.Prefix
+			out.LatestSnapshotCreatedAt = formatTime(prefix.LatestCreatedAt)
+		}
+		if !prefix.ContainsRawChat {
+			continue
+		}
+		out.RawChatSnapshotPrefixes++
+		if out.OldestRawChatPrefix == "" {
+			out.OldestRawChatPrefix = prefix.Prefix
+		}
+		if prefix.LatestCreatedAt.After(newestRaw) {
+			newestRaw = prefix.LatestCreatedAt
+			out.NewestRawChatPrefix = prefix.Prefix
+			out.NewestRawChatCreatedAt = formatTime(prefix.LatestCreatedAt)
+		}
+		if prefix.LatestCreatedAt.Before(cutoff) {
+			out.ExpiredRawChatSnapshotPrefixes++
+			out.CandidateObjectCount += prefix.ObjectCount
+			out.CandidateBytes += prefix.Bytes
+		}
+	}
+
+	for _, prefix := range inventory.Prefixes {
+		if prefix.ContainsRawChat || newestRaw.IsZero() || !prefix.LatestCreatedAt.After(newestRaw) {
+			continue
+		}
+		out.CleanSnapshotsAfterNewestRaw++
+		out.NewestCleanPrefix = prefix.Prefix
+	}
+
+	allRawExpired := out.RawChatSnapshotPrefixes > 0 && out.RawChatSnapshotPrefixes == out.ExpiredRawChatSnapshotPrefixes
+	latestRecent := !latestSnapshot.IsZero() && now.Sub(latestSnapshot) <= maximumLatestSnapshotAge
+	checks := []safetyCheck{
+		{
+			Name:   "object_versioning_disabled",
+			Passed: !inventory.VersioningEnabled,
+			Detail: fmt.Sprintf("versioning_enabled=%t", inventory.VersioningEnabled),
+		},
+		{
+			Name:   "all_raw_chat_snapshots_expired",
+			Passed: allRawExpired,
+			Detail: fmt.Sprintf("raw=%d expired=%d", out.RawChatSnapshotPrefixes, out.ExpiredRawChatSnapshotPrefixes),
+		},
+		{
+			Name:   "clean_snapshots_exist_after_raw",
+			Passed: out.CleanSnapshotsAfterNewestRaw >= minimumCleanSnapshotsAfterRaw,
+			Detail: fmt.Sprintf("clean_after_raw=%d required=%d", out.CleanSnapshotsAfterNewestRaw, minimumCleanSnapshotsAfterRaw),
+		},
+		{
+			Name:   "latest_snapshot_is_recent",
+			Passed: latestRecent,
+			Detail: fmt.Sprintf("latest=%s max_age=%s", out.LatestSnapshotCreatedAt, maximumLatestSnapshotAge),
+		},
+	}
+	out.SafetyChecks = checks
+	out.ReadyToApply = true
+	for _, check := range checks {
+		if !check.Passed {
+			out.ReadyToApply = false
+		}
+	}
+	if out.ReadyToApply {
+		out.RequiredConfirmation = confirmationToken(out)
+	}
+	out.Notes = []string{
+		"preview is read-only",
+		"apply deletes complete Firestore export prefixes that contain raw live-chat data; it does not partially edit snapshots",
+		"clean snapshots newer than the newest raw-chat snapshot are preserved",
+	}
+	if inventory.SoftDelete > 0 {
+		out.Notes = append(out.Notes, "deleted objects remain recoverable in GCS soft delete until the configured retention expires")
+	}
+	return out
+}
+
+func apply(
+	ctx context.Context,
+	bucket *storage.BucketHandle,
+	preview previewOutput,
+	inventory bucketInventory,
+	args []string,
+) error {
+	flags := flag.NewFlagSet("apply", flag.ContinueOnError)
+	flags.SetOutput(os.Stderr)
+	expectedPrefixes := flags.Int("expected-prefixes", -1, "expected expired raw-chat snapshot prefix count")
+	expectedObjects := flags.Int64("expected-objects", -1, "expected object count across candidate prefixes")
+	confirm := flags.String("confirm", "", "exact confirmation token returned by preview")
+	if err := flags.Parse(args); err != nil {
+		return fmt.Errorf("parse apply flags: %w", err)
+	}
+	if flags.NArg() != 0 || *expectedPrefixes < 0 || *expectedObjects < 0 || *confirm == "" {
+		return usageError()
+	}
+	if !preview.ReadyToApply {
+		return errors.New("refusing GCS deletion because preview safety checks are not all satisfied")
+	}
+	if *expectedPrefixes != preview.ExpiredRawChatSnapshotPrefixes {
+		return fmt.Errorf("candidate prefix count changed: expected=%d actual=%d", *expectedPrefixes, preview.ExpiredRawChatSnapshotPrefixes)
+	}
+	if *expectedObjects != preview.CandidateObjectCount {
+		return fmt.Errorf("candidate object count changed: expected=%d actual=%d", *expectedObjects, preview.CandidateObjectCount)
+	}
+	if *confirm != confirmationToken(preview) {
+		return errors.New("confirmation token does not match current preview")
+	}
+
+	deletedObjects := int64(0)
+	for _, prefix := range inventory.Prefixes {
+		if !prefix.ContainsRawChat || !prefix.LatestCreatedAt.Before(preview.Cutoff) {
+			continue
+		}
+		for _, object := range deletionOrder(prefix.Objects) {
+			objectHandle := bucket.Object(object.Name)
+			if object.Generation != 0 {
+				objectHandle = objectHandle.Generation(object.Generation)
+			}
+			if err := objectHandle.Delete(ctx); err != nil && !errors.Is(err, storage.ErrObjectNotExist) {
+				return fmt.Errorf("delete GCS object %q: %w", object.Name, err)
+			}
+			deletedObjects++
+		}
+	}
+
+	postInventory, err := inspectBucket(ctx, bucket)
+	if err != nil {
+		return fmt.Errorf("post-delete bucket inspection: %w", err)
+	}
+	postPreview := buildPreview(time.Now().UTC(), preview.BucketName, postInventory)
+	if postPreview.RawChatSnapshotPrefixes != 0 {
+		return fmt.Errorf("post-delete verification failed: %d live raw-chat snapshot prefixes remain", postPreview.RawChatSnapshotPrefixes)
+	}
+
+	return writeJSON(struct {
+		Status              string        `json:"status"`
+		BucketName          string        `json:"bucket_name"`
+		DeletedLiveObjects  int64         `json:"deleted_live_objects"`
+		SoftDeleteRetention string        `json:"soft_delete_retention,omitempty"`
+		PostCheck           previewOutput `json:"post_check"`
+	}{
+		Status:              "deleted live raw-chat snapshot prefixes",
+		BucketName:          preview.BucketName,
+		DeletedLiveObjects:  deletedObjects,
+		SoftDeleteRetention: preview.SoftDeleteRetention,
+		PostCheck:           postPreview,
+	})
+}
+
+func deletionOrder(objects []objectRef) []objectRef {
+	ordered := append([]objectRef(nil), objects...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		iRaw := strings.Contains(ordered[i].Name, rawLiveChatPathMarker)
+		jRaw := strings.Contains(ordered[j].Name, rawLiveChatPathMarker)
+		if iRaw != jRaw {
+			return !iRaw
+		}
+		return ordered[i].Name < ordered[j].Name
+	})
+	return ordered
+}
+
+func confirmationToken(preview previewOutput) string {
+	return fmt.Sprintf(
+		"DELETE %d GCS FIRESTORE EXPORT SNAPSHOTS CONTAINING RAW YOUTUBE CHAT (%d OBJECTS) FROM %s THROUGH %s",
+		preview.ExpiredRawChatSnapshotPrefixes,
+		preview.CandidateObjectCount,
+		preview.BucketName,
+		strings.TrimSuffix(preview.NewestRawChatPrefix, "/"),
+	)
+}
+
+func topLevelPrefix(objectName string) string {
+	index := strings.IndexByte(objectName, '/')
+	if index < 0 {
+		return "(root)"
+	}
+	return objectName[:index+1]
+}
+
+func formatTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func writeJSON(value any) error {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(value); err != nil {
+		return fmt.Errorf("encode JSON: %w", err)
+	}
+	return nil
+}

--- a/system/cmd/privacy-gcs-admin/main.go
+++ b/system/cmd/privacy-gcs-admin/main.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"cloud.google.com/go/firestore/apiv1/firestorepb"
 	"cloud.google.com/go/storage"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
@@ -21,7 +22,7 @@ import (
 
 const (
 	rawLiveChatPathMarker         = "/all_namespaces/kind_live-chat-history/"
-	rawYouTubeDataRetentionDays   = 30
+	firestoreCountAlias           = "row_count"
 	minimumCleanSnapshotsAfterRaw = 7
 	maximumLatestSnapshotAge      = 72 * time.Hour
 )
@@ -55,27 +56,27 @@ type safetyCheck struct {
 }
 
 type previewOutput struct {
-	GeneratedAt                    time.Time     `json:"generated_at"`
-	Cutoff                         time.Time     `json:"cutoff"`
-	BucketName                     string        `json:"bucket_name"`
-	VersioningEnabled              bool          `json:"versioning_enabled"`
-	SoftDeleteRetention            string        `json:"soft_delete_retention,omitempty"`
-	TotalSnapshotPrefixes          int           `json:"total_snapshot_prefixes"`
-	RawChatSnapshotPrefixes        int           `json:"raw_chat_snapshot_prefixes"`
-	ExpiredRawChatSnapshotPrefixes int           `json:"expired_raw_chat_snapshot_prefixes"`
-	CandidateObjectCount           int64         `json:"candidate_object_count"`
-	CandidateBytes                 int64         `json:"candidate_bytes"`
-	OldestRawChatPrefix            string        `json:"oldest_raw_chat_prefix,omitempty"`
-	NewestRawChatPrefix            string        `json:"newest_raw_chat_prefix,omitempty"`
-	NewestRawChatCreatedAt         string        `json:"newest_raw_chat_created_at,omitempty"`
-	CleanSnapshotsAfterNewestRaw   int           `json:"clean_snapshots_after_newest_raw"`
-	NewestCleanPrefix              string        `json:"newest_clean_prefix,omitempty"`
-	LatestSnapshotPrefix           string        `json:"latest_snapshot_prefix,omitempty"`
-	LatestSnapshotCreatedAt        string        `json:"latest_snapshot_created_at,omitempty"`
-	SafetyChecks                   []safetyCheck `json:"safety_checks"`
-	ReadyToApply                   bool          `json:"ready_to_apply"`
-	RequiredConfirmation           string        `json:"required_confirmation,omitempty"`
-	Notes                          []string      `json:"notes,omitempty"`
+	GeneratedAt                      time.Time      `json:"generated_at"`
+	Target                           gcsPurgeTarget `json:"target"`
+	FirestoreRawChatRows             int64          `json:"firestore_raw_chat_rows"`
+	VersioningEnabled                bool           `json:"versioning_enabled"`
+	SoftDeleteRetention              string         `json:"soft_delete_retention,omitempty"`
+	TotalSnapshotPrefixes            int            `json:"total_snapshot_prefixes"`
+	RawChatSnapshotPrefixes          int            `json:"raw_chat_snapshot_prefixes"`
+	CandidateRawChatSnapshotPrefixes int            `json:"candidate_raw_chat_snapshot_prefixes"`
+	CandidateObjectCount             int64          `json:"candidate_object_count"`
+	CandidateBytes                   int64          `json:"candidate_bytes"`
+	OldestRawChatPrefix              string         `json:"oldest_raw_chat_prefix,omitempty"`
+	NewestRawChatPrefix              string         `json:"newest_raw_chat_prefix,omitempty"`
+	NewestRawChatCreatedAt           string         `json:"newest_raw_chat_created_at,omitempty"`
+	CleanSnapshotsAfterNewestRaw     int            `json:"clean_snapshots_after_newest_raw"`
+	NewestCleanPrefix                string         `json:"newest_clean_prefix,omitempty"`
+	LatestSnapshotPrefix             string         `json:"latest_snapshot_prefix,omitempty"`
+	LatestSnapshotCreatedAt          string         `json:"latest_snapshot_created_at,omitempty"`
+	SafetyChecks                     []safetyCheck  `json:"safety_checks"`
+	ReadyToApply                     bool           `json:"ready_to_apply"`
+	RequiredConfirmation             string         `json:"required_confirmation,omitempty"`
+	Notes                            []string       `json:"notes,omitempty"`
 }
 
 func main() {
@@ -86,7 +87,18 @@ func main() {
 }
 
 func run(ctx context.Context, args []string) error {
-	if len(args) < 2 {
+	if len(args) < 5 {
+		return usageError()
+	}
+
+	command := strings.TrimSpace(args[1])
+	environment := strings.TrimSpace(args[2])
+	expectedProjectID := strings.TrimSpace(args[3])
+	expectedBucketName := strings.TrimSpace(args[4])
+	if command == "preview" && len(args) != 5 {
+		return usageError()
+	}
+	if command != "preview" && command != "apply" {
 		return usageError()
 	}
 
@@ -112,9 +124,25 @@ func run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("read system constants: %w", err)
 	}
-	bucketName := strings.TrimSpace(constants.GcsFirestoreExportBucketName)
-	if bucketName == "" {
-		return errors.New("gcs-firestore-export-bucket-name is empty")
+	actualProjectID, err := utils.GetGcpProjectID(ctx, clientOption)
+	if err != nil {
+		return fmt.Errorf("resolve GCP project ID: %w", err)
+	}
+	configuredBucketName := strings.TrimSpace(constants.GcsFirestoreExportBucketName)
+	target, err := buildGCSPurgeTarget(
+		environment,
+		expectedProjectID,
+		actualProjectID,
+		expectedBucketName,
+		configuredBucketName,
+	)
+	if err != nil {
+		return err
+	}
+
+	firestoreRawChatRows, err := countRawLiveChatRows(ctx, repo.FirestoreClient())
+	if err != nil {
+		return err
 	}
 
 	storageClient, err := storage.NewClient(ctx, clientOption)
@@ -126,30 +154,48 @@ func run(ctx context.Context, args []string) error {
 			fmt.Fprintln(os.Stderr, "privacy-gcs-admin: close GCS client:", err)
 		}
 	}()
-	bucket := storageClient.Bucket(bucketName)
+	bucket := storageClient.Bucket(target.BucketName)
 
 	now := time.Now().UTC()
 	inventory, err := inspectBucket(ctx, bucket)
 	if err != nil {
 		return err
 	}
-	preview := buildPreview(now, bucketName, inventory)
+	preview := buildPreview(now, target, inventory, firestoreRawChatRows)
 
-	switch args[1] {
+	switch command {
 	case "preview":
-		if len(args) != 2 {
-			return usageError()
-		}
 		return writeJSON(preview)
 	case "apply":
-		return apply(ctx, bucket, preview, inventory, args[2:])
+		return apply(ctx, bucket, preview, inventory, args[5:])
 	default:
 		return usageError()
 	}
 }
 
 func usageError() error {
-	return errors.New("usage: privacy-gcs-admin preview | privacy-gcs-admin apply --expected-prefixes <count> --expected-objects <count> --confirm <token>")
+	return errors.New(
+		"usage: privacy-gcs-admin preview <development|production> <expected-project-id> <expected-bucket-name> OR " +
+			"privacy-gcs-admin apply <development|production> <expected-project-id> <expected-bucket-name> " +
+			"--expected-prefixes <count> --expected-objects <count> --confirm <token> [--allow-production]",
+	)
+}
+
+func countRawLiveChatRows(ctx context.Context, client repository.DBClient) (int64, error) {
+	query := client.Collection(repository.LiveChatHistory).Query
+	result, err := query.NewAggregationQuery().WithCount(firestoreCountAlias).Get(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("count Firestore raw live chat rows: %w", err)
+	}
+	rawCount, ok := result[firestoreCountAlias]
+	if !ok {
+		return 0, fmt.Errorf("count aggregation missing alias %q", firestoreCountAlias)
+	}
+	countValue, ok := rawCount.(*firestorepb.Value)
+	if !ok {
+		return 0, fmt.Errorf("count aggregation has unexpected type %T", rawCount)
+	}
+	return countValue.GetIntegerValue(), nil
 }
 
 func inspectBucket(ctx context.Context, bucket *storage.BucketHandle) (bucketInventory, error) {
@@ -213,12 +259,16 @@ func inspectBucket(ctx context.Context, bucket *storage.BucketHandle) (bucketInv
 	}, nil
 }
 
-func buildPreview(now time.Time, bucketName string, inventory bucketInventory) previewOutput {
-	cutoff := now.AddDate(0, 0, -rawYouTubeDataRetentionDays)
+func buildPreview(
+	now time.Time,
+	target gcsPurgeTarget,
+	inventory bucketInventory,
+	firestoreRawChatRows int64,
+) previewOutput {
 	out := previewOutput{
 		GeneratedAt:           now,
-		Cutoff:                cutoff,
-		BucketName:            bucketName,
+		Target:                target,
+		FirestoreRawChatRows:  firestoreRawChatRows,
 		VersioningEnabled:     inventory.VersioningEnabled,
 		TotalSnapshotPrefixes: len(inventory.Prefixes),
 	}
@@ -238,6 +288,9 @@ func buildPreview(now time.Time, bucketName string, inventory bucketInventory) p
 			continue
 		}
 		out.RawChatSnapshotPrefixes++
+		out.CandidateRawChatSnapshotPrefixes++
+		out.CandidateObjectCount += prefix.ObjectCount
+		out.CandidateBytes += prefix.Bytes
 		if out.OldestRawChatPrefix == "" {
 			out.OldestRawChatPrefix = prefix.Prefix
 		}
@@ -245,11 +298,6 @@ func buildPreview(now time.Time, bucketName string, inventory bucketInventory) p
 			newestRaw = prefix.LatestCreatedAt
 			out.NewestRawChatPrefix = prefix.Prefix
 			out.NewestRawChatCreatedAt = formatTime(prefix.LatestCreatedAt)
-		}
-		if prefix.LatestCreatedAt.Before(cutoff) {
-			out.ExpiredRawChatSnapshotPrefixes++
-			out.CandidateObjectCount += prefix.ObjectCount
-			out.CandidateBytes += prefix.Bytes
 		}
 	}
 
@@ -261,18 +309,22 @@ func buildPreview(now time.Time, bucketName string, inventory bucketInventory) p
 		out.NewestCleanPrefix = prefix.Prefix
 	}
 
-	allRawExpired := out.RawChatSnapshotPrefixes > 0 && out.RawChatSnapshotPrefixes == out.ExpiredRawChatSnapshotPrefixes
 	latestRecent := !latestSnapshot.IsZero() && now.Sub(latestSnapshot) <= maximumLatestSnapshotAge
 	checks := []safetyCheck{
+		{
+			Name:   "firestore_raw_chat_drained",
+			Passed: firestoreRawChatRows == 0,
+			Detail: fmt.Sprintf("firestore_raw_chat_rows=%d", firestoreRawChatRows),
+		},
 		{
 			Name:   "object_versioning_disabled",
 			Passed: !inventory.VersioningEnabled,
 			Detail: fmt.Sprintf("versioning_enabled=%t", inventory.VersioningEnabled),
 		},
 		{
-			Name:   "all_raw_chat_snapshots_expired",
-			Passed: allRawExpired,
-			Detail: fmt.Sprintf("raw=%d expired=%d", out.RawChatSnapshotPrefixes, out.ExpiredRawChatSnapshotPrefixes),
+			Name:   "raw_chat_snapshots_present",
+			Passed: out.RawChatSnapshotPrefixes > 0,
+			Detail: fmt.Sprintf("raw=%d", out.RawChatSnapshotPrefixes),
 		},
 		{
 			Name:   "clean_snapshots_exist_after_raw",
@@ -298,7 +350,8 @@ func buildPreview(now time.Time, bucketName string, inventory bucketInventory) p
 	out.Notes = []string{
 		"preview is read-only",
 		"apply deletes complete Firestore export prefixes that contain raw live-chat data; it does not partially edit snapshots",
-		"clean snapshots newer than the newest raw-chat snapshot are preserved",
+		"Firestore live-chat-history must be fully drained before GCS deletion becomes ready",
+		"at least seven clean snapshots newer than the newest raw-chat snapshot are preserved",
 	}
 	if inventory.SoftDelete > 0 {
 		out.Notes = append(out.Notes, "deleted objects remain recoverable in GCS soft delete until the configured retention expires")
@@ -315,20 +368,24 @@ func apply(
 ) error {
 	flags := flag.NewFlagSet("apply", flag.ContinueOnError)
 	flags.SetOutput(os.Stderr)
-	expectedPrefixes := flags.Int("expected-prefixes", -1, "expected expired raw-chat snapshot prefix count")
+	expectedPrefixes := flags.Int("expected-prefixes", -1, "expected raw-chat snapshot prefix count")
 	expectedObjects := flags.Int64("expected-objects", -1, "expected object count across candidate prefixes")
 	confirm := flags.String("confirm", "", "exact confirmation token returned by preview")
+	allowProduction := flags.Bool("allow-production", false, "explicitly allow a production apply")
 	if err := flags.Parse(args); err != nil {
 		return fmt.Errorf("parse apply flags: %w", err)
 	}
 	if flags.NArg() != 0 || *expectedPrefixes < 0 || *expectedObjects < 0 || *confirm == "" {
 		return usageError()
 	}
+	if err := validateGCSApplyTarget(preview.Target, *allowProduction); err != nil {
+		return err
+	}
 	if !preview.ReadyToApply {
 		return errors.New("refusing GCS deletion because preview safety checks are not all satisfied")
 	}
-	if *expectedPrefixes != preview.ExpiredRawChatSnapshotPrefixes {
-		return fmt.Errorf("candidate prefix count changed: expected=%d actual=%d", *expectedPrefixes, preview.ExpiredRawChatSnapshotPrefixes)
+	if *expectedPrefixes != preview.CandidateRawChatSnapshotPrefixes {
+		return fmt.Errorf("candidate prefix count changed: expected=%d actual=%d", *expectedPrefixes, preview.CandidateRawChatSnapshotPrefixes)
 	}
 	if *expectedObjects != preview.CandidateObjectCount {
 		return fmt.Errorf("candidate object count changed: expected=%d actual=%d", *expectedObjects, preview.CandidateObjectCount)
@@ -339,7 +396,7 @@ func apply(
 
 	deletedObjects := int64(0)
 	for _, prefix := range inventory.Prefixes {
-		if !prefix.ContainsRawChat || !prefix.LatestCreatedAt.Before(preview.Cutoff) {
+		if !prefix.ContainsRawChat {
 			continue
 		}
 		for _, object := range deletionOrder(prefix.Objects) {
@@ -358,20 +415,20 @@ func apply(
 	if err != nil {
 		return fmt.Errorf("post-delete bucket inspection: %w", err)
 	}
-	postPreview := buildPreview(time.Now().UTC(), preview.BucketName, postInventory)
+	postPreview := buildPreview(time.Now().UTC(), preview.Target, postInventory, preview.FirestoreRawChatRows)
 	if postPreview.RawChatSnapshotPrefixes != 0 {
 		return fmt.Errorf("post-delete verification failed: %d live raw-chat snapshot prefixes remain", postPreview.RawChatSnapshotPrefixes)
 	}
 
 	return writeJSON(struct {
-		Status              string        `json:"status"`
-		BucketName          string        `json:"bucket_name"`
-		DeletedLiveObjects  int64         `json:"deleted_live_objects"`
-		SoftDeleteRetention string        `json:"soft_delete_retention,omitempty"`
-		PostCheck           previewOutput `json:"post_check"`
+		Status              string         `json:"status"`
+		Target              gcsPurgeTarget `json:"target"`
+		DeletedLiveObjects  int64          `json:"deleted_live_objects"`
+		SoftDeleteRetention string         `json:"soft_delete_retention,omitempty"`
+		PostCheck           previewOutput  `json:"post_check"`
 	}{
 		Status:              "deleted live raw-chat snapshot prefixes",
-		BucketName:          preview.BucketName,
+		Target:              preview.Target,
 		DeletedLiveObjects:  deletedObjects,
 		SoftDeleteRetention: preview.SoftDeleteRetention,
 		PostCheck:           postPreview,
@@ -393,10 +450,12 @@ func deletionOrder(objects []objectRef) []objectRef {
 
 func confirmationToken(preview previewOutput) string {
 	return fmt.Sprintf(
-		"DELETE %d GCS FIRESTORE EXPORT SNAPSHOTS CONTAINING RAW YOUTUBE CHAT (%d OBJECTS) FROM %s THROUGH %s",
-		preview.ExpiredRawChatSnapshotPrefixes,
+		"DELETE %d GCS FIRESTORE EXPORT SNAPSHOTS CONTAINING RAW YOUTUBE CHAT (%d OBJECTS) FROM %s PROJECT %s BUCKET %s THROUGH %s",
+		preview.CandidateRawChatSnapshotPrefixes,
 		preview.CandidateObjectCount,
-		preview.BucketName,
+		strings.ToUpper(preview.Target.Environment),
+		preview.Target.ProjectID,
+		preview.Target.BucketName,
 		strings.TrimSuffix(preview.NewestRawChatPrefix, "/"),
 	)
 }

--- a/system/cmd/privacy-gcs-admin/main_test.go
+++ b/system/cmd/privacy-gcs-admin/main_test.go
@@ -6,15 +6,20 @@ import (
 	"time"
 )
 
-func TestBuildPreviewReadyWhenRawSnapshotsAreOldAndCleanSnapshotsFollow(t *testing.T) {
-	t.Parallel()
+func testGCSTarget(bucketName string) gcsPurgeTarget {
+	return gcsPurgeTarget{
+		Environment: developmentEnvironment,
+		ProjectID:   "youtube-study-space-dev",
+		BucketName:  bucketName,
+	}
+}
 
+func readyPrefixInventory() (time.Time, []prefixInventory) {
 	now := time.Date(2026, time.August, 14, 14, 15, 0, 0, time.UTC)
-	oldRaw := time.Date(2026, time.June, 23, 15, 0, 0, 0, time.UTC)
-
+	oldRaw := time.Date(2026, time.August, 5, 15, 0, 0, 0, time.UTC)
 	prefixes := []prefixInventory{
 		{
-			Prefix:          "2026-06-23T15:00:00_1/",
+			Prefix:          "raw-2026-08-05/",
 			ObjectCount:     12,
 			Bytes:           120,
 			LatestCreatedAt: oldRaw,
@@ -29,14 +34,20 @@ func TestBuildPreviewReadyWhenRawSnapshotsAreOldAndCleanSnapshotsFollow(t *testi
 			LatestCreatedAt: time.Date(2026, time.August, day+6, 15, 0, 0, 0, time.UTC),
 		})
 	}
+	return now, prefixes
+}
 
-	got := buildPreview(now, "backup-bucket", bucketInventory{Prefixes: prefixes})
+func TestBuildPreviewReadyWhenFirestoreDrainedAndCleanSnapshotsFollow(t *testing.T) {
+	t.Parallel()
+
+	now, prefixes := readyPrefixInventory()
+	got := buildPreview(now, testGCSTarget("backup-bucket"), bucketInventory{Prefixes: prefixes}, 0)
 
 	if !got.ReadyToApply {
 		t.Fatalf("ReadyToApply = false, safety checks = %#v", got.SafetyChecks)
 	}
-	if got.RawChatSnapshotPrefixes != 1 || got.ExpiredRawChatSnapshotPrefixes != 1 {
-		t.Fatalf("raw prefix counts = %d/%d, want 1/1", got.RawChatSnapshotPrefixes, got.ExpiredRawChatSnapshotPrefixes)
+	if got.RawChatSnapshotPrefixes != 1 || got.CandidateRawChatSnapshotPrefixes != 1 {
+		t.Fatalf("raw/candidate prefix counts = %d/%d, want 1/1", got.RawChatSnapshotPrefixes, got.CandidateRawChatSnapshotPrefixes)
 	}
 	if got.CandidateObjectCount != 12 || got.CandidateBytes != 120 {
 		t.Fatalf("candidate objects/bytes = %d/%d, want 12/120", got.CandidateObjectCount, got.CandidateBytes)
@@ -47,27 +58,47 @@ func TestBuildPreviewReadyWhenRawSnapshotsAreOldAndCleanSnapshotsFollow(t *testi
 	if got.RequiredConfirmation == "" {
 		t.Fatal("RequiredConfirmation is empty")
 	}
+	if !strings.Contains(got.RequiredConfirmation, "DEVELOPMENT PROJECT youtube-study-space-dev BUCKET backup-bucket") {
+		t.Fatalf("RequiredConfirmation does not bind target: %q", got.RequiredConfirmation)
+	}
 }
 
-func TestBuildPreviewRefusesWhenRecentSnapshotStillContainsRawChat(t *testing.T) {
+func TestBuildPreviewRefusesUntilFirestoreRawChatDrains(t *testing.T) {
+	t.Parallel()
+
+	now, prefixes := readyPrefixInventory()
+	got := buildPreview(now, testGCSTarget("backup-bucket"), bucketInventory{Prefixes: prefixes}, 1)
+	if got.ReadyToApply {
+		t.Fatal("ReadyToApply = true while Firestore raw chat rows remain")
+	}
+	if got.RequiredConfirmation != "" {
+		t.Fatalf("RequiredConfirmation = %q, want empty", got.RequiredConfirmation)
+	}
+}
+
+func TestBuildPreviewRefusesWhenNotEnoughCleanSnapshotsFollowRaw(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, time.August, 14, 14, 15, 0, 0, time.UTC)
 	inventory := bucketInventory{Prefixes: []prefixInventory{
 		{
-			Prefix:          "2026-08-13T15:00:00_1/",
+			Prefix:          "raw/",
 			ObjectCount:     9,
-			LatestCreatedAt: now.Add(-23 * time.Hour),
+			LatestCreatedAt: now.Add(-48 * time.Hour),
 			ContainsRawChat: true,
+		},
+		{
+			Prefix:          "clean/",
+			LatestCreatedAt: now.Add(-24 * time.Hour),
 		},
 	}}
 
-	got := buildPreview(now, "backup-bucket", inventory)
+	got := buildPreview(now, testGCSTarget("backup-bucket"), inventory, 0)
 	if got.ReadyToApply {
 		t.Fatalf("ReadyToApply = true, want false")
 	}
-	if got.ExpiredRawChatSnapshotPrefixes != 0 {
-		t.Fatalf("ExpiredRawChatSnapshotPrefixes = %d, want 0", got.ExpiredRawChatSnapshotPrefixes)
+	if got.CandidateRawChatSnapshotPrefixes != 1 {
+		t.Fatalf("CandidateRawChatSnapshotPrefixes = %d, want 1", got.CandidateRawChatSnapshotPrefixes)
 	}
 	if got.RequiredConfirmation != "" {
 		t.Fatalf("RequiredConfirmation = %q, want empty", got.RequiredConfirmation)
@@ -77,24 +108,11 @@ func TestBuildPreviewRefusesWhenRecentSnapshotStillContainsRawChat(t *testing.T)
 func TestBuildPreviewRefusesWhenVersioningEnabled(t *testing.T) {
 	t.Parallel()
 
-	now := time.Date(2026, time.August, 14, 14, 15, 0, 0, time.UTC)
-	prefixes := []prefixInventory{{
-		Prefix:          "raw/",
-		ObjectCount:     3,
-		LatestCreatedAt: now.AddDate(0, 0, -60),
-		ContainsRawChat: true,
-	}}
-	for day := 1; day <= minimumCleanSnapshotsAfterRaw; day++ {
-		prefixes = append(prefixes, prefixInventory{
-			Prefix:          "clean-" + time.Date(2026, time.August, day+6, 15, 0, 0, 0, time.UTC).Format("2006-01-02") + "/",
-			LatestCreatedAt: time.Date(2026, time.August, day+6, 15, 0, 0, 0, time.UTC),
-		})
-	}
-
-	got := buildPreview(now, "backup-bucket", bucketInventory{
+	now, prefixes := readyPrefixInventory()
+	got := buildPreview(now, testGCSTarget("backup-bucket"), bucketInventory{
 		Prefixes:          prefixes,
 		VersioningEnabled: true,
-	})
+	}, 0)
 	if got.ReadyToApply {
 		t.Fatal("ReadyToApply = true with versioning enabled")
 	}

--- a/system/cmd/privacy-gcs-admin/main_test.go
+++ b/system/cmd/privacy-gcs-admin/main_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildPreviewReadyWhenRawSnapshotsAreOldAndCleanSnapshotsFollow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 14, 14, 15, 0, 0, time.UTC)
+	oldRaw := time.Date(2026, time.June, 23, 15, 0, 0, 0, time.UTC)
+
+	prefixes := []prefixInventory{
+		{
+			Prefix:          "2026-06-23T15:00:00_1/",
+			ObjectCount:     12,
+			Bytes:           120,
+			LatestCreatedAt: oldRaw,
+			ContainsRawChat: true,
+		},
+	}
+	for day := 1; day <= minimumCleanSnapshotsAfterRaw; day++ {
+		prefixes = append(prefixes, prefixInventory{
+			Prefix:          "clean-" + time.Date(2026, time.August, day+6, 15, 0, 0, 0, time.UTC).Format("2006-01-02") + "/",
+			ObjectCount:     9,
+			Bytes:           90,
+			LatestCreatedAt: time.Date(2026, time.August, day+6, 15, 0, 0, 0, time.UTC),
+		})
+	}
+
+	got := buildPreview(now, "backup-bucket", bucketInventory{Prefixes: prefixes})
+
+	if !got.ReadyToApply {
+		t.Fatalf("ReadyToApply = false, safety checks = %#v", got.SafetyChecks)
+	}
+	if got.RawChatSnapshotPrefixes != 1 || got.ExpiredRawChatSnapshotPrefixes != 1 {
+		t.Fatalf("raw prefix counts = %d/%d, want 1/1", got.RawChatSnapshotPrefixes, got.ExpiredRawChatSnapshotPrefixes)
+	}
+	if got.CandidateObjectCount != 12 || got.CandidateBytes != 120 {
+		t.Fatalf("candidate objects/bytes = %d/%d, want 12/120", got.CandidateObjectCount, got.CandidateBytes)
+	}
+	if got.CleanSnapshotsAfterNewestRaw != minimumCleanSnapshotsAfterRaw {
+		t.Fatalf("CleanSnapshotsAfterNewestRaw = %d, want %d", got.CleanSnapshotsAfterNewestRaw, minimumCleanSnapshotsAfterRaw)
+	}
+	if got.RequiredConfirmation == "" {
+		t.Fatal("RequiredConfirmation is empty")
+	}
+}
+
+func TestBuildPreviewRefusesWhenRecentSnapshotStillContainsRawChat(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 14, 14, 15, 0, 0, time.UTC)
+	inventory := bucketInventory{Prefixes: []prefixInventory{
+		{
+			Prefix:          "2026-08-13T15:00:00_1/",
+			ObjectCount:     9,
+			LatestCreatedAt: now.Add(-23 * time.Hour),
+			ContainsRawChat: true,
+		},
+	}}
+
+	got := buildPreview(now, "backup-bucket", inventory)
+	if got.ReadyToApply {
+		t.Fatalf("ReadyToApply = true, want false")
+	}
+	if got.ExpiredRawChatSnapshotPrefixes != 0 {
+		t.Fatalf("ExpiredRawChatSnapshotPrefixes = %d, want 0", got.ExpiredRawChatSnapshotPrefixes)
+	}
+	if got.RequiredConfirmation != "" {
+		t.Fatalf("RequiredConfirmation = %q, want empty", got.RequiredConfirmation)
+	}
+}
+
+func TestBuildPreviewRefusesWhenVersioningEnabled(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.August, 14, 14, 15, 0, 0, time.UTC)
+	prefixes := []prefixInventory{{
+		Prefix:          "raw/",
+		ObjectCount:     3,
+		LatestCreatedAt: now.AddDate(0, 0, -60),
+		ContainsRawChat: true,
+	}}
+	for day := 1; day <= minimumCleanSnapshotsAfterRaw; day++ {
+		prefixes = append(prefixes, prefixInventory{
+			Prefix:          "clean-" + time.Date(2026, time.August, day+6, 15, 0, 0, 0, time.UTC).Format("2006-01-02") + "/",
+			LatestCreatedAt: time.Date(2026, time.August, day+6, 15, 0, 0, 0, time.UTC),
+		})
+	}
+
+	got := buildPreview(now, "backup-bucket", bucketInventory{
+		Prefixes:          prefixes,
+		VersioningEnabled: true,
+	})
+	if got.ReadyToApply {
+		t.Fatal("ReadyToApply = true with versioning enabled")
+	}
+}
+
+func TestDeletionOrderKeepsRawObjectsUntilLast(t *testing.T) {
+	t.Parallel()
+
+	objects := []objectRef{
+		{Name: "snapshot/all_namespaces/kind_live-chat-history/output-0"},
+		{Name: "snapshot/all_namespaces/kind_users/output-0"},
+		{Name: "snapshot/snapshot.overall_export_metadata"},
+		{Name: "snapshot/all_namespaces/kind_live-chat-history/all_namespaces_kind_live-chat-history.export_metadata"},
+	}
+
+	ordered := deletionOrder(objects)
+	seenRaw := false
+	for _, object := range ordered {
+		isRaw := strings.Contains(object.Name, rawLiveChatPathMarker)
+		if isRaw {
+			seenRaw = true
+			continue
+		}
+		if seenRaw {
+			t.Fatalf("non-raw object %q appears after raw object", object.Name)
+		}
+	}
+}
+
+func TestTopLevelPrefix(t *testing.T) {
+	t.Parallel()
+
+	if got := topLevelPrefix("2026-08-13T15:00:06_83201/all_namespaces/kind_users/output-0"); got != "2026-08-13T15:00:06_83201/" {
+		t.Fatalf("topLevelPrefix() = %q", got)
+	}
+}

--- a/system/cmd/privacy-gcs-admin/target_guard.go
+++ b/system/cmd/privacy-gcs-admin/target_guard.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+const (
+	developmentEnvironment = "development"
+	productionEnvironment  = "production"
+)
+
+type gcsPurgeTarget struct {
+	Environment string `json:"environment"`
+	ProjectID   string `json:"project_id"`
+	BucketName  string `json:"bucket_name"`
+}
+
+func buildGCSPurgeTarget(
+	environment string,
+	expectedProjectID string,
+	actualProjectID string,
+	expectedBucketName string,
+	configuredBucketName string,
+) (gcsPurgeTarget, error) {
+	environment = strings.TrimSpace(environment)
+	expectedProjectID = strings.TrimSpace(expectedProjectID)
+	actualProjectID = strings.TrimSpace(actualProjectID)
+	expectedBucketName = strings.TrimSpace(expectedBucketName)
+	configuredBucketName = strings.TrimSpace(configuredBucketName)
+
+	if environment != developmentEnvironment && environment != productionEnvironment {
+		return gcsPurgeTarget{}, fmt.Errorf(
+			"environment must be %q or %q: %q",
+			developmentEnvironment,
+			productionEnvironment,
+			environment,
+		)
+	}
+	if expectedProjectID == "" {
+		return gcsPurgeTarget{}, errors.New("expected GCP project ID is required")
+	}
+	if actualProjectID == "" {
+		return gcsPurgeTarget{}, errors.New("credential GCP project ID is empty")
+	}
+	if expectedProjectID != actualProjectID {
+		return gcsPurgeTarget{}, fmt.Errorf(
+			"GCP project mismatch: expected=%q credential=%q; refusing to inspect or mutate",
+			expectedProjectID,
+			actualProjectID,
+		)
+	}
+	if expectedBucketName == "" {
+		return gcsPurgeTarget{}, errors.New("expected GCS bucket name is required")
+	}
+	if configuredBucketName == "" {
+		return gcsPurgeTarget{}, errors.New("configured GCS bucket name is empty")
+	}
+	if expectedBucketName != configuredBucketName {
+		return gcsPurgeTarget{}, fmt.Errorf(
+			"GCS bucket mismatch: expected=%q configured=%q; refusing to inspect or mutate",
+			expectedBucketName,
+			configuredBucketName,
+		)
+	}
+
+	return gcsPurgeTarget{
+		Environment: environment,
+		ProjectID:   actualProjectID,
+		BucketName:  configuredBucketName,
+	}, nil
+}
+
+func validateGCSApplyTarget(target gcsPurgeTarget, allowProduction bool) error {
+	if target.Environment == productionEnvironment && !allowProduction {
+		return errors.New("production apply requires --allow-production")
+	}
+	if target.Environment == developmentEnvironment && allowProduction {
+		return errors.New("--allow-production is only valid with environment=production")
+	}
+	return nil
+}

--- a/system/cmd/privacy-gcs-admin/target_guard_test.go
+++ b/system/cmd/privacy-gcs-admin/target_guard_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildGCSPurgeTarget(t *testing.T) {
+	t.Parallel()
+
+	target, err := buildGCSPurgeTarget(
+		productionEnvironment,
+		"youtube-study-space-prod",
+		"youtube-study-space-prod",
+		"firestore-backup-prod",
+		"firestore-backup-prod",
+	)
+	if err != nil {
+		t.Fatalf("buildGCSPurgeTarget() error = %v", err)
+	}
+	if target.Environment != productionEnvironment || target.ProjectID != "youtube-study-space-prod" || target.BucketName != "firestore-backup-prod" {
+		t.Fatalf("unexpected target: %#v", target)
+	}
+}
+
+func TestBuildGCSPurgeTargetRejectsProjectMismatch(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildGCSPurgeTarget(
+		developmentEnvironment,
+		"expected-dev",
+		"different-project",
+		"backup-dev",
+		"backup-dev",
+	)
+	if err == nil || !strings.Contains(err.Error(), "GCP project mismatch") {
+		t.Fatalf("error = %v, want project mismatch", err)
+	}
+}
+
+func TestBuildGCSPurgeTargetRejectsBucketMismatch(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildGCSPurgeTarget(
+		developmentEnvironment,
+		"project-dev",
+		"project-dev",
+		"expected-bucket",
+		"configured-bucket",
+	)
+	if err == nil || !strings.Contains(err.Error(), "GCS bucket mismatch") {
+		t.Fatalf("error = %v, want bucket mismatch", err)
+	}
+}
+
+func TestBuildGCSPurgeTargetRejectsUnknownEnvironment(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildGCSPurgeTarget("staging", "project", "project", "bucket", "bucket")
+	if err == nil || !strings.Contains(err.Error(), "environment must be") {
+		t.Fatalf("error = %v, want environment validation error", err)
+	}
+}
+
+func TestValidateGCSApplyTarget(t *testing.T) {
+	t.Parallel()
+
+	if err := validateGCSApplyTarget(gcsPurgeTarget{Environment: developmentEnvironment}, false); err != nil {
+		t.Fatalf("development apply rejected: %v", err)
+	}
+	if err := validateGCSApplyTarget(gcsPurgeTarget{Environment: developmentEnvironment}, true); err == nil {
+		t.Fatal("development apply accepted --allow-production")
+	}
+	if err := validateGCSApplyTarget(gcsPurgeTarget{Environment: productionEnvironment}, false); err == nil {
+		t.Fatal("production apply accepted without --allow-production")
+	}
+	if err := validateGCSApplyTarget(gcsPurgeTarget{Environment: productionEnvironment}, true); err != nil {
+		t.Fatalf("production apply rejected with --allow-production: %v", err)
+	}
+}

--- a/system/cmd/privacy-retention-admin/main.go
+++ b/system/cmd/privacy-retention-admin/main.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"flag"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -20,10 +20,22 @@ import (
 const (
 	previewBigQueryCommand = "preview-bigquery"
 	applyBigQueryCommand   = "apply-bigquery"
+
+	developmentEnvironment = "development"
+	productionEnvironment  = "production"
 )
+
+type purgeTarget struct {
+	Environment    string `json:"environment"`
+	ProjectID      string `json:"project_id"`
+	Dataset        string `json:"dataset"`
+	Table          string `json:"table"`
+	QualifiedTable string `json:"qualified_table"`
+}
 
 type previewOutput struct {
 	Mode                 string                               `json:"mode"`
+	Target               purgeTarget                          `json:"target"`
 	Cutoff               time.Time                            `json:"cutoff"`
 	Audit                mybigquery.RawLiveChatRetentionAudit `json:"audit"`
 	DeleteCandidates     int64                                `json:"delete_candidates"`
@@ -32,11 +44,18 @@ type previewOutput struct {
 
 type applyOutput struct {
 	Mode             string                               `json:"mode"`
+	Target           purgeTarget                          `json:"target"`
 	Cutoff           time.Time                            `json:"cutoff"`
 	ConfirmedRows    int64                                `json:"confirmed_rows"`
 	Before           mybigquery.RawLiveChatRetentionAudit `json:"before"`
 	After            mybigquery.RawLiveChatRetentionAudit `json:"after"`
 	DeleteCandidates int64                                `json:"delete_candidates"`
+}
+
+type applyArgs struct {
+	ExpectedRows    int64
+	Confirmation    string
+	AllowProduction bool
 }
 
 func main() {
@@ -47,15 +66,32 @@ func main() {
 }
 
 func run(ctx context.Context, args []string) error {
-	if len(args) < 3 {
+	if len(args) < 5 {
 		return usageError()
 	}
 
-	cutoff, err := time.Parse(time.RFC3339, strings.TrimSpace(args[2]))
+	command := args[1]
+	environment := strings.TrimSpace(args[2])
+	expectedProjectID := strings.TrimSpace(args[3])
+	cutoff, err := time.Parse(time.RFC3339, strings.TrimSpace(args[4]))
 	if err != nil {
 		return fmt.Errorf("parse cutoff as RFC3339: %w", err)
 	}
 	cutoff = cutoff.UTC()
+
+	if command == previewBigQueryCommand && len(args) != 5 {
+		return usageError()
+	}
+
+	var parsedApplyArgs applyArgs
+	if command == applyBigQueryCommand {
+		parsedApplyArgs, err = parseApplyArgs(args[5:])
+		if err != nil {
+			return err
+		}
+	} else if command != previewBigQueryCommand {
+		return usageError()
+	}
 
 	utils.LoadEnv(".env")
 	credentialFilePath := strings.TrimSpace(os.Getenv("CREDENTIAL_FILE_LOCATION"))
@@ -79,13 +115,18 @@ func run(ctx context.Context, args []string) error {
 	if err != nil {
 		return fmt.Errorf("read system constants: %w", err)
 	}
-	projectID, err := utils.GetGcpProjectID(ctx, clientOption)
+	actualProjectID, err := utils.GetGcpProjectID(ctx, clientOption)
 	if err != nil {
 		return fmt.Errorf("resolve GCP project ID: %w", err)
 	}
+	target, err := buildPurgeTarget(environment, expectedProjectID, actualProjectID)
+	if err != nil {
+		return err
+	}
+
 	bqClient, err := mybigquery.NewBigqueryClient(
 		ctx,
-		projectID,
+		actualProjectID,
 		clientOption,
 		constants.GcpRegion,
 	)
@@ -94,29 +135,99 @@ func run(ctx context.Context, args []string) error {
 	}
 	defer bqClient.CloseClient()
 
-	switch args[1] {
+	switch command {
 	case previewBigQueryCommand:
-		if len(args) != 3 {
-			return usageError()
-		}
-		return previewBigQuery(ctx, bqClient, cutoff)
+		return previewBigQuery(ctx, bqClient, target, cutoff)
 	case applyBigQueryCommand:
-		if len(args) != 7 || args[3] != "--expected-rows" || args[5] != "--confirm" {
-			return usageError()
+		if err := validateApplyTarget(target, parsedApplyArgs.AllowProduction); err != nil {
+			return err
 		}
-		expectedRows, err := strconv.ParseInt(args[4], 10, 64)
-		if err != nil || expectedRows <= 0 {
-			return fmt.Errorf("expected rows must be a positive integer: %q", args[4])
-		}
-		return applyBigQuery(ctx, bqClient, cutoff, expectedRows, args[6])
+		return applyBigQuery(
+			ctx,
+			bqClient,
+			target,
+			cutoff,
+			parsedApplyArgs.ExpectedRows,
+			parsedApplyArgs.Confirmation,
+		)
 	default:
 		return usageError()
 	}
 }
 
+func parseApplyArgs(args []string) (applyArgs, error) {
+	flags := flag.NewFlagSet(applyBigQueryCommand, flag.ContinueOnError)
+	expectedRows := flags.Int64("expected-rows", 0, "candidate row count from preview")
+	confirmation := flags.String("confirm", "", "exact confirmation token from preview")
+	allowProduction := flags.Bool("allow-production", false, "explicitly allow a production apply")
+	if err := flags.Parse(args); err != nil {
+		return applyArgs{}, usageError()
+	}
+	if flags.NArg() != 0 || *expectedRows <= 0 || strings.TrimSpace(*confirmation) == "" {
+		return applyArgs{}, usageError()
+	}
+	return applyArgs{
+		ExpectedRows:    *expectedRows,
+		Confirmation:    *confirmation,
+		AllowProduction: *allowProduction,
+	}, nil
+}
+
+func buildPurgeTarget(environment, expectedProjectID, actualProjectID string) (purgeTarget, error) {
+	environment = strings.TrimSpace(environment)
+	expectedProjectID = strings.TrimSpace(expectedProjectID)
+	actualProjectID = strings.TrimSpace(actualProjectID)
+
+	if environment != developmentEnvironment && environment != productionEnvironment {
+		return purgeTarget{}, fmt.Errorf(
+			"environment must be %q or %q: %q",
+			developmentEnvironment,
+			productionEnvironment,
+			environment,
+		)
+	}
+	if expectedProjectID == "" {
+		return purgeTarget{}, errors.New("expected GCP project ID is required")
+	}
+	if actualProjectID == "" {
+		return purgeTarget{}, errors.New("credential GCP project ID is empty")
+	}
+	if expectedProjectID != actualProjectID {
+		return purgeTarget{}, fmt.Errorf(
+			"GCP project mismatch: expected=%q credential=%q; refusing to inspect or mutate",
+			expectedProjectID,
+			actualProjectID,
+		)
+	}
+
+	qualifiedTable := strings.Join([]string{
+		actualProjectID,
+		mybigquery.DatasetName,
+		mybigquery.LiveChatHistoryMainTableName,
+	}, ".")
+	return purgeTarget{
+		Environment:    environment,
+		ProjectID:      actualProjectID,
+		Dataset:        mybigquery.DatasetName,
+		Table:          mybigquery.LiveChatHistoryMainTableName,
+		QualifiedTable: qualifiedTable,
+	}, nil
+}
+
+func validateApplyTarget(target purgeTarget, allowProduction bool) error {
+	if target.Environment == productionEnvironment && !allowProduction {
+		return errors.New("production apply requires --allow-production")
+	}
+	if target.Environment == developmentEnvironment && allowProduction {
+		return errors.New("--allow-production is only valid with environment=production")
+	}
+	return nil
+}
+
 func previewBigQuery(
 	ctx context.Context,
 	client *mybigquery.BigqueryController,
+	target purgeTarget,
 	cutoff time.Time,
 ) error {
 	audit, err := client.InspectRawLiveChatRetention(ctx, cutoff)
@@ -126,10 +237,11 @@ func previewBigQuery(
 	candidates := deleteCandidateCount(audit)
 	output := previewOutput{
 		Mode:                 "preview",
+		Target:               target,
 		Cutoff:               cutoff,
 		Audit:                audit,
 		DeleteCandidates:     candidates,
-		RequiredConfirmation: confirmationToken(cutoff, candidates),
+		RequiredConfirmation: confirmationToken(target, cutoff, candidates),
 	}
 	return writeJSON(output)
 }
@@ -137,6 +249,7 @@ func previewBigQuery(
 func applyBigQuery(
 	ctx context.Context,
 	client *mybigquery.BigqueryController,
+	target purgeTarget,
 	cutoff time.Time,
 	expectedRows int64,
 	confirmation string,
@@ -157,7 +270,7 @@ func applyBigQuery(
 		)
 	}
 
-	requiredConfirmation := confirmationToken(cutoff, expectedRows)
+	requiredConfirmation := confirmationToken(target, cutoff, expectedRows)
 	if confirmation != requiredConfirmation {
 		return fmt.Errorf("confirmation mismatch; required exactly %q", requiredConfirmation)
 	}
@@ -176,6 +289,7 @@ func applyBigQuery(
 
 	output := applyOutput{
 		Mode:             "applied",
+		Target:           target,
 		Cutoff:           cutoff,
 		ConfirmedRows:    expectedRows,
 		Before:           before,
@@ -189,10 +303,13 @@ func deleteCandidateCount(audit mybigquery.RawLiveChatRetentionAudit) int64 {
 	return audit.RowsOlderThanCutoff + audit.UndatedRows
 }
 
-func confirmationToken(cutoff time.Time, rows int64) string {
+func confirmationToken(target purgeTarget, cutoff time.Time, rows int64) string {
 	return fmt.Sprintf(
-		"DELETE %d RAW YOUTUBE LIVE CHAT ROWS BEFORE %s",
+		"DELETE %d RAW YOUTUBE LIVE CHAT ROWS FROM %s PROJECT %s TABLE %s BEFORE %s",
 		rows,
+		strings.ToUpper(target.Environment),
+		target.ProjectID,
+		target.QualifiedTable,
 		cutoff.UTC().Format(time.RFC3339),
 	)
 }
@@ -208,8 +325,8 @@ func writeJSON(value any) error {
 
 func usageError() error {
 	return errors.New(
-		"usage: privacy-retention-admin preview-bigquery <cutoff-rfc3339> OR " +
-			"privacy-retention-admin apply-bigquery <cutoff-rfc3339> " +
-			"--expected-rows <count> --confirm <exact-preview-token>",
+		"usage: privacy-retention-admin preview-bigquery <development|production> <expected-project-id> <cutoff-rfc3339> OR " +
+			"privacy-retention-admin apply-bigquery <development|production> <expected-project-id> <cutoff-rfc3339> " +
+			"--expected-rows <count> --confirm <exact-preview-token> [--allow-production]",
 	)
 }

--- a/system/cmd/privacy-retention-admin/main_test.go
+++ b/system/cmd/privacy-retention-admin/main_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"app.modules/core/mybigquery"
 )
@@ -17,11 +18,55 @@ func TestDeleteCandidateCount(t *testing.T) {
 	assert.EqualValues(t, 47_454, deleteCandidateCount(audit))
 }
 
+func TestBuildPurgeTarget(t *testing.T) {
+	t.Parallel()
+
+	target, err := buildPurgeTarget("production", "youtube-study-space-prod", "youtube-study-space-prod")
+	require.NoError(t, err)
+	assert.Equal(t, productionEnvironment, target.Environment)
+	assert.Equal(t, "youtube-study-space-prod", target.ProjectID)
+	assert.Equal(t, mybigquery.DatasetName, target.Dataset)
+	assert.Equal(t, mybigquery.LiveChatHistoryMainTableName, target.Table)
+	assert.Equal(t, "youtube-study-space-prod.firestore_export.live-chat-history", target.QualifiedTable)
+}
+
+func TestBuildPurgeTargetRejectsWrongProject(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildPurgeTarget("development", "expected-dev", "different-project")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "GCP project mismatch")
+}
+
+func TestBuildPurgeTargetRejectsUnknownEnvironment(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildPurgeTarget("staging", "project", "project")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "environment must be")
+}
+
+func TestValidateApplyTarget(t *testing.T) {
+	t.Parallel()
+
+	assert.NoError(t, validateApplyTarget(purgeTarget{Environment: developmentEnvironment}, false))
+	assert.Error(t, validateApplyTarget(purgeTarget{Environment: developmentEnvironment}, true))
+	assert.Error(t, validateApplyTarget(purgeTarget{Environment: productionEnvironment}, false))
+	assert.NoError(t, validateApplyTarget(purgeTarget{Environment: productionEnvironment}, true))
+}
+
 func TestConfirmationToken(t *testing.T) {
 	cutoff := time.Date(2026, 7, 15, 13, 52, 23, 0, time.FixedZone("JST-ish", 9*60*60))
+	target := purgeTarget{
+		Environment:    productionEnvironment,
+		ProjectID:      "youtube-study-space-prod",
+		Dataset:        mybigquery.DatasetName,
+		Table:          mybigquery.LiveChatHistoryMainTableName,
+		QualifiedTable: "youtube-study-space-prod.firestore_export.live-chat-history",
+	}
 	assert.Equal(
 		t,
-		"DELETE 47451 RAW YOUTUBE LIVE CHAT ROWS BEFORE 2026-07-15T04:52:23Z",
-		confirmationToken(cutoff, 47_451),
+		"DELETE 47451 RAW YOUTUBE LIVE CHAT ROWS FROM PRODUCTION PROJECT youtube-study-space-prod TABLE youtube-study-space-prod.firestore_export.live-chat-history BEFORE 2026-07-15T04:52:23Z",
+		confirmationToken(target, cutoff, 47_451),
 	)
 }

--- a/system/cmd/raw-chat-drain-audit/main.go
+++ b/system/cmd/raw-chat-drain-audit/main.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"cloud.google.com/go/firestore/apiv1/firestorepb"
+	"google.golang.org/api/option"
+
+	"app.modules/core/repository"
+	"app.modules/core/utils"
+)
+
+const firestoreCountAlias = "row_count"
+
+type auditTarget struct {
+	Environment string `json:"environment"`
+	ProjectID   string `json:"project_id"`
+	Collection  string `json:"collection"`
+}
+
+type auditOutput struct {
+	GeneratedAt time.Time   `json:"generated_at"`
+	Target      auditTarget `json:"target"`
+	TotalRows   int64       `json:"total_rows"`
+	Drained     bool        `json:"drained"`
+}
+
+func main() {
+	if err := run(context.Background(), os.Args); err != nil {
+		fmt.Fprintln(os.Stderr, "raw-chat-drain-audit:", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args []string) error {
+	if len(args) != 3 {
+		return usageError()
+	}
+	environment := strings.TrimSpace(args[1])
+	expectedProjectID := strings.TrimSpace(args[2])
+	if environment != "development" && environment != "production" {
+		return fmt.Errorf("environment must be development or production: %q", environment)
+	}
+	if expectedProjectID == "" {
+		return errors.New("expected GCP project ID is required")
+	}
+
+	utils.LoadEnv(".env")
+	credentialFilePath := strings.TrimSpace(os.Getenv("CREDENTIAL_FILE_LOCATION"))
+	if credentialFilePath == "" {
+		return errors.New("CREDENTIAL_FILE_LOCATION is required")
+	}
+	//nolint:staticcheck // Operator-controlled credential file for this read-only audit.
+	clientOption := option.WithCredentialsFile(credentialFilePath)
+
+	actualProjectID, err := utils.GetGcpProjectID(ctx, clientOption)
+	if err != nil {
+		return fmt.Errorf("resolve GCP project ID: %w", err)
+	}
+	if actualProjectID != expectedProjectID {
+		return fmt.Errorf(
+			"GCP project mismatch: expected=%q credential=%q; refusing to audit",
+			expectedProjectID,
+			actualProjectID,
+		)
+	}
+
+	repo, err := repository.NewFirestoreController(ctx, clientOption)
+	if err != nil {
+		return fmt.Errorf("initialize Firestore: %w", err)
+	}
+	defer func() {
+		if err := repo.FirestoreClient().Close(); err != nil {
+			fmt.Fprintln(os.Stderr, "raw-chat-drain-audit: close Firestore:", err)
+		}
+	}()
+
+	totalRows, err := countRawLiveChatRows(ctx, repo.FirestoreClient())
+	if err != nil {
+		return err
+	}
+
+	output := auditOutput{
+		GeneratedAt: time.Now().UTC(),
+		Target: auditTarget{
+			Environment: environment,
+			ProjectID:   actualProjectID,
+			Collection:  repository.LiveChatHistory,
+		},
+		TotalRows: totalRows,
+		Drained:   totalRows == 0,
+	}
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(output); err != nil {
+		return fmt.Errorf("encode audit output: %w", err)
+	}
+	return nil
+}
+
+func countRawLiveChatRows(ctx context.Context, client repository.DBClient) (int64, error) {
+	query := client.Collection(repository.LiveChatHistory).Query
+	result, err := query.NewAggregationQuery().WithCount(firestoreCountAlias).Get(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("count Firestore raw live chat rows: %w", err)
+	}
+	rawCount, ok := result[firestoreCountAlias]
+	if !ok {
+		return 0, fmt.Errorf("count aggregation missing alias %q", firestoreCountAlias)
+	}
+	countValue, ok := rawCount.(*firestorepb.Value)
+	if !ok {
+		return 0, fmt.Errorf("count aggregation has unexpected type %T", rawCount)
+	}
+	return countValue.GetIntegerValue(), nil
+}
+
+func usageError() error {
+	return errors.New("usage: raw-chat-drain-audit <development|production> <expected-project-id>")
+}

--- a/system/cmd/raw-chat-drain-audit/main_test.go
+++ b/system/cmd/raw-chat-drain-audit/main_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"context"
+	"testing"
+)
+
+func TestRunRejectsUnknownEnvironmentBeforeCredentialAccess(t *testing.T) {
+	t.Setenv("CREDENTIAL_FILE_LOCATION", "")
+
+	err := run(context.Background(), []string{"raw-chat-drain-audit", "staging", "project-id"})
+	if err == nil {
+		t.Fatal("run() error = nil, want environment validation error")
+	}
+}
+
+func TestRunRequiresExplicitTarget(t *testing.T) {
+	err := run(context.Background(), []string{"raw-chat-drain-audit"})
+	if err == nil {
+		t.Fatal("run() error = nil, want usage error")
+	}
+}

--- a/system/cmd/youtube-bot/main.go
+++ b/system/cmd/youtube-bot/main.go
@@ -163,23 +163,6 @@ func Bot(ctx context.Context, clientOption option.ClientOption) {
 			}
 		}
 
-		// chatMessagesを保存
-		for _, chatMessage := range chatMessages {
-			// only if chatMessage has a text message
-			if !youtubebot.HasTextMessageByAuthor(chatMessage) {
-				continue
-			}
-
-			if err = app.AddLiveChatHistoryDoc(ctx, chatMessage); err != nil {
-				app.MessageToOwnerWithError(ctx, "(1回目) failed to add live chat history", err)
-				time.Sleep(2 * time.Second)
-				if err2 := app.AddLiveChatHistoryDoc(ctx, chatMessage); err2 != nil {
-					app.MessageToOwnerWithError(ctx, "(2回目) failed to add live chat history", err2)
-					// pass
-				}
-			}
-		}
-
 		// process the command (includes not command)
 		for _, chatMessage := range chatMessages {
 			if youtubebot.IsFanFundingEvent(chatMessage) {

--- a/system/cmd/youtube-bot/main_test.go
+++ b/system/cmd/youtube-bot/main_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCalculateRetryIntervalSec(t *testing.T) {
@@ -70,4 +72,12 @@ func TestCalculateRetryIntervalSec(t *testing.T) {
 			)
 		})
 	}
+}
+
+func TestYoutubeBotDoesNotPersistRawLiveChatHistory(t *testing.T) {
+	source, err := os.ReadFile("main.go")
+	require.NoError(t, err)
+
+	assert.NotContains(t, string(source), "AddLiveChatHistoryDoc(")
+	assert.NotContains(t, string(source), "failed to add live chat history")
 }


### PR DESCRIPTION
## Goal

`feature/raw-chat-archive-retirement` で積み上げた raw YouTube live-chat archive 廃止の実装・guard・runbook を、最終レビュー用に `dev` との差分としてまとめます。

**重要: このPRは base が `dev` のため、エージェントはマージしません。**

## Included

- youtube-bot が Firestore `live-chat-history` へ新規 raw message を保存しない
- BigQuery `firestore_export.live-chat-history` one-shot purge の environment / project / table guard
- Firestore raw row の read-only drain audit
- GCS mixed Firestore export snapshot の guarded whole-prefix cleanup
  - environment / project / bucket guard
  - Firestore raw row = 0 gate
  - newest raw snapshot 後の clean snapshot >= 7
  - latest snapshot <= 72h
  - Object Versioning disabled
  - exact preview counts / confirmation token
  - production `--allow-production`
- end-to-end migration runbook
- confirmed environment/operator operations
- read-only GCP resource inventory helper

## Confirmed environment targets

| Environment | GCP project | GCS Firestore backup bucket | AWS CLI profile |
| --- | --- | --- | --- |
| development | `test-youtube-study-space` | `firestore-backup-test-youtube-study-space` | `soraride-dev` |
| production | `youtube-study-space` | `firestore-backup-youtube-study-space` | `soraride-prod` |

BigQuery target is `firestore_export.live-chat-history` in each project.

## Operator model

`youtube-bot` runs on the OBS / youtube-monitor streaming PC via:

```bash
cd system
go run ./cmd/youtube-bot
```

`system/.env` selects the service-account JSON path. The bot resolves and prints the credential Project ID before startup and requires literal `yes`; development must print `test-youtube-study-space`, production must print `youtube-study-space`.

Daily-batch/CDK deployment uses the explicit environment profile:

```bash
# development
cd aws-cdk
pnpm cdk:diff --profile soraride-dev
pnpm cdk:deploy --profile soraride-dev

# production, only after the normal dev -> main release
pnpm cdk:diff --profile soraride-prod
pnpm cdk:deploy --profile soraride-prod
```

Production release remains `dev -> main`, followed by the normal streaming-PC update and AWS/CDK deployment as required.

## Migration order

1. Human integration of this branch into the development code line.
2. Development Day 0: make both producer boundaries active:
   - streaming-PC youtube-bot raw Firestore writer removal;
   - development ECS/Fargate `transfer-bq` archive exclusion already introduced by #1002, deployed with `soraride-dev`.
3. Smoke-test real development live chat.
4. Wait for Firestore raw rows to drain to zero under the existing five-day retention.
5. Wait for at least seven newer clean daily GCS snapshots.
6. Run development previews; actual BigQuery/GCS apply remains manual.
7. Verify development fully.
8. Only then use the normal `dev -> main` release flow and repeat the producer cutover/wait/preview/manual cleanup sequence in production, using `soraride-prod` for AWS/CDK.
9. After both environments complete, inventory/remove only raw-chat-dedicated cloud resources and remove one-shot DELETE capabilities from the repository.

Typical GCS readiness may take roughly 12-14 days from Day 0, but tool-reported gates are authoritative.

## Invariants / non-goals

- Never partially delete `kind_live-chat-history/**` from a mixed snapshot; delete the complete affected top-level snapshot prefix only.
- Keep the mixed backup bucket.
- Keep BigQuery dataset `firestore_export`.
- Keep `user-activity-history` and `order-history`.
- Do not convert/backfill old raw chat into work history.
- Do not automate production destructive apply.
- This PR itself performs no deploy and no data deletion.

## Stack incorporated into the dedicated branch

- #1028 Firestore raw writer stop
- #1029 BigQuery target guards
- #1031 read-only drain audit
- #1033 runbook / inventory / environment operations
- #1001 guarded GCS whole-prefix cleanup foundation
- #1034 final GCS target guards + drain/clean-snapshot readiness gates
- #1036 confirmed AWS deployment profiles

Old stacked #1030 / #1032 were closed as superseded by #1034.

## Verification

Each component PR was CI-validated before being merged into the dedicated branch. The final GCS PR #1034 passed CI including Go lint, System Go Test, Firestore Emulator integration tests, generated-file checks, and CI Gate.

The dedicated branch integration CI #140 also completed successfully. After #1036 was merged into the dedicated branch, the integration CI was rerun on the new HEAD.

## Follow-up after raw-chat retirement: PR #991

PR #991 (`privacy-admin delete-primary`) is a separate user-data-deletion workstream and should remain deferred until this raw-chat retirement is complete.

Its current implementation still treats Firestore `live-chat-history` and BigQuery `firestore_export.live-chat-history` as deletion targets. After this migration, those stores will no longer exist as persistent raw-chat stores, so #991 must be updated to avoid requiring them before it is reviewed for integration.

Do not merge #991 in its current form. After raw-chat retirement, update it for the final storage model, move it onto an appropriate dedicated branch if continuing as a multi-PR workstream, and review it separately.

This integration PR should be treated as the final branch-level review / CI boundary before any development environment mutation.