### PR TITLE
room-image-promptのstyle注入境界を一般化

### DIFF
--- a/tools/room-image-prompt/README.md
+++ b/tools/room-image-prompt/README.md
@@ -14,7 +14,9 @@ go build -o room-image-prompt ./cmd/room-image-prompt
 ./room-image-prompt -version
 ```
 
-引数なしで、上から4テーマ行（各 `data/0N_*.txt` から1行を独立に乱数抽選）に加え、**座席数 10〜15** を1回一様乱数で決定します。`data/prompt_template.txt` の `{{STYLE}}` に `data/style_legacy.txt` を挿入し、最後にテーマ条件を連結した UTF-8 テキストを **`output/prompt-<タイムスタンプ>.txt`** に書き込みます。あわせて**同じ本文をクリップボードへコピー**します（失敗しても終了コードは成功のままです）。
+引数なしで、上から4テーマ行（各 `data/0N_*.txt` から1行を独立に乱数抽選）に加え、**座席数 10〜15** を1回一様乱数で決定します。`data/prompt_template.txt` の `{{STYLE}}` に既定の `data/style_legacy.txt` を挿入し、最後にテーマ条件を連結した UTF-8 テキストを **`output/prompt-<タイムスタンプ>.txt`** に書き込みます。あわせて**同じ本文をクリップボードへコピー**します（失敗しても終了コードは成功のままです）。
+
+`-style-file <path>` を指定すると、legacy style の代わりに任意の UTF-8 テキストをスタイルとして注入できます。
 
 - **標準エラー**: `出力: <ファイル名>` に続き、`クリップボードにコピーしました` または `コピーに失敗しました` を1行ずつ出します。Linux などで `xclip` / `xsel` が無い環境ではコピーが失敗し得ます。
 - **標準出力**: **保存したファイルの絶対パスを1行**だけ出します（スクリプト向け）。
@@ -39,8 +41,9 @@ go build -o room-image-prompt ./cmd/room-image-prompt
 | `data/prompt_template.txt` | アスペクト比、UIを重ねる領域、人物・文字の禁止など、スタイルに依存しない共通用途制約。スタイル挿入位置として `{{STYLE}}` を1個だけ持つ |
 | `data/style_legacy.txt` | 従来の画風指定。現行CLIでは後方互換のため、このスタイルを `{{STYLE}}` に挿入する |
 
-この分離は、共通用途制約と画風を物理的に切り離すためのものです。**この段階ではCLIの生成結果自体は従来と同じ legacy スタイルを維持します。**
-Direction A / B / C の選択と組み立ては後続変更で扱います。
+共通テンプレートの読み込みとスタイル注入は内部APIでも分離されています。CLIはスタイル未指定時に legacy を使い、`-style-file` では任意のスタイル本文を注入できます。
+
+Direction A / B / C の本文はこのツール配下へ複製しません。具体的な Direction とCLIの接続、および canonical source の扱いは後続変更で行います。
 
 出力に付与するテーマブロックの行ラベルは、順に `世界観` / `時間帯` / `作業空間` / `座席レイアウト` / `座席数` です（`internal/theme` の `FormatThemeBlock`）。`座席数` は10〜15の乱数で、専用の候補ファイルはありません。
 
@@ -56,6 +59,8 @@ Direction A / B / C の選択と組み立ては後続変更で扱います。
 | `-version` | バージョン表示して終了 |
 | `-out <path>` | 出力ファイル（省略時は上記タイムスタンプ名） |
 | `-seed <uint64>` | 乱数シード（10進）。省略時は非固定 |
+| `-style <name>` | 内蔵スタイル名。現在は `legacy` のみ。省略時も `legacy` |
+| `-style-file <path>` | 任意の UTF-8 スタイル本文をファイルから読み込む。 `-style` と同時指定不可 |
 
 開発中は `go run` でも可です。
 
@@ -63,6 +68,8 @@ Direction A / B / C の選択と組み立ては後続変更で扱います。
 cd tools/room-image-prompt
 go run ./cmd/room-image-prompt -version
 go run ./cmd/room-image-prompt -seed 1
+go run ./cmd/room-image-prompt -seed 1 -style legacy
+go run ./cmd/room-image-prompt -seed 1 -style-file ./my-style.txt
 ```
 
 ## テスト

--- a/tools/room-image-prompt/cmd/room-image-prompt/main.go
+++ b/tools/room-image-prompt/cmd/room-image-prompt/main.go
@@ -164,7 +164,7 @@ func resolveStyle(fsys fs.FS, styleName, styleFile string) (string, error) {
 	case "", legacyStyleName:
 		style, err := theme.ReadLegacyStyle(fsys)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("legacy style 読込: %w", err)
 		}
 		return style, nil
 	default:

--- a/tools/room-image-prompt/cmd/room-image-prompt/main.go
+++ b/tools/room-image-prompt/cmd/room-image-prompt/main.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"math/rand/v2"
 	"os"
 	"path/filepath"
@@ -34,6 +35,7 @@ const (
 オプション:
 `
 	defaultOutputMaxAttempts = 10
+	legacyStyleName          = "legacy"
 )
 
 func main() {
@@ -57,6 +59,8 @@ func run() error {
 	version := fs.Bool("version", false, "バージョンを表示して終了")
 	outPath := fs.String("out", "", "出力ファイルパス（省略時はカレントの output/prompt-<タイムスタンプ>.txt）")
 	seedStr := fs.String("seed", "", "乱数シード（10進 uint64）。省略時は非固定")
+	styleName := fs.String("style", "", "内蔵スタイル名（現在は legacy のみ）。省略時は legacy")
+	styleFile := fs.String("style-file", "", "任意スタイルを読み込む UTF-8 テキストファイル（-style と同時指定不可）")
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		configureUsage(fs, os.Stderr)
@@ -97,7 +101,15 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("テンプレート読込: %w", err)
 	}
-	body := theme.RenderFinal(tmpl, th.FormatThemeBlock())
+	style, err := resolveStyle(fsys, *styleName, *styleFile)
+	if err != nil {
+		return fmt.Errorf("スタイル読込: %w", err)
+	}
+	styledTemplate, err := theme.ApplyStyle(tmpl, style)
+	if err != nil {
+		return fmt.Errorf("スタイル適用: %w", err)
+	}
+	body := theme.RenderFinal(styledTemplate, th.FormatThemeBlock())
 
 	dest := *outPath
 	if dest == "" {
@@ -133,6 +145,31 @@ func run() error {
 
 	fmt.Println(abs)
 	return nil
+}
+
+func resolveStyle(fsys fs.FS, styleName, styleFile string) (string, error) {
+	if styleName != "" && styleFile != "" {
+		return "", fmt.Errorf("-style と -style-file は同時指定できません")
+	}
+
+	if styleFile != "" {
+		b, err := os.ReadFile(styleFile)
+		if err != nil {
+			return "", fmt.Errorf("-style-file %q: %w", styleFile, err)
+		}
+		return string(b), nil
+	}
+
+	switch styleName {
+	case "", legacyStyleName:
+		style, err := theme.ReadLegacyStyle(fsys)
+		if err != nil {
+			return "", err
+		}
+		return style, nil
+	default:
+		return "", fmt.Errorf("-style %q は未対応です（現在は %q のみ）", styleName, legacyStyleName)
+	}
 }
 
 func configureUsage(fs *flag.FlagSet, output io.Writer) {

--- a/tools/room-image-prompt/cmd/room-image-prompt/main_e2e_test.go
+++ b/tools/room-image-prompt/cmd/room-image-prompt/main_e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/fstest"
 	"time"
 )
 
@@ -72,6 +73,94 @@ func TestCLI_StdoutPath_TC_C2_extension(t *testing.T) {
 	}
 	if okCopy && failCopy {
 		t.Fatalf("stderr should contain only one clipboard status\ngot %q", errOut)
+	}
+
+	body, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "写真風、3D建築レンダリング風、フォトリアル表現にはしないでください。") {
+		t.Fatalf("default output should keep legacy style:\n%s", body)
+	}
+}
+
+func TestCLI_StyleFile(t *testing.T) {
+	t.Parallel()
+
+	dir := moduleRoot(t)
+	tmp := t.TempDir()
+	styleFile := filepath.Join(tmp, "custom-style.txt")
+	if err := os.WriteFile(styleFile, []byte("CUSTOM_STYLE\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	outFile := filepath.Join(tmp, "custom.txt")
+
+	cmd := exec.Command(
+		"go", "run", "./cmd/room-image-prompt",
+		"-seed", "1",
+		"-style-file", styleFile,
+		"-out", outFile,
+	)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%v\n%s", err, out)
+	}
+
+	body, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(body)
+	if !strings.Contains(got, "CUSTOM_STYLE") {
+		t.Fatalf("custom style was not injected:\n%s", got)
+	}
+	if strings.Contains(got, "写真風、3D建築レンダリング風、フォトリアル表現にはしないでください。") {
+		t.Fatalf("legacy style should not be injected with -style-file:\n%s", got)
+	}
+}
+
+func TestResolveStyle(t *testing.T) {
+	t.Parallel()
+
+	fsys := fstest.MapFS{
+		"style_legacy.txt": {Data: []byte("LEGACY_STYLE\n")},
+	}
+	customPath := filepath.Join(t.TempDir(), "custom-style.txt")
+	if err := os.WriteFile(customPath, []byte("CUSTOM_STYLE\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name      string
+		styleName string
+		styleFile string
+		want      string
+		wantErr   bool
+	}{
+		{name: "default legacy", want: "LEGACY_STYLE\n"},
+		{name: "explicit legacy", styleName: legacyStyleName, want: "LEGACY_STYLE\n"},
+		{name: "custom file", styleFile: customPath, want: "CUSTOM_STYLE\n"},
+		{name: "conflicting sources", styleName: legacyStyleName, styleFile: customPath, wantErr: true},
+		{name: "unsupported named style", styleName: "direction-a", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveStyle(fsys, tt.styleName, tt.styleFile)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("style mismatch: got %q want %q", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/tools/room-image-prompt/internal/theme/theme.go
+++ b/tools/room-image-prompt/internal/theme/theme.go
@@ -1,7 +1,6 @@
 package theme
 
 import (
-	"bytes"
 	"fmt"
 	"io/fs"
 	"math/rand/v2"
@@ -77,27 +76,46 @@ func BuildTheme(fsys fs.FS, r *rand.Rand) (Theme, error) {
 	return t, nil
 }
 
-// ReadTemplate loads the common prompt template and the legacy style block, normalizes CRLF to LF,
-// and injects the style block at exactly one {{STYLE}} placeholder.
-//
-// The style is deliberately stored separately so later callers can replace it with an explicit
-// art direction without duplicating or parsing the common usage constraints.
+// ReadTemplate loads and validates the common prompt template without choosing a style.
 func ReadTemplate(fsys fs.FS) (string, error) {
 	tmpl, err := readRequiredText(fsys, templateFile)
 	if err != nil {
 		return "", err
 	}
-	if count := strings.Count(tmpl, stylePlaceholder); count != 1 {
-		return "", fmt.Errorf("%q: %s は1個必要です（実際: %d個）", templateFile, stylePlaceholder, count)
+	if err := validateStylePlaceholder(tmpl); err != nil {
+		return "", fmt.Errorf("%q: %w", templateFile, err)
+	}
+	return tmpl, nil
+}
+
+// ReadLegacyStyle loads the bundled legacy style used when no explicit style is supplied.
+func ReadLegacyStyle(fsys fs.FS) (string, error) {
+	return readRequiredText(fsys, legacyStyleFile)
+}
+
+// ApplyStyle injects style into exactly one {{STYLE}} placeholder.
+// It accepts arbitrary style text so callers do not need to encode named art directions here.
+func ApplyStyle(template, style string) (string, error) {
+	template = normalizeNewlines(template)
+	if err := validateStylePlaceholder(template); err != nil {
+		return "", err
 	}
 
-	style, err := readRequiredText(fsys, legacyStyleFile)
-	if err != nil {
-		return "", err
+	style = normalizeNewlines(style)
+	if strings.TrimSpace(style) == "" {
+		return "", fmt.Errorf("style: テキストが空です")
 	}
 	style = strings.TrimRight(style, "\n")
 
-	return strings.Replace(tmpl, stylePlaceholder, style, 1), nil
+	return strings.Replace(template, stylePlaceholder, style, 1), nil
+}
+
+func validateStylePlaceholder(template string) error {
+	count := strings.Count(template, stylePlaceholder)
+	if count != 1 {
+		return fmt.Errorf("%s は1個必要です（実際: %d個）", stylePlaceholder, count)
+	}
+	return nil
 }
 
 func readRequiredText(fsys fs.FS, name string) (string, error) {
@@ -105,9 +123,13 @@ func readRequiredText(fsys fs.FS, name string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("read %q: %w", name, err)
 	}
-	s := string(bytes.ReplaceAll(b, []byte("\r\n"), []byte("\n")))
+	s := normalizeNewlines(string(b))
 	if strings.TrimSpace(s) == "" {
 		return "", fmt.Errorf("%q: テキストが空です", name)
 	}
 	return s, nil
+}
+
+func normalizeNewlines(s string) string {
+	return strings.ReplaceAll(s, "\r\n", "\n")
 }

--- a/tools/room-image-prompt/internal/theme/theme_test.go
+++ b/tools/room-image-prompt/internal/theme/theme_test.go
@@ -74,6 +74,14 @@ func TestRenderFinal_TC_C1(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	style, err := ReadLegacyStyle(fsys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl, err = ApplyStyle(tmpl, style)
+	if err != nil {
+		t.Fatal(err)
+	}
 	th, err := BuildTheme(fsys, rand.New(rand.NewPCG(1, 0)))
 	if err != nil {
 		t.Fatal(err)
@@ -106,6 +114,14 @@ func TestWriteFinal_TC_C2(t *testing.T) {
 	t.Parallel()
 	fsys := testdataDir(t, "build_single")
 	tmpl, err := ReadTemplate(fsys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	style, err := ReadLegacyStyle(fsys)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpl, err = ApplyStyle(tmpl, style)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -178,17 +194,52 @@ func TestReadTemplate_RequiresExactlyOneStylePlaceholder(t *testing.T) {
 	}
 }
 
-func TestReadTemplate_RejectsEmptyLegacyStyle(t *testing.T) {
+func TestReadLegacyStyle_RejectsEmpty(t *testing.T) {
 	t.Parallel()
 	fsys := fstest.MapFS{
-		templateFile:    {Data: []byte("BEFORE\n{{STYLE}}\nAFTER\n")},
 		legacyStyleFile: {Data: []byte("\n")},
 	}
-	_, err := ReadTemplate(fsys)
+	_, err := ReadLegacyStyle(fsys)
 	if err == nil {
 		t.Fatal("expected error")
 	}
 	if !strings.Contains(err.Error(), legacyStyleFile) || !strings.Contains(err.Error(), "空") {
 		t.Fatalf("expected empty-style hint: %v", err)
+	}
+}
+
+func TestApplyStyle_CustomStyle(t *testing.T) {
+	t.Parallel()
+
+	got, err := ApplyStyle("BEFORE\r\n{{STYLE}}\r\nAFTER\r\n", "CUSTOM\r\nSTYLE\r\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "BEFORE\nCUSTOM\nSTYLE\nAFTER\n"
+	if got != want {
+		t.Fatalf("styled template mismatch:\ngot  %q\nwant %q", got, want)
+	}
+}
+
+func TestApplyStyle_RejectsInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		template string
+		style    string
+	}{
+		{name: "missing placeholder", template: "COMMON_ONLY\n", style: "STYLE\n"},
+		{name: "multiple placeholders", template: "{{STYLE}}\n{{STYLE}}\n", style: "STYLE\n"},
+		{name: "empty style", template: "BEFORE\n{{STYLE}}\nAFTER\n", style: "\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := ApplyStyle(tt.template, tt.style); err == nil {
+				t.Fatal("expected error")
+			}
+		})
 	}
 }


### PR DESCRIPTION
## 概要

#1055 で物理分離した共通用途制約 / legacy style の境界を、**任意のstyleを注入できるAPI / CLI境界**へ一般化します。

このPRでは Direction A / B / C の本文や選択ロジックはまだ持ち込みません。CLI自身は特定Directionを知らず、任意styleテキストを受け取れるところまでを責務とします。

## Goal

- 共通テンプレートの読み込みとstyle適用を別APIにする
- 既定動作は従来どおり legacy style
- CLIから任意のUTF-8 styleファイルを注入できる
- Direction A/B/C の定義を `tools/room-image-prompt` へ複製しない

## 変更内容

### 内部API

`internal/theme` を以下の責務へ分離します。

- `ReadTemplate(fsys)`
  - 共通用途制約テンプレートを読む
  - `{{STYLE}}` がちょうど1個であることを検証
  - styleはまだ適用しない
- `ReadLegacyStyle(fsys)`
  - 後方互換用の同梱legacy styleを読む
- `ApplyStyle(template, style)`
  - 任意のstyle本文を `{{STYLE}}` へ注入
  - CRLFを正規化
  - 空style、placeholder 0個 / 複数個を拒否

### CLI

- 未指定: legacy style
- `-style legacy`: legacy styleを明示指定
- `-style-file <path>`: 任意のUTF-8 styleファイルを注入
- `-style` と `-style-file` の同時指定はエラー
- 未知の named style は現時点では拒否

`direction-a` などをこのPRで追加しないことで、#1057 の canonical source 設計と分離します。

### Tests

- 既定CLI出力がlegacy styleを維持すること
- `-style-file` の本文が最終プロンプトへ入り、legacy styleが混入しないこと
- style sourceの既定 / 明示legacy / custom file / 競合 / 未対応named style
- `ApplyStyle` の任意style、CRLF正規化、空style、placeholder不正

### README

新しいstyle注入境界とCLIオプションを記載します。

## Invariants

- 引数なしの生成結果は #1055 時点のlegacy styleと同じ
- テーマ抽選、座席数、出力ファイル、クリップボード動作は変更しない
- 共通用途制約はstyleから独立したまま
- A/B/C の本文はこのPRでコピーしない

## Non-goals

- Direction A/B/C のnamed style対応
- Direction定義のcanonical source設計
- SkillからCLI fragmentを生成する仕組み
- テーマ候補や座席レイアウトの変更
- 暫定互換境界の削除

## Acceptance criteria

- `room-image-prompt -seed 1` がlegacy styleを使う
- `room-image-prompt -seed 1 -style legacy` が同じstyleを使う
- `room-image-prompt -seed 1 -style-file ./custom.txt` がcustom styleだけを適用する
- `-style` と `-style-file` の同時指定、および未対応named styleを拒否する
- Go Test / Lint / CI Gate が成功する

## Verification

手元では実行していません。GitHub Actions の以下を最終ゲートとします。

- Room Image Prompt Go Test
- Room Image Prompt Go Lint
- CI Gate

## Stack

```text
#1055 共通用途制約 / legacy style の物理分離 ✅ integration branchへmerge済み
  ↓
#1056 style injection API / CLI境界の一般化 ← このPR
  ↓
#1057 Direction A/B/C とCLIを接続
       canonical sourceを単一に保つ
  ↓
#1058 暫定境界整理 / E2E / 周辺更新
```

baseは `feat/room-art-direction-rollout` です。最終的な `dev` 反映は統合ブランチから別PRで行います。
