### PR TITLE
ci: add base image digest update report

### DIFF
--- a/.github/scripts/base-image-update-report.mjs
+++ b/.github/scripts/base-image-update-report.mjs
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+export const COMMENT_MARKER = "<!-- base-image-update-report -->";
+
+export function parseFromImages(content) {
+  const images = [];
+  for (const [index, line] of content.split(/\r?\n/).entries()) {
+    const trimmed = line.trim();
+    if (!/^FROM\s+/i.test(trimmed)) continue;
+
+    const parts = trimmed.split(/\s+/);
+    let imageIndex = 1;
+    while (parts[imageIndex]?.startsWith("--")) imageIndex += 1;
+    if (!parts[imageIndex]) continue;
+
+    images.push({
+      stage: images.length + 1,
+      line: index + 1,
+      image: parts[imageIndex],
+    });
+  }
+  return images;
+}
+
+export function parsePinnedImage(ref) {
+  const match = ref.match(/^(.*)@(sha256:[0-9a-f]{64})$/i);
+  if (!match) return null;
+
+  const taggedRef = match[1];
+  const digest = match[2].toLowerCase();
+  const slashIndex = taggedRef.lastIndexOf("/");
+  const colonIndex = taggedRef.lastIndexOf(":");
+  if (colonIndex <= slashIndex) return null;
+
+  return {
+    ref,
+    taggedRef,
+    image: taggedRef.slice(0, colonIndex),
+    tag: taggedRef.slice(colonIndex + 1),
+    digest,
+  };
+}
+
+export function detectDigestUpdates(baseContent, headContent) {
+  const before = parseFromImages(baseContent);
+  const after = parseFromImages(headContent);
+  const updates = [];
+  const count = Math.max(before.length, after.length);
+
+  for (let index = 0; index < count; index += 1) {
+    const oldStage = before[index];
+    const newStage = after[index];
+    if (!oldStage || !newStage || oldStage.image === newStage.image) continue;
+
+    const oldImage = parsePinnedImage(oldStage.image);
+    const newImage = parsePinnedImage(newStage.image);
+    if (!oldImage || !newImage) continue;
+
+    updates.push({
+      stage: newStage.stage,
+      line: newStage.line,
+      oldImage,
+      newImage,
+    });
+  }
+
+  return updates;
+}
+
+export function publicGalleryUrl(taggedRef) {
+  const prefix = "public.ecr.aws/";
+  if (!taggedRef.startsWith(prefix)) return null;
+
+  const withoutRegistry = taggedRef.slice(prefix.length);
+  const slashIndex = withoutRegistry.lastIndexOf("/");
+  const colonIndex = withoutRegistry.lastIndexOf(":");
+  const repository = colonIndex > slashIndex
+    ? withoutRegistry.slice(0, colonIndex)
+    : withoutRegistry;
+  if (!repository) return null;
+
+  return `https://gallery.ecr.aws/${repository}`;
+}
+
+export function renderReport(entries) {
+  const lines = [
+    COMMENT_MARKER,
+    "## 🐳 Base image update report",
+    "",
+    `Detected **${entries.length}** digest-pinned base image update${entries.length === 1 ? "" : "s"}.`,
+    "",
+  ];
+
+  for (const entry of entries) {
+    const { file, stage, line, oldImage, newImage, resolvedDigest, verificationError } = entry;
+    const matches = resolvedDigest === newImage.digest;
+    const galleryUrl = publicGalleryUrl(newImage.taggedRef);
+
+    lines.push(`### ${matches ? "✅" : "❌"} \`${newImage.taggedRef}\``);
+    lines.push("");
+    lines.push(`> \`${oldImage.digest}\` → \`${newImage.digest}\``);
+    lines.push("");
+    lines.push("| Item | Value |");
+    lines.push("| --- | --- |");
+    lines.push(`| Dockerfile | \`${file}\` (stage ${stage}, line ${line}) |`);
+    if (oldImage.tag !== newImage.tag || oldImage.image !== newImage.image) {
+      lines.push(`| Before image | \`${oldImage.taggedRef}\` |`);
+      lines.push(`| After image | \`${newImage.taggedRef}\` |`);
+    } else {
+      lines.push(`| Image tag | \`${newImage.taggedRef}\` |`);
+    }
+    lines.push(`| Before digest | \`${oldImage.digest}\` |`);
+    lines.push(`| After digest | \`${newImage.digest}\` |`);
+
+    if (resolvedDigest) {
+      lines.push(`| Current tag digest | \`${resolvedDigest}\` |`);
+      lines.push(`| Verification | ${matches ? "✅ Pinned digest matches the current registry tag" : "❌ Pinned digest does not match the current registry tag"} |`);
+    } else {
+      lines.push("| Current tag digest | _Unavailable_ |");
+      lines.push(`| Verification | ❌ Could not verify the current registry tag${verificationError ? `: \`${escapeInlineCode(verificationError)}\`` : ""} |`);
+    }
+
+    lines.push("");
+    if (galleryUrl) {
+      lines.push(`🔗 [View \`${newImage.image}\` in Amazon ECR Public Gallery](${galleryUrl})`);
+      lines.push("");
+    }
+  }
+
+  if (entries.every((entry) => entry.resolvedDigest === entry.newImage.digest)) {
+    lines.push("> ✅ All pinned digests in this update match their current registry tags.");
+  } else {
+    lines.push("> ❌ One or more pinned digests could not be verified against the current registry tag.");
+  }
+  lines.push("");
+  lines.push("_Generated automatically from the PR Dockerfile diff and the container registry._");
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+function escapeInlineCode(value) {
+  return String(value).replaceAll("`", "'").replaceAll("\n", " ").trim();
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+async function githubRequest(path, options = {}) {
+  const apiUrl = process.env.GITHUB_API_URL || "https://api.github.com";
+  const token = requireEnv("GITHUB_TOKEN");
+  const response = await fetch(`${apiUrl}${path}`, {
+    ...options,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...(options.headers || {}),
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub API ${options.method || "GET"} ${path} failed: ${response.status} ${body}`);
+  }
+
+  if (response.status === 204) return null;
+  return response.json();
+}
+
+async function paginatedGithubRequest(path) {
+  const items = [];
+  for (let page = 1; ; page += 1) {
+    const separator = path.includes("?") ? "&" : "?";
+    const pageItems = await githubRequest(`${path}${separator}per_page=100&page=${page}`);
+    items.push(...pageItems);
+    if (pageItems.length < 100) return items;
+  }
+}
+
+function encodeRepositoryPath(path) {
+  return path.split("/").map(encodeURIComponent).join("/");
+}
+
+async function getFileContent(repository, path, ref) {
+  const response = await githubRequest(
+    `/repos/${repository}/contents/${encodeRepositoryPath(path)}?ref=${encodeURIComponent(ref)}`,
+  );
+  if (response.type !== "file" || response.encoding !== "base64") {
+    throw new Error(`Unexpected GitHub contents response for ${path}@${ref}`);
+  }
+  return Buffer.from(response.content.replaceAll("\n", ""), "base64").toString("utf8");
+}
+
+function resolveTagDigest(taggedRef) {
+  return execFileSync(
+    "docker",
+    ["buildx", "imagetools", "inspect", taggedRef, "--format", "{{.Manifest.Digest}}"],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"], timeout: 120_000 },
+  ).trim().toLowerCase();
+}
+
+async function findExistingReportComment(repository, pullNumber) {
+  const comments = await paginatedGithubRequest(`/repos/${repository}/issues/${pullNumber}/comments`);
+  return comments.find(
+    (comment) => comment.user?.login === "github-actions[bot]" && comment.body?.includes(COMMENT_MARKER),
+  );
+}
+
+async function upsertReportComment(repository, pullNumber, body) {
+  const existing = await findExistingReportComment(repository, pullNumber);
+  if (existing) {
+    await githubRequest(`/repos/${repository}/issues/comments/${existing.id}`, {
+      method: "PATCH",
+      body: JSON.stringify({ body }),
+      headers: { "Content-Type": "application/json" },
+    });
+    return;
+  }
+
+  await githubRequest(`/repos/${repository}/issues/${pullNumber}/comments`, {
+    method: "POST",
+    body: JSON.stringify({ body }),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function deleteExistingReportComment(repository, pullNumber) {
+  const existing = await findExistingReportComment(repository, pullNumber);
+  if (!existing) return;
+  await githubRequest(`/repos/${repository}/issues/comments/${existing.id}`, { method: "DELETE" });
+}
+
+async function main() {
+  const repository = requireEnv("GITHUB_REPOSITORY");
+  const pullNumber = Number(requireEnv("PR_NUMBER"));
+  const baseSha = requireEnv("BASE_SHA");
+  const headSha = requireEnv("HEAD_SHA");
+
+  if (!Number.isInteger(pullNumber) || pullNumber <= 0) {
+    throw new Error(`Invalid PR_NUMBER: ${process.env.PR_NUMBER}`);
+  }
+
+  const changedFiles = await paginatedGithubRequest(`/repos/${repository}/pulls/${pullNumber}/files`);
+  const dockerfiles = changedFiles
+    .map((file) => file.filename)
+    .filter((filename) => /^system\/Dockerfile[^/]*$/.test(filename));
+
+  const entries = [];
+  for (const file of dockerfiles) {
+    const [baseContent, headContent] = await Promise.all([
+      getFileContent(repository, file, baseSha),
+      getFileContent(repository, file, headSha),
+    ]);
+
+    for (const update of detectDigestUpdates(baseContent, headContent)) {
+      let resolvedDigest = null;
+      let verificationError = null;
+      try {
+        resolvedDigest = resolveTagDigest(update.newImage.taggedRef);
+      } catch (error) {
+        verificationError = error instanceof Error ? error.message : String(error);
+      }
+      entries.push({ file, ...update, resolvedDigest, verificationError });
+    }
+  }
+
+  if (entries.length === 0) {
+    await deleteExistingReportComment(repository, pullNumber);
+    console.log("No digest-pinned base image updates detected.");
+    return;
+  }
+
+  const report = renderReport(entries);
+  await upsertReportComment(repository, pullNumber, report);
+  process.stdout.write(`${report}\n`);
+
+  const failed = entries.filter((entry) => entry.resolvedDigest !== entry.newImage.digest);
+  if (failed.length > 0) {
+    throw new Error(`${failed.length} base image digest verification(s) failed`);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.stack : error);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/base-image-update-report.mjs
+++ b/.github/scripts/base-image-update-report.mjs
@@ -5,6 +5,26 @@ import { pathToFileURL } from "node:url";
 
 export const COMMENT_MARKER = "<!-- base-image-update-report -->";
 
+const ALLOWED_REGISTRIES = new Set(["docker.io", "public.ecr.aws", "gcr.io"]);
+
+export function registryHost(image) {
+  const firstComponent = image.split("/")[0];
+  if (
+    image.includes("/") &&
+    (firstComponent.includes(".") || firstComponent.includes(":") || firstComponent === "localhost")
+  ) {
+    return firstComponent.toLowerCase();
+  }
+  return "docker.io";
+}
+
+export function canVerifyRegistryUpdate(oldImage, newImage) {
+  return (
+    oldImage.image === newImage.image &&
+    ALLOWED_REGISTRIES.has(registryHost(newImage.image))
+  );
+}
+
 export function parseFromImages(content) {
   const images = [];
   for (const [index, line] of content.split(/\r?\n/).entries()) {
@@ -35,11 +55,16 @@ export function parsePinnedImage(ref) {
   const colonIndex = taggedRef.lastIndexOf(":");
   if (colonIndex <= slashIndex) return null;
 
+  const image = taggedRef.slice(0, colonIndex);
+  const tag = taggedRef.slice(colonIndex + 1);
+  if (!/^[A-Za-z0-9._/:~-]+$/.test(image)) return null;
+  if (!/^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$/.test(tag)) return null;
+
   return {
     ref,
     taggedRef,
-    image: taggedRef.slice(0, colonIndex),
-    tag: taggedRef.slice(colonIndex + 1),
+    image,
+    tag,
     digest,
   };
 }
@@ -262,10 +287,15 @@ async function main() {
     for (const update of detectDigestUpdates(baseContent, headContent)) {
       let resolvedDigest = null;
       let verificationError = null;
-      try {
-        resolvedDigest = resolveTagDigest(update.newImage.taggedRef);
-      } catch (error) {
-        verificationError = error instanceof Error ? error.message : String(error);
+      if (!canVerifyRegistryUpdate(update.oldImage, update.newImage)) {
+        verificationError =
+          "Automatic verification skipped because the image repository changed or the registry is not allowlisted.";
+      } else {
+        try {
+          resolvedDigest = resolveTagDigest(update.newImage.taggedRef);
+        } catch (error) {
+          verificationError = error instanceof Error ? error.message : String(error);
+        }
       }
       entries.push({ file, ...update, resolvedDigest, verificationError });
     }

--- a/.github/scripts/base-image-update-report.test.mjs
+++ b/.github/scripts/base-image-update-report.test.mjs
@@ -3,10 +3,12 @@ import test from "node:test";
 
 import {
   COMMENT_MARKER,
+  canVerifyRegistryUpdate,
   detectDigestUpdates,
   parseFromImages,
   parsePinnedImage,
   publicGalleryUrl,
+  registryHost,
   renderReport,
 } from "./base-image-update-report.mjs";
 
@@ -51,6 +53,19 @@ test("detectDigestUpdates also reports pinned tag changes", () => {
   assert.equal(updates.length, 1);
   assert.equal(updates[0].oldImage.tag, "1.26");
   assert.equal(updates[0].newImage.tag, "1.27");
+});
+
+test("registry verification is restricted to the existing image repository and known registries", () => {
+  assert.equal(registryHost("golang"), "docker.io");
+  assert.equal(registryHost("public.ecr.aws/lambda/provided"), "public.ecr.aws");
+  assert.equal(registryHost("gcr.io/distroless/static-debian12"), "gcr.io");
+
+  const oldImage = parsePinnedImage(`public.ecr.aws/lambda/provided:al2023@${OLD}`);
+  const sameRepository = parsePinnedImage(`public.ecr.aws/lambda/provided:al2023@${NEW}`);
+  const changedRepository = parsePinnedImage(`evil.example/repo:al2023@${NEW}`);
+
+  assert.equal(canVerifyRegistryUpdate(oldImage, sameRepository), true);
+  assert.equal(canVerifyRegistryUpdate(oldImage, changedRepository), false);
 });
 
 test("publicGalleryUrl returns a stable ECR Public Gallery repository URL", () => {

--- a/.github/scripts/base-image-update-report.test.mjs
+++ b/.github/scripts/base-image-update-report.test.mjs
@@ -125,6 +125,6 @@ test("report workflow remains advisory and non-blocking", () => {
   assert.match(workflow, /name: Checkout trusted base revision[\s\S]*?continue-on-error: true/);
   assert.match(workflow, /name: Verify Docker Buildx availability[\s\S]*?continue-on-error: true/);
   assert.match(workflow, /name: Generate or update PR report[\s\S]*?continue-on-error: true/);
-  assert.match(workflow, /name: Keep report advisory[\s\S]*?if: always\(\)/);
+  assert.match(workflow, /name: Keep report advisory[\s\S]*?if: always\(\)[\s\S]*?continue-on-error: true/);
   assert.match(workflow, /does not block merging/);
 });

--- a/.github/scripts/base-image-update-report.test.mjs
+++ b/.github/scripts/base-image-update-report.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 
 import {
@@ -116,4 +117,14 @@ test("renderReport is explicit when registry verification fails", () => {
 
   assert.match(report, /❌ Pinned digest does not match the current registry tag/);
   assert.match(report, /One or more pinned digests could not be verified/);
+});
+
+test("report workflow remains advisory and non-blocking", () => {
+  const workflow = readFileSync(".github/workflows/base-image-update-report.yml", "utf8");
+
+  assert.match(workflow, /name: Checkout trusted base revision[\s\S]*?continue-on-error: true/);
+  assert.match(workflow, /name: Verify Docker Buildx availability[\s\S]*?continue-on-error: true/);
+  assert.match(workflow, /name: Generate or update PR report[\s\S]*?continue-on-error: true/);
+  assert.match(workflow, /name: Keep report advisory[\s\S]*?if: always\(\)/);
+  assert.match(workflow, /does not block merging/);
 });

--- a/.github/scripts/base-image-update-report.test.mjs
+++ b/.github/scripts/base-image-update-report.test.mjs
@@ -119,11 +119,13 @@ test("renderReport is explicit when registry verification fails", () => {
   assert.match(report, /One or more pinned digests could not be verified/);
 });
 
-test("report workflow remains advisory and non-blocking", () => {
+test("report workflow remains advisory and catches stale-comment cleanup", () => {
   const workflow = readFileSync(".github/workflows/base-image-update-report.yml", "utf8");
 
+  assert.match(workflow, /pull_request_target:[\s\S]*?types: \[opened, synchronize, reopened\]/);
+  assert.doesNotMatch(workflow, /pull_request_target:[\s\S]*?paths:/);
+  assert.doesNotMatch(workflow, /Verify Docker Buildx availability/);
   assert.match(workflow, /name: Checkout trusted base revision[\s\S]*?continue-on-error: true/);
-  assert.match(workflow, /name: Verify Docker Buildx availability[\s\S]*?continue-on-error: true/);
   assert.match(workflow, /name: Generate or update PR report[\s\S]*?continue-on-error: true/);
   assert.match(workflow, /name: Keep report advisory[\s\S]*?if: always\(\)[\s\S]*?continue-on-error: true/);
   assert.match(workflow, /does not block merging/);

--- a/.github/scripts/base-image-update-report.test.mjs
+++ b/.github/scripts/base-image-update-report.test.mjs
@@ -1,0 +1,104 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  COMMENT_MARKER,
+  detectDigestUpdates,
+  parseFromImages,
+  parsePinnedImage,
+  publicGalleryUrl,
+  renderReport,
+} from "./base-image-update-report.mjs";
+
+const OLD = "sha256:d8d858dc6f7a6552ffc131e029802c28969c8211d311c33f9400449e30cf7442";
+const NEW = "sha256:6d97a9ef52d2d84ef361172b7cfc12ca673a7e6dd722fd4b195b3f15bfcdb767";
+
+test("parseFromImages extracts multi-stage FROM images", () => {
+  const images = parseFromImages(`FROM --platform=linux/amd64 golang:1.26@${OLD} AS build\nFROM public.ecr.aws/lambda/provided:al2023@${NEW}\n`);
+  assert.deepEqual(images, [
+    { stage: 1, line: 1, image: `golang:1.26@${OLD}` },
+    { stage: 2, line: 2, image: `public.ecr.aws/lambda/provided:al2023@${NEW}` },
+  ]);
+});
+
+test("parsePinnedImage separates image, tag, and digest", () => {
+  assert.deepEqual(parsePinnedImage(`public.ecr.aws/lambda/provided:al2023@${NEW}`), {
+    ref: `public.ecr.aws/lambda/provided:al2023@${NEW}`,
+    taggedRef: "public.ecr.aws/lambda/provided:al2023",
+    image: "public.ecr.aws/lambda/provided",
+    tag: "al2023",
+    digest: NEW,
+  });
+});
+
+test("detectDigestUpdates finds PR 1045-style digest-only changes", () => {
+  const base = `FROM golang:1.26@${OLD} AS build\nFROM public.ecr.aws/lambda/provided:al2023@${OLD}\n`;
+  const head = `FROM golang:1.26@${OLD} AS build\nFROM public.ecr.aws/lambda/provided:al2023@${NEW}\n`;
+  const updates = detectDigestUpdates(base, head);
+
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].stage, 2);
+  assert.equal(updates[0].line, 2);
+  assert.equal(updates[0].oldImage.digest, OLD);
+  assert.equal(updates[0].newImage.digest, NEW);
+});
+
+test("detectDigestUpdates also reports pinned tag changes", () => {
+  const base = `FROM golang:1.26@${OLD} AS build\n`;
+  const head = `FROM golang:1.27@${NEW} AS build\n`;
+  const updates = detectDigestUpdates(base, head);
+
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].oldImage.tag, "1.26");
+  assert.equal(updates[0].newImage.tag, "1.27");
+});
+
+test("publicGalleryUrl returns a stable ECR Public Gallery repository URL", () => {
+  assert.equal(
+    publicGalleryUrl("public.ecr.aws/lambda/provided:al2023"),
+    "https://gallery.ecr.aws/lambda/provided",
+  );
+  assert.equal(publicGalleryUrl("golang:1.26"), null);
+});
+
+test("renderReport includes verified digests and ECR Public Gallery link", () => {
+  const update = detectDigestUpdates(
+    `FROM public.ecr.aws/lambda/provided:al2023@${OLD}\n`,
+    `FROM public.ecr.aws/lambda/provided:al2023@${NEW}\n`,
+  )[0];
+
+  const report = renderReport([
+    {
+      file: "system/Dockerfile.lambda",
+      ...update,
+      resolvedDigest: NEW,
+      verificationError: null,
+    },
+  ]);
+
+  assert.match(report, new RegExp(COMMENT_MARKER.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.match(report, /## 🐳 Base image update report/);
+  assert.match(report, /✅ Pinned digest matches the current registry tag/);
+  assert.match(report, new RegExp(OLD));
+  assert.match(report, new RegExp(NEW));
+  assert.match(report, /https:\/\/gallery\.ecr\.aws\/lambda\/provided/);
+});
+
+test("renderReport is explicit when registry verification fails", () => {
+  const update = detectDigestUpdates(
+    `FROM public.ecr.aws/lambda/provided:al2023@${OLD}\n`,
+    `FROM public.ecr.aws/lambda/provided:al2023@${NEW}\n`,
+  )[0];
+
+  const report = renderReport([
+    {
+      file: "system/Dockerfile.lambda",
+      ...update,
+      resolvedDigest: OLD,
+      verificationError: null,
+    },
+  ]);
+
+  assert.match(report, /❌ Pinned digest does not match the current registry tag/);
+  assert.match(report, /One or more pinned digests could not be verified/);
+});

--- a/.github/scripts/detect-ci-paths.sh
+++ b/.github/scripts/detect-ci-paths.sh
@@ -56,7 +56,7 @@ set_all_groups() {
 
 path_is_ci_config() {
 	case "$1" in
-		.github/workflows/*|.github/scripts/detect-ci-paths.sh|.github/scripts/test-detect-ci-paths.sh|.github/scripts/run-firestore-integration-tests.sh|.github/actions/*)
+		.github/workflows/*|.github/scripts/detect-ci-paths.sh|.github/scripts/test-detect-ci-paths.sh|.github/scripts/run-firestore-integration-tests.sh|.github/scripts/base-image-update-report*.mjs|.github/actions/*)
 			return 0
 			;;
 		*)

--- a/.github/scripts/test-detect-ci-paths.sh
+++ b/.github/scripts/test-detect-ci-paths.sh
@@ -54,6 +54,8 @@ assert_exact_groups "system room_image_prompt menu_image_generator youtube_monit
 assert_exact_groups "system room_image_prompt menu_image_generator youtube_monitor docs_site aws_cdk node_projects firestore_integration formal_spec all" .github/scripts/detect-ci-paths.sh
 assert_exact_groups "system room_image_prompt menu_image_generator youtube_monitor docs_site aws_cdk node_projects firestore_integration formal_spec all" .github/scripts/test-detect-ci-paths.sh
 assert_exact_groups "system room_image_prompt menu_image_generator youtube_monitor docs_site aws_cdk node_projects firestore_integration formal_spec all" .github/scripts/run-firestore-integration-tests.sh
+assert_exact_groups "system room_image_prompt menu_image_generator youtube_monitor docs_site aws_cdk node_projects firestore_integration formal_spec all" .github/scripts/base-image-update-report.mjs
+assert_exact_groups "system room_image_prompt menu_image_generator youtube_monitor docs_site aws_cdk node_projects firestore_integration formal_spec all" .github/scripts/base-image-update-report.test.mjs
 assert_exact_groups "system firestore_integration youtube_monitor" system/core/app.go youtube-monitor/src/app.ts
 
 manual_output="$(GITHUB_EVENT_NAME=workflow_dispatch "$detector")"

--- a/.github/workflows/base-image-update-report.yml
+++ b/.github/workflows/base-image-update-report.yml
@@ -6,8 +6,6 @@ name: Base Image Update Report
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
-    paths:
-      - "system/Dockerfile*"
 
 permissions:
   contents: read
@@ -32,14 +30,11 @@ jobs:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 
-      - name: Verify Docker Buildx availability
-        if: steps.checkout.outcome == 'success'
-        id: buildx
-        continue-on-error: true
-        run: docker buildx version
-
+      # The script checks the PR changed-files list first. If no system/Dockerfile*
+      # remains in the final PR diff, it removes any stale report comment and exits
+      # before invoking Docker Buildx.
       - name: Generate or update PR report
-        if: steps.checkout.outcome == 'success' && steps.buildx.outcome == 'success'
+        if: steps.checkout.outcome == 'success'
         id: report
         continue-on-error: true
         env:
@@ -54,10 +49,9 @@ jobs:
         continue-on-error: true
         env:
           CHECKOUT_OUTCOME: ${{ steps.checkout.outcome }}
-          BUILDX_OUTCOME: ${{ steps.buildx.outcome }}
           REPORT_OUTCOME: ${{ steps.report.outcome }}
         run: |
-          if [[ "$CHECKOUT_OUTCOME" != "success" || "$BUILDX_OUTCOME" != "success" || "$REPORT_OUTCOME" != "success" ]]; then
+          if [[ "$CHECKOUT_OUTCOME" != "success" || "$REPORT_OUTCOME" != "success" ]]; then
             echo "::warning::Base image update reporting did not complete successfully. This check is advisory and does not block merging."
           fi
           echo "Base Image Update Report is advisory; merge gating is handled by the normal CI workflow."

--- a/.github/workflows/base-image-update-report.yml
+++ b/.github/workflows/base-image-update-report.yml
@@ -25,18 +25,38 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout trusted base revision
+        id: checkout
+        continue-on-error: true
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 
       - name: Verify Docker Buildx availability
+        if: steps.checkout.outcome == 'success'
+        id: buildx
+        continue-on-error: true
         run: docker buildx version
 
       - name: Generate or update PR report
+        if: steps.checkout.outcome == 'success' && steps.buildx.outcome == 'success'
+        id: report
+        continue-on-error: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node .github/scripts/base-image-update-report.mjs
+
+      - name: Keep report advisory
+        if: always()
+        env:
+          CHECKOUT_OUTCOME: ${{ steps.checkout.outcome }}
+          BUILDX_OUTCOME: ${{ steps.buildx.outcome }}
+          REPORT_OUTCOME: ${{ steps.report.outcome }}
+        run: |
+          if [[ "$CHECKOUT_OUTCOME" != "success" || "$BUILDX_OUTCOME" != "success" || "$REPORT_OUTCOME" != "success" ]]; then
+            echo "::warning::Base image update reporting did not complete successfully. This check is advisory and does not block merging."
+          fi
+          echo "Base Image Update Report is advisory; merge gating is handled by the normal CI workflow."

--- a/.github/workflows/base-image-update-report.yml
+++ b/.github/workflows/base-image-update-report.yml
@@ -1,0 +1,42 @@
+name: Base Image Update Report
+
+# Dependabot-triggered pull_request workflows receive a read-only token.
+# pull_request_target is used only so the trusted base-branch workflow can update
+# the PR comment. Never checkout or execute the PR head revision in this workflow.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "system/Dockerfile*"
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: base-image-update-report-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    name: Verify and Report Base Image Digests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout trusted base revision
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          persist-credentials: false
+
+      - name: Verify Docker Buildx availability
+        run: docker buildx version
+
+      - name: Generate or update PR report
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node .github/scripts/base-image-update-report.mjs

--- a/.github/workflows/base-image-update-report.yml
+++ b/.github/workflows/base-image-update-report.yml
@@ -51,6 +51,7 @@ jobs:
 
       - name: Keep report advisory
         if: always()
+        continue-on-error: true
         env:
           CHECKOUT_OUTCOME: ${{ steps.checkout.outcome }}
           BUILDX_OUTCOME: ${{ steps.buildx.outcome }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,20 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: bash .github/scripts/detect-ci-paths.sh
 
+  base-image-update-report-test:
+    name: Base Image Update Report Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+      - name: Run tests
+        run: node --test .github/scripts/base-image-update-report.test.mjs
+
   node-lts-ignore-expiry:
     name: Node LTS Ignore Expiry
     runs-on: ubuntu-latest
@@ -471,6 +485,7 @@ jobs:
     if: always()
     needs:
       - changes
+      - base-image-update-report-test
       - node-lts-ignore-expiry
       - check-i18n-generate
       - go-lint

--- a/system/README.md
+++ b/system/README.md
@@ -78,6 +78,9 @@ docker buildx build --platform linux/arm64 -f system/Dockerfile.fargate system -
 `Dockerfile.lambda` / `Dockerfile.fargate` の `FROM` は、`image:tag@sha256:...` の形式で **digest 固定** している（再現可能ビルドのため。詳細は issue #693）。digest の更新は基本的に Dependabot の docker ecosystem PR に任せる。
 
 - **Dependabot からの digest 更新 PR が来たとき**:
+  - `Base Image Update Report` workflow が、旧/新 digest、現在タグの digest、一致判定を同じ PR コメントへ自動で投稿・更新する
+  - Amazon ECR Public のイメージでは、対応する ECR Public Gallery へのリンクもコメントに表示する
+  - registry の現在タグと pinned digest を検証できない場合は workflow を失敗させる
   1. `aws-cdk/` で `pnpm cdk:diff --profile <dev プロファイル>` を実行し、変更が digest 差し替えだけであることを確認
   2. `pnpm cdk:deploy --profile <dev プロファイル>` で dev 環境にデプロイしてスモーク確認
   3. 問題なければ prod プロファイルで同じ手順を実行

--- a/system/README.md
+++ b/system/README.md
@@ -79,6 +79,7 @@ docker buildx build --platform linux/arm64 -f system/Dockerfile.fargate system -
 
 - **Dependabot からの digest 更新 PR が来たとき**:
   - `Base Image Update Report` workflow が、旧/新 digest、現在タグの digest、一致判定を同じ PR コメントへ自動で投稿・更新する
+- workflow はすべての PR `opened` / `synchronize` / `reopened` を拾い、最終差分から Dockerfile 更新が消えた場合は古い report comment を削除する。Dockerfile 更新がない場合は registry 照合を行わず終了する
   - Amazon ECR Public のイメージでは、対応する ECR Public Gallery へのリンクもコメントに表示する
   - registry の現在タグと pinned digest を検証できない場合はコメント／Actions warningで明示するが、この report workflow 自体は advisory としてマージをブロックしない
   1. `aws-cdk/` で `pnpm cdk:diff --profile <dev プロファイル>` を実行し、変更が digest 差し替えだけであることを確認

--- a/system/README.md
+++ b/system/README.md
@@ -80,7 +80,7 @@ docker buildx build --platform linux/arm64 -f system/Dockerfile.fargate system -
 - **Dependabot からの digest 更新 PR が来たとき**:
   - `Base Image Update Report` workflow が、旧/新 digest、現在タグの digest、一致判定を同じ PR コメントへ自動で投稿・更新する
   - Amazon ECR Public のイメージでは、対応する ECR Public Gallery へのリンクもコメントに表示する
-  - registry の現在タグと pinned digest を検証できない場合は workflow を失敗させる
+  - registry の現在タグと pinned digest を検証できない場合はコメント／Actions warningで明示するが、この report workflow 自体は advisory としてマージをブロックしない
   1. `aws-cdk/` で `pnpm cdk:diff --profile <dev プロファイル>` を実行し、変更が digest 差し替えだけであることを確認
   2. `pnpm cdk:deploy --profile <dev プロファイル>` で dev 環境にデプロイしてスモーク確認
   3. 問題なければ prod プロファイルで同じ手順を実行


### PR DESCRIPTION
## Summary

Docker base image の digest 更新 PR を人間が手軽に検証できるよう、PRへ Markdown の検証コメントを自動投稿・更新する workflow を追加します。

## Report contents

digest-pinned `FROM` の変更を検出し、確実に取得・検証できる情報だけを表示します。

- 対象 Dockerfile / stage / line
- image tag
- old digest
- new digest
- registry 上の current tag digest
- pinned digest と current tag digest の一致判定
- Amazon ECR Public image の場合は ECR Public Gallery へのリンク

push日時・サイズ・package差分・リスク評価など、取得根拠や意味が不安定になり得る情報は今回は出しません。

## Comment behavior

- `<!-- base-image-update-report -->` marker 付きの同一 bot comment を更新
- rebase / synchronize でコメントを増殖させない
- `opened` / `synchronize` / `reopened` は path filter なしで拾い、最終差分から Dockerfile update が消えた場合も cleanup を実行
- digest update がなくなった場合は既存 report comment を削除し、Dockerfile 更新がなければ registry 照合前に終了
- registry の current tag を解決できない、または digest が一致しない場合はコメント／Actions warningで明示する
- report workflow は advisory とし、report処理に失敗してもマージをブロックしない

## Security

Dependabot 起点の通常 `pull_request` workflow は write token を利用できないため、コメント用 workflow は `pull_request_target` を使用します。

ただし高権限コンテキストで PR head を checkout / execute しません。

- checkout するのは `github.event.pull_request.base.sha` のみ
- PR head の Dockerfile は GitHub Contents API から text data として取得
- registry lookup は trusted base branch の script から `docker buildx imagetools inspect` を引数配列で実行
- 自動照合は base と同じ image repository に限定
- registry は現在利用中の Docker Hub / Amazon ECR Public / GCR の allowlist に限定

## Tests

- Node built-in test runner で 9 ケースを追加
  - multi-stage Dockerfile
  - digest-only update（PR #1045 相当）
  - tag + digest update
  - ECR Public Gallery URL
  - registry allowlist / repository-change guard
  - verified report rendering
  - mismatch rendering
  - report workflow の non-blocking 契約と stale-comment cleanup trigger
- `CI Gate` に `Base Image Update Report Test` を追加
- CI path detector で report workflow / script / tests を CI config として扱うよう更新

## Notes

この PR 自体では、新しい `pull_request_target` workflow はまだ base branch に存在しないため report comment は実行されません。マージ後の Dockerfile 更新 PR から有効になります。

実運用の report workflow は advisory です。checkout / Buildx / registry照合 / コメント投稿が失敗しても merge gate にはせず、通常の `CI Gate` がマージ可否を担います。レポート生成コード自体の単体テストは引き続き `CI Gate` に含めます。

Base branch は `dev` ですが、このPRのマージは行いません。