### PR TITLE
feat: add rollback-safe AWS WIF runtime support

### DIFF
--- a/aws-cdk/lib/aws-cdk-stack.ts
+++ b/aws-cdk/lib/aws-cdk-stack.ts
@@ -59,6 +59,49 @@ export class AwsCdkStack extends cdk.Stack {
 		})
 
 		// =========================
+		// Google Cloud authentication migration
+		// =========================
+		const gcpAuthMode = new cdk.CfnParameter(this, 'GcpAuthMode', {
+			type: 'String',
+			default: 'legacy',
+			allowedValues: ['legacy', 'wif'],
+			description:
+				'Google Cloud auth mode for AWS workloads. Keep legacy until WIF is configured and verified.',
+		})
+		const googleCloudProject = new cdk.CfnParameter(
+			this,
+			'GoogleCloudProject',
+			{
+				type: 'String',
+				default: '',
+				description:
+					'Google Cloud project ID. Required when GcpAuthMode=wif so Firestore can resolve the project explicitly.',
+			},
+		)
+		const gcpWifAudience = new cdk.CfnParameter(this, 'GcpWifAudience', {
+			type: 'String',
+			default: '',
+			description:
+				'Full Workload Identity Federation provider audience. Required when GcpAuthMode=wif.',
+		})
+		const gcpWifServiceAccountEmail = new cdk.CfnParameter(
+			this,
+			'GcpWifServiceAccountEmail',
+			{
+				type: 'String',
+				default: '',
+				description:
+					'Google service account email impersonated through WIF. Required when GcpAuthMode=wif.',
+			},
+		)
+		const googleAuthEnvironment = {
+			GCP_AUTH_MODE: gcpAuthMode.valueAsString,
+			GOOGLE_CLOUD_PROJECT: googleCloudProject.valueAsString,
+			GCP_WIF_AUDIENCE: gcpWifAudience.valueAsString,
+			GCP_WIF_SERVICE_ACCOUNT_EMAIL: gcpWifServiceAccountEmail.valueAsString,
+		}
+
+		// =========================
 		// Secrets Manager
 		// =========================
 		const openaiApiKeySecret = new secretsmanager.Secret(
@@ -172,6 +215,7 @@ export class AwsCdkStack extends cdk.Stack {
 				streamPrefix: 'daily-batch',
 			}),
 			environment: {
+				...googleAuthEnvironment,
 				// ECS/Fargate でも AWS_REGION は基本入るが、念のため DEFAULT もセット
 				AWS_REGION: cdk.Stack.of(this).region,
 				AWS_DEFAULT_REGION: cdk.Stack.of(this).region,
@@ -191,6 +235,7 @@ export class AwsCdkStack extends cdk.Stack {
 				code: createLambdaImageCode(systemDir, 'sns_notify_discord'),
 				timeout: cdk.Duration.seconds(30),
 				reservedConcurrentExecutions: 1,
+				environment: googleAuthEnvironment,
 			},
 		)
 		;(snsNotifyDiscordFunction.role as iam.Role).addToPolicy(
@@ -610,6 +655,7 @@ export class AwsCdkStack extends cdk.Stack {
 				code: createLambdaImageCode(systemDir, 'set_desired_max_seats'),
 				timeout: cdk.Duration.seconds(20),
 				reservedConcurrentExecutions: undefined,
+				environment: googleAuthEnvironment,
 			},
 		)
 		;(setDesiredMaxSeatsFunction.role as iam.Role).addToPolicy(
@@ -629,6 +675,7 @@ export class AwsCdkStack extends cdk.Stack {
 				code: createLambdaImageCode(systemDir, 'youtube_organize_database'),
 				timeout: cdk.Duration.seconds(50),
 				reservedConcurrentExecutions: 1,
+				environment: googleAuthEnvironment,
 			},
 		)
 		;(youtubeOrganizeDatabaseFunction.role as iam.Role).addToPolicy(
@@ -648,6 +695,7 @@ export class AwsCdkStack extends cdk.Stack {
 				code: createLambdaImageCode(systemDir, 'check_live_stream_status'),
 				timeout: cdk.Duration.seconds(20),
 				reservedConcurrentExecutions: undefined,
+				environment: googleAuthEnvironment,
 			},
 		)
 		;(checkLiveStreamStatusFunction.role as iam.Role).addToPolicy(
@@ -668,6 +716,7 @@ export class AwsCdkStack extends cdk.Stack {
 				timeout: cdk.Duration.minutes(5),
 				reservedConcurrentExecutions: 1,
 				environment: {
+					...googleAuthEnvironment,
 					SECRET_NAME: openaiApiKeySecret.secretName,
 				},
 			},
@@ -689,6 +738,7 @@ export class AwsCdkStack extends cdk.Stack {
 				functionName: 'error_log_notify_discord',
 				code: createLambdaImageCode(systemDir, 'error_log_notify_discord'),
 				timeout: cdk.Duration.seconds(30),
+				environment: googleAuthEnvironment,
 			},
 		)
 		;(errorLogNotifyDiscordFunction.role as iam.Role).addToPolicy(

--- a/aws-cdk/test/aws-cdk.test.ts
+++ b/aws-cdk/test/aws-cdk.test.ts
@@ -132,6 +132,84 @@ describe('AwsCdkStack', () => {
 		t.hasParameter('AlarmEmail', { Type: 'String', Default: '' })
 	})
 
+	test('defines rollback-safe WIF parameters and propagates them to Google Cloud workloads', () => {
+		const t = createTemplate()
+		t.hasParameter('GcpAuthMode', {
+			Type: 'String',
+			Default: 'legacy',
+			AllowedValues: ['legacy', 'wif'],
+		})
+		t.hasParameter('GoogleCloudProject', { Type: 'String', Default: '' })
+		t.hasParameter('GcpWifAudience', { Type: 'String', Default: '' })
+		t.hasParameter('GcpWifServiceAccountEmail', {
+			Type: 'String',
+			Default: '',
+		})
+
+		const json = t.toJSON() as {
+			Resources?: Record<
+				string,
+				{
+					Type?: string
+					Properties?: {
+						FunctionName?: string
+						Environment?: {
+							Variables?: Record<string, unknown>
+						}
+					}
+				}
+			>
+		}
+		const credentialUsingLambdas = new Set([
+			'sns_notify_discord',
+			'set_desired_max_seats',
+			'youtube_organize_database',
+			'check_live_stream_status',
+			'update_work_name_trend',
+			'error_log_notify_discord',
+		])
+		const lambdaResources = Object.values(json.Resources ?? {}).filter(
+			(resource) =>
+				resource.Type === 'AWS::Lambda::Function' &&
+				credentialUsingLambdas.has(resource.Properties?.FunctionName ?? ''),
+		)
+		expect(lambdaResources).toHaveLength(credentialUsingLambdas.size)
+		for (const resource of lambdaResources) {
+			expect(resource.Properties?.Environment?.Variables).toEqual(
+				expect.objectContaining({
+					GCP_AUTH_MODE: { Ref: 'GcpAuthMode' },
+					GOOGLE_CLOUD_PROJECT: { Ref: 'GoogleCloudProject' },
+					GCP_WIF_AUDIENCE: { Ref: 'GcpWifAudience' },
+					GCP_WIF_SERVICE_ACCOUNT_EMAIL: {
+						Ref: 'GcpWifServiceAccountEmail',
+					},
+				}),
+			)
+		}
+
+		t.hasResourceProperties('AWS::ECS::TaskDefinition', {
+			ContainerDefinitions: Match.arrayWith([
+				Match.objectLike({
+					Environment: Match.arrayWith([
+						{ Name: 'GCP_AUTH_MODE', Value: { Ref: 'GcpAuthMode' } },
+						{
+							Name: 'GOOGLE_CLOUD_PROJECT',
+							Value: { Ref: 'GoogleCloudProject' },
+						},
+						{
+							Name: 'GCP_WIF_AUDIENCE',
+							Value: { Ref: 'GcpWifAudience' },
+						},
+						{
+							Name: 'GCP_WIF_SERVICE_ACCOUNT_EMAIL',
+							Value: { Ref: 'GcpWifServiceAccountEmail' },
+						},
+					]),
+				}),
+			]),
+		})
+	})
+
 	test('subscribes AlarmsTopic to email and Lambda notifier', () => {
 		const t = createTemplate()
 		const json = t.toJSON() as {

--- a/system/go.mod
+++ b/system/go.mod
@@ -3,6 +3,7 @@ module app.modules
 go 1.25.8
 
 require (
+	cloud.google.com/go/auth v0.20.0
 	cloud.google.com/go/bigquery v1.79.0
 	cloud.google.com/go/firestore v1.24.0
 	cloud.google.com/go/storage v1.64.0
@@ -29,7 +30,6 @@ require (
 require (
 	cel.dev/expr v0.25.1 // indirect
 	cloud.google.com/go v0.123.0 // indirect
-	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.11.0 // indirect

--- a/system/internal/awsruntime/credential.go
+++ b/system/internal/awsruntime/credential.go
@@ -1,20 +1,161 @@
 package awsruntime
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"strings"
 
 	"app.modules/internal/awsruntime/mydynamodb"
 
+	"cloud.google.com/go/auth/credentials/externalaccount"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
 	"google.golang.org/api/option"
 )
 
-// FirestoreClientOption retrieves Firebase credentials from DynamoDB and
-// returns a client option suitable for creating a Firestore client.
-func FirestoreClientOption() (option.ClientOption, error) {
+const (
+	gcpAuthModeEnv                    = "GCP_AUTH_MODE"
+	gcpAuthModeLegacy                 = "legacy"
+	gcpAuthModeWIF                    = "wif"
+	googleCloudProjectEnv             = "GOOGLE_CLOUD_PROJECT"
+	gcpWIFAudienceEnv                 = "GCP_WIF_AUDIENCE"
+	gcpWIFServiceAccountEmailEnv      = "GCP_WIF_SERVICE_ACCOUNT_EMAIL"
+	awsSubjectTokenType               = "urn:ietf:params:aws:token-type:aws4_request"
+	googleCloudPlatformScope          = "https://www.googleapis.com/auth/cloud-platform"
+	iamCredentialsServiceAccountPath = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken"
+)
+
+var loadDefaultAWSConfig = config.LoadDefaultConfig
+
+type wifConfig struct {
+	audience            string
+	serviceAccountEmail string
+}
+
+type awsSDKSecurityCredentialsProvider struct {
+	region      string
+	credentials aws.CredentialsProvider
+}
+
+func (p *awsSDKSecurityCredentialsProvider) AwsRegion(context.Context, *externalaccount.RequestOptions) (string, error) {
+	if p.region == "" {
+		return "", fmt.Errorf("AWS region is empty")
+	}
+	return p.region, nil
+}
+
+func (p *awsSDKSecurityCredentialsProvider) AwsSecurityCredentials(ctx context.Context, _ *externalaccount.RequestOptions) (*externalaccount.AwsSecurityCredentials, error) {
+	if p.credentials == nil {
+		return nil, fmt.Errorf("AWS credentials provider is nil")
+	}
+
+	credentials, err := p.credentials.Retrieve(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("retrieve AWS credentials: %w", err)
+	}
+
+	return &externalaccount.AwsSecurityCredentials{
+		AccessKeyID:     credentials.AccessKeyID,
+		SecretAccessKey: credentials.SecretAccessKey,
+		SessionToken:    credentials.SessionToken,
+	}, nil
+}
+
+// GoogleClientOption returns the Google Cloud client credential option for AWS
+// workloads. During the migration, legacy DynamoDB-backed service account
+// credentials remain the default so deployments are rollback-safe.
+func GoogleClientOption(ctx context.Context) (option.ClientOption, error) {
+	mode := strings.ToLower(strings.TrimSpace(os.Getenv(gcpAuthModeEnv)))
+	if mode == "" {
+		mode = gcpAuthModeLegacy
+	}
+
+	switch mode {
+	case gcpAuthModeLegacy:
+		return legacyGoogleClientOption()
+	case gcpAuthModeWIF:
+		return wifGoogleClientOption(ctx)
+	default:
+		return nil, fmt.Errorf("%s must be %q or %q, got %q", gcpAuthModeEnv, gcpAuthModeLegacy, gcpAuthModeWIF, mode)
+	}
+}
+
+func legacyGoogleClientOption() (option.ClientOption, error) {
 	credentialBytes, err := mydynamodb.FetchFirebaseCredentialsAsBytes()
 	if err != nil {
 		return nil, fmt.Errorf("in FetchFirebaseCredentialsAsBytes: %w", err)
 	}
-	//nolint:staticcheck // Credential JSON is fetched from our managed DynamoDB secret and is limited to the Firebase service account payload.
+	//nolint:staticcheck // Temporary legacy fallback. Removed after production WIF validation and credential-key retirement.
 	return option.WithCredentialsJSON(credentialBytes), nil
+}
+
+func wifGoogleClientOption(ctx context.Context) (option.ClientOption, error) {
+	wif, err := wifConfigFromEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	region := strings.TrimSpace(os.Getenv("AWS_REGION"))
+	if region == "" {
+		region = strings.TrimSpace(os.Getenv("AWS_DEFAULT_REGION"))
+	}
+
+	var awsConfig aws.Config
+	if region == "" {
+		awsConfig, err = loadDefaultAWSConfig(ctx)
+	} else {
+		awsConfig, err = loadDefaultAWSConfig(ctx, config.WithRegion(region))
+	}
+	if err != nil {
+		return nil, fmt.Errorf("load AWS default config: %w", err)
+	}
+	if awsConfig.Region == "" {
+		return nil, fmt.Errorf("AWS region could not be resolved")
+	}
+
+	awsProvider := &awsSDKSecurityCredentialsProvider{
+		region:      awsConfig.Region,
+		credentials: awsConfig.Credentials,
+	}
+	credentials, err := externalaccount.NewCredentials(&externalaccount.Options{
+		Audience:                       wif.audience,
+		SubjectTokenType:               awsSubjectTokenType,
+		ServiceAccountImpersonationURL: fmt.Sprintf(iamCredentialsServiceAccountPath, wif.serviceAccountEmail),
+		Scopes:                         []string{googleCloudPlatformScope},
+		AwsSecurityCredentialsProvider: awsProvider,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create Google WIF credentials: %w", err)
+	}
+
+	return option.WithAuthCredentials(credentials), nil
+}
+
+func wifConfigFromEnv() (wifConfig, error) {
+	if strings.TrimSpace(os.Getenv(googleCloudProjectEnv)) == "" {
+		return wifConfig{}, fmt.Errorf("%s is required when %s=%s", googleCloudProjectEnv, gcpAuthModeEnv, gcpAuthModeWIF)
+	}
+
+	audience := strings.TrimSpace(os.Getenv(gcpWIFAudienceEnv))
+	if audience == "" {
+		return wifConfig{}, fmt.Errorf("%s is required when %s=%s", gcpWIFAudienceEnv, gcpAuthModeEnv, gcpAuthModeWIF)
+	}
+
+	serviceAccountEmail := strings.TrimSpace(os.Getenv(gcpWIFServiceAccountEmailEnv))
+	if serviceAccountEmail == "" {
+		return wifConfig{}, fmt.Errorf("%s is required when %s=%s", gcpWIFServiceAccountEmailEnv, gcpAuthModeEnv, gcpAuthModeWIF)
+	}
+
+	return wifConfig{
+		audience:            audience,
+		serviceAccountEmail: serviceAccountEmail,
+	}, nil
+}
+
+// FirestoreClientOption is kept as a migration compatibility wrapper for
+// existing call sites. New code should use GoogleClientOption with the caller's
+// context. This wrapper is removed together with the legacy auth path.
+func FirestoreClientOption() (option.ClientOption, error) {
+	return GoogleClientOption(context.Background())
 }

--- a/system/internal/awsruntime/credential.go
+++ b/system/internal/awsruntime/credential.go
@@ -15,14 +15,14 @@ import (
 )
 
 const (
-	gcpAuthModeEnv                    = "GCP_AUTH_MODE"
-	gcpAuthModeLegacy                 = "legacy"
-	gcpAuthModeWIF                    = "wif"
-	googleCloudProjectEnv             = "GOOGLE_CLOUD_PROJECT"
-	gcpWIFAudienceEnv                 = "GCP_WIF_AUDIENCE"
-	gcpWIFServiceAccountEmailEnv      = "GCP_WIF_SERVICE_ACCOUNT_EMAIL"
-	awsSubjectTokenType               = "urn:ietf:params:aws:token-type:aws4_request"
-	googleCloudPlatformScope          = "https://www.googleapis.com/auth/cloud-platform"
+	gcpAuthModeEnv                   = "GCP_AUTH_MODE"
+	gcpAuthModeLegacy                = "legacy"
+	gcpAuthModeWIF                   = "wif"
+	googleCloudProjectEnv            = "GOOGLE_CLOUD_PROJECT"
+	gcpWIFAudienceEnv                = "GCP_WIF_AUDIENCE"
+	gcpWIFServiceAccountEmailEnv     = "GCP_WIF_SERVICE_ACCOUNT_EMAIL"
+	awsSubjectTokenType              = "urn:ietf:params:aws:token-type:aws4_request"
+	googleCloudPlatformScope         = "https://www.googleapis.com/auth/cloud-platform"
 	iamCredentialsServiceAccountPath = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken"
 )
 

--- a/system/internal/awsruntime/credential_test.go
+++ b/system/internal/awsruntime/credential_test.go
@@ -1,0 +1,124 @@
+package awsruntime
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"cloud.google.com/go/auth/credentials/externalaccount"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+)
+
+type fakeAWSCredentialsProvider struct {
+	credentials aws.Credentials
+	err         error
+}
+
+func (f fakeAWSCredentialsProvider) Retrieve(context.Context) (aws.Credentials, error) {
+	return f.credentials, f.err
+}
+
+func TestGoogleClientOptionRejectsUnknownAuthMode(t *testing.T) {
+	t.Setenv(gcpAuthModeEnv, "wat")
+
+	_, err := GoogleClientOption(context.Background())
+	if err == nil || !strings.Contains(err.Error(), gcpAuthModeEnv) {
+		t.Fatalf("expected invalid auth mode error, got %v", err)
+	}
+}
+
+func TestWIFConfigFromEnv(t *testing.T) {
+	t.Setenv(googleCloudProjectEnv, "test-youtube-study-space")
+	t.Setenv(gcpWIFAudienceEnv, "//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/aws/providers/dev")
+	t.Setenv(gcpWIFServiceAccountEmailEnv, "runtime@test-youtube-study-space.iam.gserviceaccount.com")
+
+	got, err := wifConfigFromEnv()
+	if err != nil {
+		t.Fatalf("wifConfigFromEnv returned error: %v", err)
+	}
+	if got.audience != "//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/aws/providers/dev" {
+		t.Fatalf("unexpected audience: %q", got.audience)
+	}
+	if got.serviceAccountEmail != "runtime@test-youtube-study-space.iam.gserviceaccount.com" {
+		t.Fatalf("unexpected service account email: %q", got.serviceAccountEmail)
+	}
+}
+
+func TestWIFConfigFromEnvRequiresProjectID(t *testing.T) {
+	t.Setenv(gcpWIFAudienceEnv, "audience")
+	t.Setenv(gcpWIFServiceAccountEmailEnv, "runtime@example.iam.gserviceaccount.com")
+
+	_, err := wifConfigFromEnv()
+	if err == nil || !strings.Contains(err.Error(), googleCloudProjectEnv) {
+		t.Fatalf("expected missing project ID error, got %v", err)
+	}
+}
+
+func TestAWSSDKSecurityCredentialsProvider(t *testing.T) {
+	want := aws.Credentials{
+		AccessKeyID:     "AKIAEXAMPLE",
+		SecretAccessKey: "secret",
+		SessionToken:    "session",
+	}
+	provider := &awsSDKSecurityCredentialsProvider{
+		region:      "ap-northeast-1",
+		credentials: fakeAWSCredentialsProvider{credentials: want},
+	}
+
+	region, err := provider.AwsRegion(context.Background(), &externalaccount.RequestOptions{})
+	if err != nil {
+		t.Fatalf("AwsRegion returned error: %v", err)
+	}
+	if region != "ap-northeast-1" {
+		t.Fatalf("unexpected region: %q", region)
+	}
+
+	got, err := provider.AwsSecurityCredentials(context.Background(), &externalaccount.RequestOptions{})
+	if err != nil {
+		t.Fatalf("AwsSecurityCredentials returned error: %v", err)
+	}
+	if got.AccessKeyID != want.AccessKeyID || got.SecretAccessKey != want.SecretAccessKey || got.SessionToken != want.SessionToken {
+		t.Fatalf("unexpected credentials: %#v", got)
+	}
+}
+
+func TestAWSSDKSecurityCredentialsProviderPropagatesRetrieveError(t *testing.T) {
+	provider := &awsSDKSecurityCredentialsProvider{
+		region:      "ap-northeast-1",
+		credentials: fakeAWSCredentialsProvider{err: errors.New("boom")},
+	}
+
+	_, err := provider.AwsSecurityCredentials(context.Background(), &externalaccount.RequestOptions{})
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected retrieve error, got %v", err)
+	}
+}
+
+func TestGoogleClientOptionWIFUsesAWSDefaultCredentialChain(t *testing.T) {
+	t.Setenv(gcpAuthModeEnv, gcpAuthModeWIF)
+	t.Setenv(googleCloudProjectEnv, "test-youtube-study-space")
+	t.Setenv(gcpWIFAudienceEnv, "//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/aws/providers/dev")
+	t.Setenv(gcpWIFServiceAccountEmailEnv, "runtime@test-youtube-study-space.iam.gserviceaccount.com")
+	t.Setenv("AWS_REGION", "ap-northeast-1")
+
+	originalLoadDefaultAWSConfig := loadDefaultAWSConfig
+	loadDefaultAWSConfig = func(context.Context, ...func(*config.LoadOptions) error) (aws.Config, error) {
+		return aws.Config{
+			Region: "ap-northeast-1",
+			Credentials: fakeAWSCredentialsProvider{credentials: aws.Credentials{
+				AccessKeyID:     "AKIAEXAMPLE",
+				SecretAccessKey: "secret",
+				SessionToken:    "session",
+			}},
+		}, nil
+	}
+	t.Cleanup(func() {
+		loadDefaultAWSConfig = originalLoadDefaultAWSConfig
+	})
+
+	if _, err := GoogleClientOption(context.Background()); err != nil {
+		t.Fatalf("GoogleClientOption returned error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds the runtime side of the AWS -> Google Cloud Workload Identity Federation migration while keeping the existing DynamoDB service-account credential path as the rollback path during rollout.

### What changes

- Add a common Google Cloud credential factory with `GCP_AUTH_MODE=legacy|wif`
- Keep `legacy` as the CloudFormation default
- In WIF mode, use the AWS SDK v2 default credential chain and supply the resulting Lambda execution-role / ECS task-role credentials to Google external-account auth
- Use service-account impersonation for the first migration phase
- Require `GOOGLE_CLOUD_PROJECT` explicitly in WIF mode so Firestore `DetectProjectID` does not depend on service-account JSON metadata
- Add CDK parameters and propagate auth configuration to the daily batch task and Google Cloud-using Lambdas
- Add Go and CDK tests

### Rollout safety

No cloud-side WIF resources are created by this PR.

Existing deployments remain on the current DynamoDB credential path unless `GcpAuthMode=wif` is explicitly supplied. The legacy implementation and permissions are retained temporarily as an immediate rollback path during dev/prod verification.

### Validation

CI is green, including:

- Go lint
- System Go tests
- Firestore Emulator integration tests
- AWS CDK tests
- CI gate

Development runtime validation is complete:

- all six Google Cloud-using Lambda workloads have successful post-fix runtime evidence under WIF
- WIF token exchange and service-account impersonation succeed across the Lambda execution roles
- Firestore reads and writes succeed from Lambda workloads
- ECS/Fargate task-role credentials work through the AWS SDK v2 provider
- the normal daily-batch workflow completed with all three ECS tasks succeeding
- the transfer job accessed Firestore, GCS, and BigQuery successfully under WIF
- no WIF / STS / IAM authentication errors remain after the provider-side mapping fix

A provider-side subject-mapping issue found during dev validation was fixed in the private cloud configuration/runbook; no repository code change was required.

Concrete cloud identifiers, role names, project numbers, and operator commands are intentionally kept in the private Notion runbook rather than this public repository.

### Follow-up

1. inventory and configure production WIF separately
2. run production CDK diff and confirm there is no IAM role replacement
3. roll out production with the same staged Lambda -> Fargate validation
4. retain the legacy path until production WIF validation is complete
5. remove the legacy DynamoDB credential path only after production acceptance
