### PR TITLE
Cache compiled NG-word regexes

### DIFF
--- a/system/core/utils/regex_cache_test.go
+++ b/system/core/utils/regex_cache_test.go
@@ -1,9 +1,12 @@
 package utils
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
 func TestCachedRegex_ReusesCompiledRegexp(t *testing.T) {
-	compiledRegexCache = syncMapForTest(t)
+	compiledRegexCache = sync.Map{}
 
 	first, err := cachedRegex("荒らし")
 	if err != nil {
@@ -20,7 +23,7 @@ func TestCachedRegex_ReusesCompiledRegexp(t *testing.T) {
 }
 
 func TestContainsRegexWithIndex_UsesCachedRegexAndPreservesBehavior(t *testing.T) {
-	compiledRegexCache = syncMapForTest(t)
+	compiledRegexCache = sync.Map{}
 
 	patterns := []string{"荒らし", "要確認"}
 
@@ -49,7 +52,7 @@ func TestContainsRegexWithIndex_UsesCachedRegexAndPreservesBehavior(t *testing.T
 }
 
 func TestContainsRegexWithIndex_InvalidRegexStillReturnsCompileError(t *testing.T) {
-	compiledRegexCache = syncMapForTest(t)
+	compiledRegexCache = sync.Map{}
 
 	found, index, err := ContainsRegexWithIndex([]string{"ok", "["}, "no match")
 	if err == nil {
@@ -61,9 +64,4 @@ func TestContainsRegexWithIndex_InvalidRegexStillReturnsCompileError(t *testing.
 	if index != 0 {
 		t.Fatalf("ContainsRegexWithIndex() index = %d, want 0 on error", index)
 	}
-}
-
-func syncMapForTest(t *testing.T) sync.Map {
-	t.Helper()
-	return sync.Map{}
 }

--- a/system/core/utils/regex_cache_test.go
+++ b/system/core/utils/regex_cache_test.go
@@ -1,0 +1,69 @@
+package utils
+
+import "testing"
+
+func TestCachedRegex_ReusesCompiledRegexp(t *testing.T) {
+	compiledRegexCache = syncMapForTest(t)
+
+	first, err := cachedRegex("荒らし")
+	if err != nil {
+		t.Fatalf("cachedRegex() first call error = %v", err)
+	}
+	second, err := cachedRegex("荒らし")
+	if err != nil {
+		t.Fatalf("cachedRegex() second call error = %v", err)
+	}
+
+	if first != second {
+		t.Fatal("cachedRegex() returned different regexp pointers for the same pattern")
+	}
+}
+
+func TestContainsRegexWithIndex_UsesCachedRegexAndPreservesBehavior(t *testing.T) {
+	compiledRegexCache = syncMapForTest(t)
+
+	patterns := []string{"荒らし", "要確認"}
+
+	found, index, err := ContainsRegexWithIndex(patterns, "これは要確認です")
+	if err != nil {
+		t.Fatalf("ContainsRegexWithIndex() error = %v", err)
+	}
+	if !found {
+		t.Fatal("ContainsRegexWithIndex() found = false, want true")
+	}
+	if index != 1 {
+		t.Fatalf("ContainsRegexWithIndex() index = %d, want 1", index)
+	}
+
+	first, err := cachedRegex("要確認")
+	if err != nil {
+		t.Fatalf("cachedRegex() error = %v", err)
+	}
+	second, err := cachedRegex("要確認")
+	if err != nil {
+		t.Fatalf("cachedRegex() second call error = %v", err)
+	}
+	if first != second {
+		t.Fatal("expected cached regexp to be reused")
+	}
+}
+
+func TestContainsRegexWithIndex_InvalidRegexStillReturnsCompileError(t *testing.T) {
+	compiledRegexCache = syncMapForTest(t)
+
+	found, index, err := ContainsRegexWithIndex([]string{"ok", "["}, "no match")
+	if err == nil {
+		t.Fatal("ContainsRegexWithIndex() error = nil, want compile error")
+	}
+	if found {
+		t.Fatal("ContainsRegexWithIndex() found = true, want false")
+	}
+	if index != 0 {
+		t.Fatalf("ContainsRegexWithIndex() index = %d, want 0 on error", index)
+	}
+}
+
+func syncMapForTest(t *testing.T) sync.Map {
+	t.Helper()
+	return sync.Map{}
+}

--- a/system/core/utils/utils.go
+++ b/system/core/utils/utils.go
@@ -81,16 +81,24 @@ func Contains[T comparable](s []T, e T) bool {
 
 func cachedRegex(pattern string) (*regexp.Regexp, error) {
 	if cached, ok := compiledRegexCache.Load(pattern); ok {
-		return cached.(*regexp.Regexp), nil
+		compiled, ok := cached.(*regexp.Regexp)
+		if !ok {
+			return nil, fmt.Errorf("cached regex has unexpected type %T", cached)
+		}
+		return compiled, nil
 	}
 
 	compiled, err := regexp.Compile(pattern)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("compile regex %q: %w", pattern, err)
 	}
 
 	actual, _ := compiledRegexCache.LoadOrStore(pattern, compiled)
-	return actual.(*regexp.Regexp), nil
+	actualRegex, ok := actual.(*regexp.Regexp)
+	if !ok {
+		return nil, fmt.Errorf("cached regex has unexpected type %T", actual)
+	}
+	return actualRegex, nil
 }
 
 func ContainsRegexWithIndex(s []string, e string) (bool, int, error) {

--- a/system/core/utils/utils.go
+++ b/system/core/utils/utils.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 	"unicode/utf8"
 
@@ -21,6 +22,8 @@ import (
 	"google.golang.org/api/option"
 	"google.golang.org/api/transport"
 )
+
+var compiledRegexCache sync.Map // map[string]*regexp.Regexp
 
 // LoadEnv TODO さらに上の階層に書くべき
 func LoadEnv(relativeEnvPath string) {
@@ -76,9 +79,23 @@ func Contains[T comparable](s []T, e T) bool {
 	return false
 }
 
+func cachedRegex(pattern string) (*regexp.Regexp, error) {
+	if cached, ok := compiledRegexCache.Load(pattern); ok {
+		return cached.(*regexp.Regexp), nil
+	}
+
+	compiled, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+
+	actual, _ := compiledRegexCache.LoadOrStore(pattern, compiled)
+	return actual.(*regexp.Regexp), nil
+}
+
 func ContainsRegexWithIndex(s []string, e string) (bool, int, error) {
 	for i, a := range s {
-		r, err := regexp.Compile(a)
+		r, err := cachedRegex(a)
 		if err != nil {
 			return false, 0, fmt.Errorf("compile regex at index %d: %w", i, err)
 		}


### PR DESCRIPTION
## Summary
- cache compiled NG-word regular expressions by pattern
- reuse compiled `*regexp.Regexp` values across chat-message checks
- preserve existing match/index/error behavior
- add focused regression tests for cache reuse and invalid regex handling

## Why
`ContainsRegexWithIndex` previously called `regexp.Compile` for every configured pattern on every chat-message check. This PR removes that repeated compilation cost while keeping the current spreadsheet-driven regex configuration and moderation behavior unchanged.

## Scope
This PR intentionally does not change NG-word matching semantics or add exception-word handling. It only removes repeated regex compilation.

## Testing
Added unit coverage for:
- reusing the same compiled regexp for the same pattern
- preserving match/index behavior
- preserving compile-error behavior for invalid regexes
