### PR TITLE
perf: speed up guarded GCS raw-chat purge

### DIFF
--- a/system/cmd/privacy-gcs-admin/delete_workers.go
+++ b/system/cmd/privacy-gcs-admin/delete_workers.go
@@ -9,10 +9,9 @@ import (
 	"time"
 )
 
-const (
-	defaultDeleteConcurrency = 16
-	deleteProgressInterval    = 5 * time.Second
-)
+const defaultDeleteConcurrency = 16
+
+const deleteProgressInterval = 5 * time.Second
 
 type objectDeleteFunc func(context.Context, objectRef) error
 
@@ -111,7 +110,7 @@ func deleteObjectsBounded(
 		close(results)
 	}()
 
-	fmt.Fprintf(
+	writeProgress(
 		progressWriter,
 		"privacy-gcs-admin: delete phase=%s started total=%d concurrency=%d\n",
 		phase,
@@ -128,7 +127,7 @@ func deleteObjectsBounded(
 		case result, ok := <-results:
 			if !ok {
 				summary.Skipped = summary.Total - summary.Deleted - summary.Failed
-				fmt.Fprintf(
+				writeProgress(
 					progressWriter,
 					"privacy-gcs-admin: delete phase=%s finished deleted=%d failed=%d skipped=%d total=%d\n",
 					phase,
@@ -171,7 +170,7 @@ func deleteObjectsBounded(
 			summary.Deleted++
 		case <-ticker.C:
 			completed := summary.Deleted + summary.Failed
-			fmt.Fprintf(
+			writeProgress(
 				progressWriter,
 				"privacy-gcs-admin: delete phase=%s progress completed=%d/%d deleted=%d failed=%d\n",
 				phase,
@@ -181,5 +180,11 @@ func deleteObjectsBounded(
 				summary.Failed,
 			)
 		}
+	}
+}
+
+func writeProgress(writer io.Writer, format string, args ...any) {
+	if _, err := fmt.Fprintf(writer, format, args...); err != nil {
+		return
 	}
 }

--- a/system/cmd/privacy-gcs-admin/delete_workers.go
+++ b/system/cmd/privacy-gcs-admin/delete_workers.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	defaultDeleteConcurrency = 16
+	deleteProgressInterval    = 5 * time.Second
+)
+
+type objectDeleteFunc func(context.Context, objectRef) error
+
+type deletionPhaseSummary struct {
+	Phase   string
+	Total   int64
+	Deleted int64
+	Failed  int64
+	Skipped int64
+}
+
+type deletionResult struct {
+	err error
+}
+
+func splitDeletionPhases(inventory bucketInventory) (nonRawObjects, rawMarkerObjects []objectRef) {
+	for _, prefix := range inventory.Prefixes {
+		if !prefix.ContainsRawChat {
+			continue
+		}
+		for _, object := range prefix.Objects {
+			if strings.Contains(object.Name, rawLiveChatPathMarker) {
+				rawMarkerObjects = append(rawMarkerObjects, object)
+				continue
+			}
+			nonRawObjects = append(nonRawObjects, object)
+		}
+	}
+	return nonRawObjects, rawMarkerObjects
+}
+
+func deleteObjectsBounded(
+	ctx context.Context,
+	phase string,
+	objects []objectRef,
+	concurrency int,
+	progressInterval time.Duration,
+	progressWriter io.Writer,
+	deleteObject objectDeleteFunc,
+) (deletionPhaseSummary, error) {
+	summary := deletionPhaseSummary{
+		Phase: phase,
+		Total: int64(len(objects)),
+	}
+	if len(objects) == 0 {
+		return summary, nil
+	}
+	if concurrency <= 0 {
+		return summary, fmt.Errorf("delete phase %q concurrency must be positive: %d", phase, concurrency)
+	}
+	if progressInterval <= 0 {
+		progressInterval = deleteProgressInterval
+	}
+	if progressWriter == nil {
+		progressWriter = io.Discard
+	}
+	if deleteObject == nil {
+		return summary, fmt.Errorf("delete phase %q delete function is required", phase)
+	}
+
+	workerCount := concurrency
+	if workerCount > len(objects) {
+		workerCount = len(objects)
+	}
+
+	jobs := make(chan objectRef)
+	results := make(chan deletionResult, workerCount)
+	var workers sync.WaitGroup
+	workers.Add(workerCount)
+
+	for range workerCount {
+		go func() {
+			defer workers.Done()
+			for object := range jobs {
+				if err := ctx.Err(); err != nil {
+					return
+				}
+				results <- deletionResult{err: deleteObject(ctx, object)}
+			}
+		}()
+	}
+
+	go func() {
+		defer close(jobs)
+		for _, object := range objects {
+			select {
+			case jobs <- object:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	go func() {
+		workers.Wait()
+		close(results)
+	}()
+
+	fmt.Fprintf(
+		progressWriter,
+		"privacy-gcs-admin: delete phase=%s started total=%d concurrency=%d\n",
+		phase,
+		summary.Total,
+		workerCount,
+	)
+
+	ticker := time.NewTicker(progressInterval)
+	defer ticker.Stop()
+
+	var firstErr error
+	for {
+		select {
+		case result, ok := <-results:
+			if !ok {
+				summary.Skipped = summary.Total - summary.Deleted - summary.Failed
+				fmt.Fprintf(
+					progressWriter,
+					"privacy-gcs-admin: delete phase=%s finished deleted=%d failed=%d skipped=%d total=%d\n",
+					phase,
+					summary.Deleted,
+					summary.Failed,
+					summary.Skipped,
+					summary.Total,
+				)
+				if err := ctx.Err(); err != nil {
+					return summary, fmt.Errorf(
+						"delete phase %q canceled after deleted=%d failed=%d skipped=%d total=%d; rerun preview before retrying: %w",
+						phase,
+						summary.Deleted,
+						summary.Failed,
+						summary.Skipped,
+						summary.Total,
+						err,
+					)
+				}
+				if summary.Failed > 0 {
+					return summary, fmt.Errorf(
+						"delete phase %q completed with failures: deleted=%d failed=%d skipped=%d total=%d; rerun preview before retrying: %w",
+						phase,
+						summary.Deleted,
+						summary.Failed,
+						summary.Skipped,
+						summary.Total,
+						firstErr,
+					)
+				}
+				return summary, nil
+			}
+			if result.err != nil {
+				summary.Failed++
+				if firstErr == nil {
+					firstErr = result.err
+				}
+				continue
+			}
+			summary.Deleted++
+		case <-ticker.C:
+			completed := summary.Deleted + summary.Failed
+			fmt.Fprintf(
+				progressWriter,
+				"privacy-gcs-admin: delete phase=%s progress completed=%d/%d deleted=%d failed=%d\n",
+				phase,
+				completed,
+				summary.Total,
+				summary.Deleted,
+				summary.Failed,
+			)
+		}
+	}
+}

--- a/system/cmd/privacy-gcs-admin/delete_workers_test.go
+++ b/system/cmd/privacy-gcs-admin/delete_workers_test.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestSplitDeletionPhasesKeepsRawMarkersSeparate(t *testing.T) {
+	t.Parallel()
+
+	inventory := bucketInventory{Prefixes: []prefixInventory{
+		{
+			Prefix:          "raw/",
+			ContainsRawChat: true,
+			Objects: []objectRef{
+				{Name: "raw/all_namespaces/kind_users/output-0"},
+				{Name: "raw/all_namespaces/kind_live-chat-history/output-0"},
+				{Name: "raw/snapshot.overall_export_metadata"},
+			},
+		},
+		{
+			Prefix: "clean/",
+			Objects: []objectRef{
+				{Name: "clean/all_namespaces/kind_users/output-0"},
+			},
+		},
+	}}
+
+	nonRaw, rawMarkers := splitDeletionPhases(inventory)
+	if len(nonRaw) != 2 {
+		t.Fatalf("len(nonRaw) = %d, want 2", len(nonRaw))
+	}
+	if len(rawMarkers) != 1 {
+		t.Fatalf("len(rawMarkers) = %d, want 1", len(rawMarkers))
+	}
+	if !strings.Contains(rawMarkers[0].Name, rawLiveChatPathMarker) {
+		t.Fatalf("raw marker = %q, want live-chat marker", rawMarkers[0].Name)
+	}
+}
+
+func TestDeleteObjectsBoundedCapsConcurrency(t *testing.T) {
+	t.Parallel()
+
+	const concurrency = 4
+	objects := make([]objectRef, 24)
+	for i := range objects {
+		objects[i] = objectRef{Name: "object"}
+	}
+
+	var inFlight atomic.Int64
+	var maxInFlight atomic.Int64
+	deleteObject := func(context.Context, objectRef) error {
+		current := inFlight.Add(1)
+		defer inFlight.Add(-1)
+		for {
+			maximum := maxInFlight.Load()
+			if current <= maximum || maxInFlight.CompareAndSwap(maximum, current) {
+				break
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+		return nil
+	}
+
+	summary, err := deleteObjectsBounded(
+		context.Background(),
+		"test",
+		objects,
+		concurrency,
+		time.Hour,
+		&bytes.Buffer{},
+		deleteObject,
+	)
+	if err != nil {
+		t.Fatalf("deleteObjectsBounded() error = %v", err)
+	}
+	if summary.Deleted != int64(len(objects)) || summary.Failed != 0 || summary.Skipped != 0 {
+		t.Fatalf("summary = %#v", summary)
+	}
+	if got := maxInFlight.Load(); got > concurrency {
+		t.Fatalf("max in-flight = %d, want <= %d", got, concurrency)
+	}
+	if got := maxInFlight.Load(); got < 2 {
+		t.Fatalf("max in-flight = %d, want concurrent deletion", got)
+	}
+}
+
+func TestDeleteObjectsBoundedReportsPartialFailures(t *testing.T) {
+	t.Parallel()
+
+	objects := []objectRef{{Name: "ok-1"}, {Name: "fail"}, {Name: "ok-2"}}
+	deleteObject := func(_ context.Context, object objectRef) error {
+		if object.Name == "fail" {
+			return errors.New("boom")
+		}
+		return nil
+	}
+
+	summary, err := deleteObjectsBounded(
+		context.Background(),
+		"non-raw",
+		objects,
+		2,
+		time.Hour,
+		&bytes.Buffer{},
+		deleteObject,
+	)
+	if err == nil {
+		t.Fatal("deleteObjectsBounded() error = nil, want failure")
+	}
+	if summary.Deleted != 2 || summary.Failed != 1 || summary.Skipped != 0 {
+		t.Fatalf("summary = %#v, want deleted=2 failed=1 skipped=0", summary)
+	}
+	if !strings.Contains(err.Error(), "rerun preview before retrying") {
+		t.Fatalf("error = %q, want rerun-preview guidance", err)
+	}
+}
+
+func TestDeleteObjectsBoundedRespectsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	objects := []objectRef{{Name: "one"}, {Name: "two"}}
+	var calls atomic.Int64
+	deleteObject := func(context.Context, objectRef) error {
+		calls.Add(1)
+		return nil
+	}
+
+	summary, err := deleteObjectsBounded(
+		ctx,
+		"test",
+		objects,
+		2,
+		time.Hour,
+		&bytes.Buffer{},
+		deleteObject,
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("delete calls = %d, want 0", calls.Load())
+	}
+	if summary.Skipped != int64(len(objects)) {
+		t.Fatalf("summary = %#v, want all objects skipped", summary)
+	}
+}
+
+func TestDeleteObjectsBoundedWritesProgress(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	objects := []objectRef{{Name: "one"}, {Name: "two"}}
+	summary, err := deleteObjectsBounded(
+		context.Background(),
+		"raw-marker",
+		objects,
+		1,
+		time.Hour,
+		&output,
+		func(context.Context, objectRef) error { return nil },
+	)
+	if err != nil {
+		t.Fatalf("deleteObjectsBounded() error = %v", err)
+	}
+	if summary.Deleted != 2 {
+		t.Fatalf("summary = %#v", summary)
+	}
+	got := output.String()
+	if !strings.Contains(got, "phase=raw-marker started") || !strings.Contains(got, "phase=raw-marker finished") {
+		t.Fatalf("progress output = %q", got)
+	}
+}

--- a/system/cmd/privacy-gcs-admin/main.go
+++ b/system/cmd/privacy-gcs-admin/main.go
@@ -394,22 +394,53 @@ func apply(
 		return errors.New("confirmation token does not match current preview")
 	}
 
-	deletedObjects := int64(0)
-	for _, prefix := range inventory.Prefixes {
-		if !prefix.ContainsRawChat {
-			continue
-		}
-		for _, object := range deletionOrder(prefix.Objects) {
-			objectHandle := bucket.Object(object.Name)
-			if object.Generation != 0 {
-				objectHandle = objectHandle.Generation(object.Generation)
-			}
-			if err := objectHandle.Delete(ctx); err != nil && !errors.Is(err, storage.ErrObjectNotExist) {
-				return fmt.Errorf("delete GCS object %q: %w", object.Name, err)
-			}
-			deletedObjects++
-		}
+	nonRawObjects, rawMarkerObjects := splitDeletionPhases(inventory)
+	phaseObjectCount := int64(len(nonRawObjects) + len(rawMarkerObjects))
+	if phaseObjectCount != preview.CandidateObjectCount {
+		return fmt.Errorf(
+			"internal candidate object mismatch: preview=%d deletion_phases=%d; refusing deletion",
+			preview.CandidateObjectCount,
+			phaseObjectCount,
+		)
 	}
+
+	deleteObject := func(ctx context.Context, object objectRef) error {
+		objectHandle := bucket.Object(object.Name)
+		if object.Generation != 0 {
+			objectHandle = objectHandle.Generation(object.Generation)
+		}
+		if err := objectHandle.Delete(ctx); err != nil && !errors.Is(err, storage.ErrObjectNotExist) {
+			return fmt.Errorf("delete GCS object %q: %w", object.Name, err)
+		}
+		return nil
+	}
+
+	nonRawSummary, err := deleteObjectsBounded(
+		ctx,
+		"non-raw",
+		nonRawObjects,
+		defaultDeleteConcurrency,
+		deleteProgressInterval,
+		os.Stderr,
+		deleteObject,
+	)
+	if err != nil {
+		return err
+	}
+
+	rawSummary, err := deleteObjectsBounded(
+		ctx,
+		"raw-marker",
+		rawMarkerObjects,
+		defaultDeleteConcurrency,
+		deleteProgressInterval,
+		os.Stderr,
+		deleteObject,
+	)
+	if err != nil {
+		return err
+	}
+	deletedObjects := nonRawSummary.Deleted + rawSummary.Deleted
 
 	postInventory, err := inspectBucket(ctx, bucket)
 	if err != nil {


### PR DESCRIPTION
## Summary

Implements #1040 before the Production raw-chat archive cleanup.

Development cleanup showed the current serial GCS purge takes 41m55s for 18,991 objects. This change keeps the destructive-operation guards intact while making the object deletion bounded-concurrent and observable.

## Changes

- delete candidate GCS objects with a fixed bounded concurrency of 16
- preserve raw-chat detectability during partial failure by deleting in two phases:
  1. non-raw objects inside raw-containing snapshot prefixes
  2. `kind_live-chat-history` marker objects only after phase 1 fully succeeds
- emit deletion start/progress/final counters to stderr
- report deleted / failed / skipped counts and require a fresh preview after failure/cancellation
- respect context cancellation
- retain current target guard, expected prefix/object counts, exact confirmation token, production opt-in, and post-delete verification
- add race-safe unit tests for concurrency bounds, phase splitting, partial failures, cancellation, and progress output

## Safety notes

This remains migration-only tooling. After Development and Production raw-chat retirement are complete, the destructive apply capability is still intended to be removed.

PR base is the dedicated `integration/raw-chat-production-readiness` branch, not `dev`.

Closes #1040