### PR TITLE
ci: link gcr base images to Artifact Registry

### DIFF
--- a/.github/scripts/base-image-update-report.mjs
+++ b/.github/scripts/base-image-update-report.mjs
@@ -110,6 +110,19 @@ export function publicGalleryUrl(taggedRef) {
   return `https://gallery.ecr.aws/${repository}`;
 }
 
+export function googleArtifactRegistryUrl(image) {
+  const prefix = "gcr.io/";
+  if (!image.startsWith(prefix)) return null;
+
+  const parts = image.slice(prefix.length).split("/");
+  const project = parts.shift();
+  if (!project || parts.length === 0) return null;
+
+  const encodedProject = encodeURIComponent(project);
+  const encodedImagePath = parts.map(encodeURIComponent).join("/");
+  return `https://console.cloud.google.com/artifacts/docker/${encodedProject}/us/gcr.io/${encodedImagePath}`;
+}
+
 export function renderReport(entries) {
   const lines = [
     COMMENT_MARKER,
@@ -123,6 +136,7 @@ export function renderReport(entries) {
     const { file, stage, line, oldImage, newImage, resolvedDigest, verificationError } = entry;
     const matches = resolvedDigest === newImage.digest;
     const galleryUrl = publicGalleryUrl(newImage.taggedRef);
+    const artifactRegistryUrl = googleArtifactRegistryUrl(newImage.image);
 
     lines.push(`### ${matches ? "✅" : "❌"} \`${newImage.taggedRef}\``);
     lines.push("");
@@ -151,6 +165,10 @@ export function renderReport(entries) {
     lines.push("");
     if (galleryUrl) {
       lines.push(`🔗 [View \`${newImage.image}\` in Amazon ECR Public Gallery](${galleryUrl})`);
+      lines.push("");
+    }
+    if (artifactRegistryUrl) {
+      lines.push(`🔗 [View \`${newImage.image}\` in Google Artifact Registry](${artifactRegistryUrl})`);
       lines.push("");
     }
   }

--- a/.github/scripts/base-image-update-report.mjs
+++ b/.github/scripts/base-image-update-report.mjs
@@ -115,10 +115,19 @@ export function googleArtifactRegistryUrl(image) {
   if (!image.startsWith(prefix)) return null;
 
   const parts = image.slice(prefix.length).split("/");
-  const project = parts.shift();
-  if (!project || parts.length === 0) return null;
+  if (parts.length < 2) return null;
 
-  const encodedProject = encodeURIComponent(project);
+  let encodedProject;
+  if (parts[0].includes(".")) {
+    if (parts.length < 3) return null;
+    const domain = parts.shift();
+    const projectId = parts.shift();
+    encodedProject = `${encodeURIComponent(domain)}:${encodeURIComponent(projectId)}`;
+  } else {
+    encodedProject = encodeURIComponent(parts.shift());
+  }
+
+  if (!encodedProject || parts.length === 0) return null;
   const encodedImagePath = parts.map(encodeURIComponent).join("/");
   return `https://console.cloud.google.com/artifacts/docker/${encodedProject}/us/gcr.io/${encodedImagePath}`;
 }

--- a/.github/scripts/base-image-update-report.test.mjs
+++ b/.github/scripts/base-image-update-report.test.mjs
@@ -83,6 +83,10 @@ test("googleArtifactRegistryUrl maps gcr.io images to the Artifact Registry cons
     googleArtifactRegistryUrl("gcr.io/distroless/static-debian12"),
     "https://console.cloud.google.com/artifacts/docker/distroless/us/gcr.io/static-debian12",
   );
+  assert.equal(
+    googleArtifactRegistryUrl("gcr.io/google.com/cloudsdktool/google-cloud-cli"),
+    "https://console.cloud.google.com/artifacts/docker/google.com:cloudsdktool/us/gcr.io/google-cloud-cli",
+  );
   assert.equal(googleArtifactRegistryUrl("public.ecr.aws/lambda/provided"), null);
 });
 

--- a/.github/scripts/base-image-update-report.test.mjs
+++ b/.github/scripts/base-image-update-report.test.mjs
@@ -6,6 +6,7 @@ import {
   COMMENT_MARKER,
   canVerifyRegistryUpdate,
   detectDigestUpdates,
+  googleArtifactRegistryUrl,
   parseFromImages,
   parsePinnedImage,
   publicGalleryUrl,
@@ -75,6 +76,36 @@ test("publicGalleryUrl returns a stable ECR Public Gallery repository URL", () =
     "https://gallery.ecr.aws/lambda/provided",
   );
   assert.equal(publicGalleryUrl("golang:1.26"), null);
+});
+
+test("googleArtifactRegistryUrl maps gcr.io images to the Artifact Registry console", () => {
+  assert.equal(
+    googleArtifactRegistryUrl("gcr.io/distroless/static-debian12"),
+    "https://console.cloud.google.com/artifacts/docker/distroless/us/gcr.io/static-debian12",
+  );
+  assert.equal(googleArtifactRegistryUrl("public.ecr.aws/lambda/provided"), null);
+});
+
+test("renderReport includes Google Artifact Registry link for gcr.io images", () => {
+  const update = detectDigestUpdates(
+    `FROM gcr.io/distroless/static-debian12:nonroot@${OLD}\n`,
+    `FROM gcr.io/distroless/static-debian12:nonroot@${NEW}\n`,
+  )[0];
+
+  const report = renderReport([
+    {
+      file: "system/Dockerfile.fargate",
+      ...update,
+      resolvedDigest: NEW,
+      verificationError: null,
+    },
+  ]);
+
+  assert.match(report, /View \`gcr\.io\/distroless\/static-debian12\` in Google Artifact Registry/);
+  assert.match(
+    report,
+    /https:\/\/console\.cloud\.google\.com\/artifacts\/docker\/distroless\/us\/gcr\.io\/static-debian12/,
+  );
 });
 
 test("renderReport includes verified digests and ECR Public Gallery link", () => {

--- a/system/README.md
+++ b/system/README.md
@@ -79,8 +79,9 @@ docker buildx build --platform linux/arm64 -f system/Dockerfile.fargate system -
 
 - **Dependabot からの digest 更新 PR が来たとき**:
   - `Base Image Update Report` workflow が、旧/新 digest、現在タグの digest、一致判定を同じ PR コメントへ自動で投稿・更新する
-- workflow はすべての PR `opened` / `synchronize` / `reopened` を拾い、最終差分から Dockerfile 更新が消えた場合は古い report comment を削除する。Dockerfile 更新がない場合は registry 照合を行わず終了する
+  - workflow はすべての PR `opened` / `synchronize` / `reopened` を拾い、最終差分から Dockerfile 更新が消えた場合は古い report comment を削除する。Dockerfile 更新がない場合は registry 照合を行わず終了する
   - Amazon ECR Public のイメージでは、対応する ECR Public Gallery へのリンクもコメントに表示する
+  - `gcr.io` のイメージでは、対応する Google Artifact Registry のイメージ画面へのリンクもコメントに表示する
   - registry の現在タグと pinned digest を検証できない場合はコメント／Actions warningで明示するが、この report workflow 自体は advisory としてマージをブロックしない
   1. `aws-cdk/` で `pnpm cdk:diff --profile <dev プロファイル>` を実行し、変更が digest 差し替えだけであることを確認
   2. `pnpm cdk:deploy --profile <dev プロファイル>` で dev 環境にデプロイしてスモーク確認


### PR DESCRIPTION
## Summary

`Base Image Update Report` の `gcr.io` イメージに、Google Artifact Registry のブラウザ画面へのリンクを追加します。

PR #1047 のような

```text
gcr.io/distroless/static-debian12:nonroot@sha256:...
```

に対して、report comment に次のリンクを表示します。

```text
🔗 View gcr.io/distroless/static-debian12 in Google Artifact Registry
```

リンク先:

```text
https://console.cloud.google.com/artifacts/docker/distroless/us/gcr.io/static-debian12
```

## Why

`gcr.io` URL の Google-owned images は現在 Artifact Registry でホストされており、Google Cloud の対応表では `gcr.io` は location `us` / repository `gcr.io` に対応します。

これにより ECR Public と GCR のどちらの base image update でも、PRコメントから人間向けregistry UIへ移動できます。

## Changes

- `googleArtifactRegistryUrl()` を追加
- `gcr.io/<project>/<image>` を Artifact Registry Console URL へ変換
- domain-scoped project ID（例: `gcr.io/google.com/cloudsdktool/google-cloud-cli` → project `google.com:cloudsdktool`）にも対応
- report comment に Google Artifact Registry link を表示
- URL生成と report rendering のテストを追加
- Google公式 `cloud-sdk-docker` の domain-scoped project ID ケースを回帰テストに追加
- README に GCR link の挙動を追記
- あわせて base image 更新運用セクションの既存箇条書きインデントを整形

## Scope

今回は現在利用中の `gcr.io` のみを対象にします。`asia.gcr.io` / `eu.gcr.io` / `us.gcr.io` など未使用hostへの対応は追加していません。

Base branch は `dev` ですが、このPRのマージは行いません。