### PR TITLE
canonical DirectionからCLI styleを生成して接続

### DIFF
--- a/.agents/skills/room-art-direction/SKILL.md
+++ b/.agents/skills/room-art-direction/SKILL.md
@@ -64,9 +64,9 @@ YouTube Study Space のルーム背景画像に、再利用可能なアートデ
 その資料に含まれる用途制約は利用してよいが、特定の色・レンダリング・質感の指定を、選択中の Direction より優先しない。
 
 > [!IMPORTANT]
-> `tools/room-image-prompt` の現行 CLI 出力は、`prompt_template.txt` に残る legacy な画風指定（3D 建築レンダリング風を避ける、ベクターライク、素材感控えめ、落ち着いた配色など）をそのまま含むため、Direction A / B / C 適用時には CLI の生成結果をそのまま画像生成モデルへ渡さない。
-> `prompt_template.txt` からアスペクト比、座席カード配置、人物・文字の禁止などの**用途制約だけを抽出**し、画風に関する部分は**選択中の Direction の定義で置き換える**。
-> 将来的に CLI 側で「共通用途制約」と「Style / Direction」を物理的に分離するまでは、このルールを互換境界とする。
+> Direction の canonical source は `references/direction-*.md` である。CLI用の `tools/room-image-prompt/data/style_direction_*.generated.txt` は各referenceの **`## Prompt guidance` セクションから自動生成**されるため、生成物を直接編集しない。
+> Direction を変更したら `cd tools/room-image-prompt && go generate ./data` を実行し、生成物も同じ変更に含める。CIはcanonical Markdownと生成物の不一致を拒否する。
+> CLIでは `-style direction-a` / `direction-b` / `direction-c` で生成済みDirectionを利用できる。未指定時だけ後方互換のため `legacy` を使う。
 
 ### 2. Direction の不変条件を読む
 
@@ -150,7 +150,10 @@ Direction を新規追加・大幅更新したときは、可能なら次の Sub
 1. `references/direction-<id>-<name>.md` を追加する。
 2. このファイルの「現在のアートディレクション」表へ追加する。
 3. Core / Prefer / Avoid / Non-goals を必ず書く。
-4. 過去生成物から抽出したモチーフと、実際の描画ルールを分離する。
-5. Subject Swap Test で題材依存になっていないことを確認する。
+4. **`## Prompt guidance` を必ず1つだけ置き、CLIへ渡してよい簡潔なstyle fragmentだけを書く。** このセクションが実行用styleのcanonical sourceになる。
+5. 過去生成物から抽出したモチーフと、実際の描画ルールを分離する。
+6. Subject Swap Test で題材依存になっていないことを確認する。
+7. `cd tools/room-image-prompt && go generate ./data` を実行し、生成された `style_direction_*.generated.txt` をコミットする。
+8. `go test ./...` でcanonical sourceと生成物の同期を確認する。
 
 既存 Direction の内容を、新しい Direction に合わせて平均化しない。管理人の複数の好みは複数の方向性として共存させる。

--- a/.github/scripts/detect-ci-paths.sh
+++ b/.github/scripts/detect-ci-paths.sh
@@ -96,7 +96,7 @@ classify_path() {
 			formal_spec=true
 			matched=true
 			;;
-		tools/room-image-prompt/*)
+		.agents/skills/room-art-direction/references/*|tools/room-image-prompt/*)
 			room_image_prompt=true
 			matched=true
 			;;

--- a/.github/scripts/test-detect-ci-paths.sh
+++ b/.github/scripts/test-detect-ci-paths.sh
@@ -46,6 +46,7 @@ assert_exact_groups "system firestore_integration aws_cdk" system/.dockerignore
 assert_exact_groups aws_cdk aws-cdk/lib/aws-cdk-stack.ts
 assert_exact_groups docs_site docs-site/docs/intro.md
 assert_exact_groups room_image_prompt tools/room-image-prompt/cmd/room-image-prompt/main.go
+assert_exact_groups room_image_prompt .agents/skills/room-art-direction/references/direction-a-clean-vivid-digital.md
 assert_exact_groups menu_image_generator tools/menu-image-generator/src/index.ts
 assert_exact_groups node_projects .node-version
 assert_exact_groups node_projects .nvmrc

--- a/tools/room-image-prompt/README.md
+++ b/tools/room-image-prompt/README.md
@@ -1,6 +1,6 @@
 # room-image-prompt
 
-ルーム画像生成（画像生成モデル等）向けのプロンプトを組み立て、`output/` に保存する Go CLI です。候補テキスト、共通テンプレート、スタイル定義は `data/` に置き、`go:embed` でバイナリに同梱します（外部の `-data-dir` はありません。差し替えは `data/` を編集して再ビルドしてください）。
+ルーム画像生成（画像生成モデル等）向けのプロンプトを組み立て、`output/` に保存する Go CLI です。候補テキストと共通テンプレートは `data/` に置き、`go:embed` でバイナリに同梱します。Direction A/B/C の正は `.agents/skills/room-art-direction/references/` にあり、CLI用style assetはそこから生成します。
 
 ## 必要環境
 
@@ -16,7 +16,7 @@ go build -o room-image-prompt ./cmd/room-image-prompt
 
 引数なしで、上から4テーマ行（各 `data/0N_*.txt` から1行を独立に乱数抽選）に加え、**座席数 10〜15** を1回一様乱数で決定します。`data/prompt_template.txt` の `{{STYLE}}` に既定の `data/style_legacy.txt` を挿入し、最後にテーマ条件を連結した UTF-8 テキストを **`output/prompt-<タイムスタンプ>.txt`** に書き込みます。あわせて**同じ本文をクリップボードへコピー**します（失敗しても終了コードは成功のままです）。
 
-`-style-file <path>` を指定すると、legacy style の代わりに任意の UTF-8 テキストをスタイルとして注入できます。
+`-style direction-a` / `direction-b` / `direction-c` で管理人のアートディレクションを選択できます。`-style-file <path>` を指定すると、任意の UTF-8 テキストをスタイルとして注入できます。未指定時は後方互換のため `legacy` です。
 
 - **標準エラー**: `出力: <ファイル名>` に続き、`クリップボードにコピーしました` または `コピーに失敗しました` を1行ずつ出します。Linux などで `xclip` / `xsel` が無い環境ではコピーが失敗し得ます。
 - **標準出力**: **保存したファイルの絶対パスを1行**だけ出します（スクリプト向け）。
@@ -39,11 +39,23 @@ go build -o room-image-prompt ./cmd/room-image-prompt
 | ファイル | 役割 |
 |----------|------|
 | `data/prompt_template.txt` | アスペクト比、UIを重ねる領域、人物・文字の禁止など、スタイルに依存しない共通用途制約。スタイル挿入位置として `{{STYLE}}` を1個だけ持つ |
-| `data/style_legacy.txt` | 従来の画風指定。現行CLIでは後方互換のため、このスタイルを `{{STYLE}}` に挿入する |
+| `data/style_legacy.txt` | 後方互換用の従来画風。手動管理 |
+| `data/style_direction_*.generated.txt` | Direction Markdown の `## Prompt guidance` から生成されるCLI用style。**直接編集禁止** |
 
-共通テンプレートの読み込みとスタイル注入は内部APIでも分離されています。CLIはスタイル未指定時に legacy を使い、`-style-file` では任意のスタイル本文を注入できます。
+共通テンプレートの読み込み、style sourceの選択、style適用は別々の責務です。
 
-Direction A / B / C の本文はこのツール配下へ複製しません。具体的な Direction とCLIの接続、および canonical source の扱いは後続変更で行います。
+### Direction の単一の正と生成
+
+Direction A/B/C の canonical source は `.agents/skills/room-art-direction/references/direction-*.md` です。各Markdownの **`## Prompt guidance` セクションだけ**をCLI向けの実行用fragmentとして抽出します。Summary / Core / Avoid / Non-goals / Review checklist まで丸ごとCLIへ入れないため、Agent向け文書の表現力と実行プロンプトの簡潔さを両立します。
+
+生成は次で行います。
+
+```bash
+cd tools/room-image-prompt
+go generate ./data
+```
+
+生成済みファイルがcanonical Markdownと一致しない場合はGo testが失敗します。また、Direction referenceの変更でもRoom Image Prompt CIが起動するようpath routingで保護します。
 
 出力に付与するテーマブロックの行ラベルは、順に `世界観` / `時間帯` / `作業空間` / `座席レイアウト` / `座席数` です（`internal/theme` の `FormatThemeBlock`）。`座席数` は10〜15の乱数で、専用の候補ファイルはありません。
 
@@ -59,7 +71,7 @@ Direction A / B / C の本文はこのツール配下へ複製しません。具
 | `-version` | バージョン表示して終了 |
 | `-out <path>` | 出力ファイル（省略時は上記タイムスタンプ名） |
 | `-seed <uint64>` | 乱数シード（10進）。省略時は非固定 |
-| `-style <name>` | 内蔵スタイル名。現在は `legacy` のみ。省略時も `legacy` |
+| `-style <name>` | `legacy` または生成済み `direction-a` / `direction-b` / `direction-c`。省略時は `legacy` |
 | `-style-file <path>` | 任意の UTF-8 スタイル本文をファイルから読み込む。 `-style` と同時指定不可 |
 
 開発中は `go run` でも可です。
@@ -69,6 +81,9 @@ cd tools/room-image-prompt
 go run ./cmd/room-image-prompt -version
 go run ./cmd/room-image-prompt -seed 1
 go run ./cmd/room-image-prompt -seed 1 -style legacy
+go run ./cmd/room-image-prompt -seed 1 -style direction-a
+go run ./cmd/room-image-prompt -seed 1 -style direction-b
+go run ./cmd/room-image-prompt -seed 1 -style direction-c
 go run ./cmd/room-image-prompt -seed 1 -style-file ./my-style.txt
 ```
 

--- a/tools/room-image-prompt/cmd/generate-styles/main.go
+++ b/tools/room-image-prompt/cmd/generate-styles/main.go
@@ -1,0 +1,51 @@
+// generate-styles derives room-image-prompt style assets from canonical room-art-direction Markdown.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/kani3camp/youtube-study-space/tools/room-image-prompt/internal/stylegen"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	check := flag.Bool("check", false, "生成済みstyleがcanonical Markdownと一致することだけを確認")
+	flag.Parse()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("get working directory: %w", err)
+	}
+	repoRoot, err := stylegen.FindRepoRoot(wd)
+	if err != nil {
+		return fmt.Errorf("find repository root: %w", err)
+	}
+	artifacts, err := stylegen.Generate(repoRoot)
+	if err != nil {
+		return fmt.Errorf("generate styles: %w", err)
+	}
+
+	if *check {
+		if err := stylegen.Check(repoRoot, artifacts); err != nil {
+			return fmt.Errorf("check generated styles: %w", err)
+		}
+		fmt.Printf("generated styles are up-to-date (%d)\n", len(artifacts))
+		return nil
+	}
+
+	if err := stylegen.Write(repoRoot, artifacts); err != nil {
+		return fmt.Errorf("write generated styles: %w", err)
+	}
+	for _, artifact := range artifacts {
+		fmt.Printf("%s <- %s\n", artifact.OutputPath, artifact.SourcePath)
+	}
+	return nil
+}

--- a/tools/room-image-prompt/cmd/room-image-prompt/main.go
+++ b/tools/room-image-prompt/cmd/room-image-prompt/main.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/atotto/clipboard"
@@ -59,7 +60,7 @@ func run() error {
 	version := fs.Bool("version", false, "バージョンを表示して終了")
 	outPath := fs.String("out", "", "出力ファイルパス（省略時はカレントの output/prompt-<タイムスタンプ>.txt）")
 	seedStr := fs.String("seed", "", "乱数シード（10進 uint64）。省略時は非固定")
-	styleName := fs.String("style", "", "内蔵スタイル名（現在は legacy のみ）。省略時は legacy")
+	styleName := fs.String("style", "", "内蔵スタイル名（legacy または生成済み direction-*）。省略時は legacy")
 	styleFile := fs.String("style-file", "", "任意スタイルを読み込む UTF-8 テキストファイル（-style と同時指定不可）")
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
@@ -168,7 +169,14 @@ func resolveStyle(fsys fs.FS, styleName, styleFile string) (string, error) {
 		}
 		return style, nil
 	default:
-		return "", fmt.Errorf("-style %q は未対応です（現在は %q のみ）", styleName, legacyStyleName)
+		if strings.HasPrefix(styleName, "direction-") {
+			style, err := theme.ReadDirectionStyle(fsys, styleName)
+			if err != nil {
+				return "", fmt.Errorf("named style %q 読込: %w", styleName, err)
+			}
+			return style, nil
+		}
+		return "", fmt.Errorf("-style %q は未対応です（legacy または生成済み direction-* を指定してください）", styleName)
 	}
 }
 

--- a/tools/room-image-prompt/cmd/room-image-prompt/main_e2e_test.go
+++ b/tools/room-image-prompt/cmd/room-image-prompt/main_e2e_test.go
@@ -125,8 +125,8 @@ func TestResolveStyle(t *testing.T) {
 	t.Parallel()
 
 	fsys := fstest.MapFS{
-		"style_legacy.txt":                    {Data: []byte("LEGACY_STYLE\n")},
-		"style_direction_a.generated.txt":     {Data: []byte("DIRECTION_A\n")},
+		"style_legacy.txt":                {Data: []byte("LEGACY_STYLE\n")},
+		"style_direction_a.generated.txt": {Data: []byte("DIRECTION_A\n")},
 	}
 	customPath := filepath.Join(t.TempDir(), "custom-style.txt")
 	if err := os.WriteFile(customPath, []byte("CUSTOM_STYLE\n"), 0o644); err != nil {

--- a/tools/room-image-prompt/cmd/room-image-prompt/main_e2e_test.go
+++ b/tools/room-image-prompt/cmd/room-image-prompt/main_e2e_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"testing/fstest"
 	"time"
+
+	"github.com/kani3camp/youtube-study-space/tools/room-image-prompt/data"
 )
 
 func moduleRoot(t *testing.T) string {
@@ -123,7 +125,8 @@ func TestResolveStyle(t *testing.T) {
 	t.Parallel()
 
 	fsys := fstest.MapFS{
-		"style_legacy.txt": {Data: []byte("LEGACY_STYLE\n")},
+		"style_legacy.txt":                    {Data: []byte("LEGACY_STYLE\n")},
+		"style_direction_a.generated.txt":     {Data: []byte("DIRECTION_A\n")},
 	}
 	customPath := filepath.Join(t.TempDir(), "custom-style.txt")
 	if err := os.WriteFile(customPath, []byte("CUSTOM_STYLE\n"), 0o644); err != nil {
@@ -140,8 +143,10 @@ func TestResolveStyle(t *testing.T) {
 		{name: "default legacy", want: "LEGACY_STYLE\n"},
 		{name: "explicit legacy", styleName: legacyStyleName, want: "LEGACY_STYLE\n"},
 		{name: "custom file", styleFile: customPath, want: "CUSTOM_STYLE\n"},
+		{name: "direction style", styleName: "direction-a", want: "DIRECTION_A\n"},
 		{name: "conflicting sources", styleName: legacyStyleName, styleFile: customPath, wantErr: true},
-		{name: "unsupported named style", styleName: "direction-a", wantErr: true},
+		{name: "missing direction style", styleName: "direction-z", wantErr: true},
+		{name: "unsupported named style", styleName: "other", wantErr: true},
 	}
 
 	for _, tt := range tests {
@@ -161,6 +166,61 @@ func TestResolveStyle(t *testing.T) {
 				t.Fatalf("style mismatch: got %q want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestResolveBundledDirectionStyles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		marker string
+	}{
+		{name: "direction-a", marker: "premium game environment art"},
+		{name: "direction-b", marker: "full-scene anime environment illustration"},
+		{name: "direction-c", marker: "clean abstract graphic spatial illustration"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			style, err := resolveStyle(data.FS, tt.name, "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(style, tt.marker) {
+				t.Fatalf("style %q does not contain marker %q: %s", tt.name, tt.marker, style)
+			}
+		})
+	}
+}
+
+func TestCLI_DirectionStyle(t *testing.T) {
+	t.Parallel()
+
+	dir := moduleRoot(t)
+	outFile := filepath.Join(t.TempDir(), "direction-a.txt")
+	cmd := exec.Command(
+		"go", "run", "./cmd/room-image-prompt",
+		"-seed", "1",
+		"-style", "direction-a",
+		"-out", outFile,
+	)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%v\n%s", err, out)
+	}
+
+	body, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(body)
+	if !strings.Contains(got, "premium game environment art") {
+		t.Fatalf("direction-a style was not injected:\n%s", got)
+	}
+	if strings.Contains(got, "写真風、3D建築レンダリング風、フォトリアル表現にはしないでください。") {
+		t.Fatalf("legacy style should not be injected with direction-a:\n%s", got)
 	}
 }
 

--- a/tools/room-image-prompt/data/embed.go
+++ b/tools/room-image-prompt/data/embed.go
@@ -2,5 +2,7 @@ package data
 
 import "embed"
 
+//go:generate go run ../cmd/generate-styles
+
 //go:embed *.txt
 var FS embed.FS

--- a/tools/room-image-prompt/data/style_direction_a.generated.txt
+++ b/tools/room-image-prompt/data/style_direction_a.generated.txt
@@ -1,0 +1,12 @@
+- polished cinematic stylized CG environment
+- premium game environment art
+- vivid deliberate color design
+- convincing but stylized materials
+- crisp readable geometry
+- strong depth and spatial layering
+- dramatic but readable lighting
+- imaginative memorable environment
+- stylized rather than strictly photorealistic
+- no hand-drawn contour feeling
+- no paper, watercolor, painterly or grain texture
+- avoid generic luxury interior and brown-orange cozy treatment

--- a/tools/room-image-prompt/data/style_direction_b.generated.txt
+++ b/tools/room-image-prompt/data/style_direction_b.generated.txt
@@ -1,0 +1,10 @@
+- full-scene anime environment illustration
+- every object rendered consistently in anime visual language
+- modern anime realism without strong caricature
+- cinematic animated-film lighting and atmosphere
+- clean cel-style shapes and controlled outlines
+- beautiful deliberate color design
+- illustrated materials rather than photoreal PBR materials
+- polished, vivid, clean digital finish
+- no paper or film grain
+- not a family-cartoon or heavily deformed style

--- a/tools/room-image-prompt/data/style_direction_c.generated.txt
+++ b/tools/room-image-prompt/data/style_direction_c.generated.txt
@@ -1,0 +1,12 @@
+- clean abstract graphic spatial illustration
+- simplified geometric architecture and furniture
+- soft pastel palette with multiple coordinated colors
+- airy whites and light neutrals
+- crisp clean edges
+- flat to gently shaded color planes
+- stylized non-photoreal materials
+- clear readable composition
+- elegant negative space and shape rhythm
+- no realistic texture, no PBR material detail
+- no paper, watercolor, painterly or grain texture
+- avoid neon-purple default palette

--- a/tools/room-image-prompt/internal/stylegen/stylegen.go
+++ b/tools/room-image-prompt/internal/stylegen/stylegen.go
@@ -1,0 +1,224 @@
+package stylegen
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	referenceDirRelative = ".agents/skills/room-art-direction/references"
+	outputDirRelative    = "tools/room-image-prompt/data"
+	promptGuidanceHeader = "## Prompt guidance"
+	generatedFilePrefix  = "style_direction_"
+	generatedFileSuffix  = ".generated.txt"
+)
+
+// Artifact is one generated CLI style asset derived from a canonical Direction Markdown file.
+type Artifact struct {
+	StyleName  string
+	SourcePath string
+	OutputPath string
+	Content    string
+}
+
+// FindRepoRoot walks upward from start until both the canonical Direction directory and
+// room-image-prompt directory exist.
+func FindRepoRoot(start string) (string, error) {
+	abs, err := filepath.Abs(start)
+	if err != nil {
+		return "", fmt.Errorf("resolve start path: %w", err)
+	}
+
+	for dir := abs; ; dir = filepath.Dir(dir) {
+		if isDir(filepath.Join(dir, referenceDirRelative)) && isDir(filepath.Join(dir, outputDirRelative)) {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+	}
+	return "", fmt.Errorf("repository root not found from %q", start)
+}
+
+// Generate reads every canonical direction-*.md reference and derives the CLI style asset
+// from its Prompt guidance section. Direction Markdown remains the single source of truth.
+func Generate(repoRoot string) ([]Artifact, error) {
+	referenceDir := filepath.Join(repoRoot, referenceDirRelative)
+	entries, err := os.ReadDir(referenceDir)
+	if err != nil {
+		return nil, fmt.Errorf("read direction references: %w", err)
+	}
+
+	var artifacts []Artifact
+	seenStyles := make(map[string]string)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		styleName, ok := styleNameFromReferenceFile(entry.Name())
+		if !ok {
+			continue
+		}
+		if previous, exists := seenStyles[styleName]; exists {
+			return nil, fmt.Errorf("duplicate style %q from %q and %q", styleName, previous, entry.Name())
+		}
+		seenStyles[styleName] = entry.Name()
+
+		sourcePath := filepath.Join(referenceDirRelative, entry.Name())
+		b, err := os.ReadFile(filepath.Join(repoRoot, sourcePath))
+		if err != nil {
+			return nil, fmt.Errorf("read %q: %w", sourcePath, err)
+		}
+		content, err := ExtractPromptGuidance(string(b))
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", sourcePath, err)
+		}
+
+		outputName := "style_" + strings.ReplaceAll(styleName, "-", "_") + generatedFileSuffix
+		artifacts = append(artifacts, Artifact{
+			StyleName:  styleName,
+			SourcePath: sourcePath,
+			OutputPath: filepath.Join(outputDirRelative, outputName),
+			Content:    content,
+		})
+	}
+
+	if len(artifacts) == 0 {
+		return nil, fmt.Errorf("no direction references found in %q", referenceDirRelative)
+	}
+	sort.Slice(artifacts, func(i, j int) bool { return artifacts[i].StyleName < artifacts[j].StyleName })
+	return artifacts, nil
+}
+
+// ExtractPromptGuidance returns the exact Markdown body under one "## Prompt guidance" heading,
+// normalized to LF and terminated by one newline.
+func ExtractPromptGuidance(markdown string) (string, error) {
+	markdown = strings.ReplaceAll(markdown, "\r\n", "\n")
+	lines := strings.Split(markdown, "\n")
+
+	start := -1
+	found := 0
+	for i, line := range lines {
+		if strings.TrimSpace(line) == promptGuidanceHeader {
+			found++
+			start = i + 1
+		}
+	}
+	if found != 1 {
+		return "", fmt.Errorf("%q section must appear exactly once (actual: %d)", promptGuidanceHeader, found)
+	}
+
+	end := len(lines)
+	for i := start; i < len(lines); i++ {
+		if strings.HasPrefix(strings.TrimSpace(lines[i]), "## ") {
+			end = i
+			break
+		}
+	}
+	body := strings.TrimSpace(strings.Join(lines[start:end], "\n"))
+	if body == "" {
+		return "", fmt.Errorf("%q section is empty", promptGuidanceHeader)
+	}
+	return body + "\n", nil
+}
+
+// Write updates generated style assets and removes stale generated Direction assets.
+func Write(repoRoot string, artifacts []Artifact) error {
+	wanted := make(map[string]struct{}, len(artifacts))
+	for _, artifact := range artifacts {
+		wanted[filepath.Base(artifact.OutputPath)] = struct{}{}
+	}
+
+	outputDir := filepath.Join(repoRoot, outputDirRelative)
+	entries, err := os.ReadDir(outputDir)
+	if err != nil {
+		return fmt.Errorf("read output dir: %w", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !isGeneratedDirectionFile(name) {
+			continue
+		}
+		if _, ok := wanted[name]; ok {
+			continue
+		}
+		if err := os.Remove(filepath.Join(outputDir, name)); err != nil {
+			return fmt.Errorf("remove stale generated style %q: %w", name, err)
+		}
+	}
+
+	for _, artifact := range artifacts {
+		path := filepath.Join(repoRoot, artifact.OutputPath)
+		if err := os.WriteFile(path, []byte(artifact.Content), 0o644); err != nil {
+			return fmt.Errorf("write %q: %w", artifact.OutputPath, err)
+		}
+	}
+	return nil
+}
+
+// Check verifies that committed generated style assets exactly match canonical Markdown.
+func Check(repoRoot string, artifacts []Artifact) error {
+	wanted := make(map[string]struct{}, len(artifacts))
+	for _, artifact := range artifacts {
+		wanted[filepath.Base(artifact.OutputPath)] = struct{}{}
+		b, err := os.ReadFile(filepath.Join(repoRoot, artifact.OutputPath))
+		if err != nil {
+			return fmt.Errorf("generated style %q: %w", artifact.OutputPath, err)
+		}
+		if string(b) != artifact.Content {
+			return fmt.Errorf("generated style %q is stale; run go generate ./data", artifact.OutputPath)
+		}
+	}
+
+	entries, err := os.ReadDir(filepath.Join(repoRoot, outputDirRelative))
+	if err != nil {
+		return fmt.Errorf("read output dir: %w", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !isGeneratedDirectionFile(entry.Name()) {
+			continue
+		}
+		if _, ok := wanted[entry.Name()]; !ok {
+			return fmt.Errorf("stale generated style %q; run go generate ./data", filepath.Join(outputDirRelative, entry.Name()))
+		}
+	}
+	return nil
+}
+
+func styleNameFromReferenceFile(name string) (string, bool) {
+	if !strings.HasPrefix(name, "direction-") || !strings.HasSuffix(name, ".md") {
+		return "", false
+	}
+	base := strings.TrimSuffix(name, ".md")
+	parts := strings.Split(base, "-")
+	if len(parts) < 3 || parts[0] != "direction" || !validStyleID(parts[1]) {
+		return "", false
+	}
+	return "direction-" + parts[1], true
+}
+
+func validStyleID(id string) bool {
+	if id == "" {
+		return false
+	}
+	for _, r := range id {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') {
+			return false
+		}
+	}
+	return true
+}
+
+func isGeneratedDirectionFile(name string) bool {
+	return strings.HasPrefix(name, generatedFilePrefix) && strings.HasSuffix(name, generatedFileSuffix)
+}
+
+func isDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}

--- a/tools/room-image-prompt/internal/stylegen/stylegen_test.go
+++ b/tools/room-image-prompt/internal/stylegen/stylegen_test.go
@@ -1,0 +1,79 @@
+package stylegen
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestExtractPromptGuidance(t *testing.T) {
+	t.Parallel()
+
+	markdown := "# Direction A\r\n\r\n## Prompt guidance\r\n\r\n- one\r\n- two\r\n\r\n## Review checklist\r\n- [ ] check\r\n"
+	got, err := ExtractPromptGuidance(markdown)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "- one\n- two\n"
+	if got != want {
+		t.Fatalf("fragment mismatch: got %q want %q", got, want)
+	}
+}
+
+func TestExtractPromptGuidance_RequiresExactlyOneSection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		markdown string
+	}{
+		{name: "missing", markdown: "# Direction A\n"},
+		{name: "duplicate", markdown: "## Prompt guidance\n- one\n## Prompt guidance\n- two\n"},
+		{name: "empty", markdown: "## Prompt guidance\n\n## Review checklist\n"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := ExtractPromptGuidance(tt.markdown); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}
+
+func TestGeneratedStylesUpToDate(t *testing.T) {
+	t.Parallel()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	repoRoot, err := FindRepoRoot(wd)
+	if err != nil {
+		t.Fatal(err)
+	}
+	artifacts, err := Generate(repoRoot)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Check(repoRoot, artifacts); err != nil {
+		t.Fatal(err)
+	}
+
+	styles := make(map[string]bool, len(artifacts))
+	for _, artifact := range artifacts {
+		styles[artifact.StyleName] = true
+	}
+	for _, required := range []string{"direction-a", "direction-b", "direction-c"} {
+		if !styles[required] {
+			t.Fatalf("required generated style is missing: %q", required)
+		}
+	}
+
+	for _, artifact := range artifacts {
+		if filepath.Ext(artifact.OutputPath) != ".txt" || !strings.Contains(filepath.Base(artifact.OutputPath), ".generated.") {
+			t.Fatalf("unexpected generated output path: %q", artifact.OutputPath)
+		}
+	}
+}

--- a/tools/room-image-prompt/internal/theme/theme.go
+++ b/tools/room-image-prompt/internal/theme/theme.go
@@ -93,6 +93,19 @@ func ReadLegacyStyle(fsys fs.FS) (string, error) {
 	return readRequiredText(fsys, legacyStyleFile)
 }
 
+// ReadDirectionStyle loads a generated Direction style asset by its CLI name, such as direction-a.
+func ReadDirectionStyle(fsys fs.FS, styleName string) (string, error) {
+	filename, err := directionStyleFilename(styleName)
+	if err != nil {
+		return "", err
+	}
+	style, err := readRequiredText(fsys, filename)
+	if err != nil {
+		return "", fmt.Errorf("read direction style %q: %w", styleName, err)
+	}
+	return style, nil
+}
+
 // ApplyStyle injects style into exactly one {{STYLE}} placeholder.
 // It accepts arbitrary style text so callers do not need to encode named art directions here.
 func ApplyStyle(template, style string) (string, error) {
@@ -108,6 +121,26 @@ func ApplyStyle(template, style string) (string, error) {
 	style = strings.TrimRight(style, "\n")
 
 	return strings.Replace(template, stylePlaceholder, style, 1), nil
+}
+
+func directionStyleFilename(styleName string) (string, error) {
+	parts := strings.Split(styleName, "-")
+	if len(parts) != 2 || parts[0] != "direction" || !validDirectionID(parts[1]) {
+		return "", fmt.Errorf("invalid direction style name %q", styleName)
+	}
+	return "style_direction_" + parts[1] + ".generated.txt", nil
+}
+
+func validDirectionID(id string) bool {
+	if id == "" {
+		return false
+	}
+	for _, r := range id {
+		if (r < 'a' || r > 'z') && (r < '0' || r > '9') {
+			return false
+		}
+	}
+	return true
 }
 
 func validateStylePlaceholder(template string) error {

--- a/tools/room-image-prompt/internal/theme/theme_test.go
+++ b/tools/room-image-prompt/internal/theme/theme_test.go
@@ -264,7 +264,6 @@ func TestReadDirectionStyle_RejectsInvalidOrMissingStyle(t *testing.T) {
 
 	fsys := fstest.MapFS{}
 	for _, name := range []string{"direction-", "direction-a-extra", "Direction-a", "direction-z"} {
-		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if _, err := ReadDirectionStyle(fsys, name); err == nil {

--- a/tools/room-image-prompt/internal/theme/theme_test.go
+++ b/tools/room-image-prompt/internal/theme/theme_test.go
@@ -243,3 +243,33 @@ func TestApplyStyle_RejectsInvalidInput(t *testing.T) {
 		})
 	}
 }
+
+func TestReadDirectionStyle(t *testing.T) {
+	t.Parallel()
+
+	fsys := fstest.MapFS{
+		"style_direction_a.generated.txt": {Data: []byte("DIRECTION_A\n")},
+	}
+	got, err := ReadDirectionStyle(fsys, "direction-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "DIRECTION_A\n" {
+		t.Fatalf("direction style mismatch: %q", got)
+	}
+}
+
+func TestReadDirectionStyle_RejectsInvalidOrMissingStyle(t *testing.T) {
+	t.Parallel()
+
+	fsys := fstest.MapFS{}
+	for _, name := range []string{"direction-", "direction-a-extra", "Direction-a", "direction-z"} {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, err := ReadDirectionStyle(fsys, name); err == nil {
+				t.Fatal("expected error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要

#1056 で作った任意style注入境界へ Direction A / B / C を接続します。

今回の核心は、Direction本文をCLI側へ手作業でコピーせず、**`.agents/skills/room-art-direction/references/` を単一の正に保つこと**です。

## 設計判断

検討した2案:

1. **CLIが実行時にcanonical Markdownを直接読む**
   - 二重管理は起きない
   - ただしCLIがリポジトリ配置へ実行時依存し、`go:embed` で自己完結していたツールの性質を崩す
   - Agent向けMarkdown全文から実行時に必要部分を解釈する責務もCLIへ入る

2. **canonical MarkdownからCLI用fragmentを生成する**
   - canonical sourceはMarkdownのまま
   - CLIは短い生成済みassetだけをembedできる
   - 生成物の同期を機械的に検証できる

**2を採用しました。**

```text
.agents/skills/room-art-direction/references/direction-*.md
                         │
                         │ ## Prompt guidance のみ抽出
                         ▼
                cmd/generate-styles
                         │
                         ▼
tools/room-image-prompt/data/style_direction_*.generated.txt
                         │
                         │ go:embed
                         ▼
                  room-image-prompt
```

## canonical source

各Direction Markdownの **`## Prompt guidance` セクション**を、CLIへ渡す実行用style fragmentのcanonical sourceとします。

Summary / Core / Prefer / Avoid / Non-goals / Review checklist の全文をCLIプロンプトへ入れないため、Agent向け文書は豊かなまま、実行用promptは簡潔に保てます。

生成物は直接編集しません。

```bash
cd tools/room-image-prompt
go generate ./data
```

## CLI

以下が利用可能になります。

```text
-style legacy
-style direction-a
-style direction-b
-style direction-c
-style-file <path>
```

未指定時は従来どおり `legacy` です。

Direction追加時はファイル名規約から `direction-<id>` と生成asset名を導出するため、Direction本文の対応表をGoコードへ重複保持しません。

## Drift prevention

`internal/stylegen` に以下を追加します。

- canonical referenceの列挙
- `## Prompt guidance` がちょうど1つ存在することの検証
- CLI fragment生成
- stale / missing generated assetの検出
- 削除されたDirection由来の古いgenerated assetの検出

`TestGeneratedStylesUpToDate` により、canonical Markdownとcommit済み生成物がずれた場合はGo testを失敗させます。

さらに `.agents/skills/room-art-direction/references/**` の変更を `room_image_prompt` CI groupへルーティングします。これにより、**canonicalだけ変更して生成を忘れるPRでもCIが検出**します。

## E2E / contract tests

- A/B/Cすべてがembedされたnamed styleとして解決できる
- `-style direction-a` でDirection Aが最終promptへ入る
- Direction利用時にlegacy styleが混入しない
- 不正 / 存在しないDirection名を拒否
- Prompt guidance sectionの missing / duplicate / empty を拒否
- generated assetがcanonicalと一致することを検証

#1056 の以下の契約も維持します。

- style未指定 → legacy
- `-style-file` → customのみ
- `-style` + `-style-file` → error

## Invariants

- Direction本文の単一の正は `.agents/skills/room-art-direction/references/`
- `style_direction_*.generated.txt` は派生物であり直接編集しない
- 引数なしのCLIはlegacyのまま
- 共通用途制約、テーマ抽選、座席数、出力、clipboard動作は変更しない
- Direction A/B/C自体の画風定義はこのPRでは変更しない

## Non-goals

- legacy defaultの廃止
- Directionのランダム選択
- theme候補の見直し
- `-style-file` のUTF-8妥当性検証
- 画像生成モデルを使った視覚回帰
- rollout完了後の暫定説明の最終棚卸し（#1058）

## Verification

手元ではテストを実行していません。GitHub Actionsを最終ゲートとします。

このPRではCI path routing自体も変更するため、CI設定変更として全groupが実行対象になります。

特に確認するゲート:

- Room Image Prompt Go Test
- Room Image Prompt Go Lint
- CI path detector test
- CLI build
- CI Gate

## Stack

```text
#1055 共通用途制約 / legacy style の物理分離 ✅
  ↓
#1056 style injection API / CLI境界の一般化 ✅
  ↓
#1057 canonical Direction → generated style → CLI接続 ← このPR
  ↓
#1058 暫定境界整理 / 周辺生成フロー / 最終回帰確認
```

baseは `feat/room-art-direction-rollout` です。最終的な `dev` 反映は統合ブランチから別PRで行います。
