### PR TITLE
Room Image Prompt に Look レイヤーを追加

### DIFF
--- a/.agents/skills/room-art-direction/SKILL.md
+++ b/.agents/skills/room-art-direction/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: room-art-direction
-description: YouTube Study Space のルーム背景画像について、画像生成・プロンプト作成・レビュー・方向性比較を行うときに使う。描画スタイルと題材・レイアウトを分離し、references に保存した再利用可能なアートディレクションを適用する。
+description: YouTube Study Space のルーム背景画像について、画像生成・プロンプト作成・レビュー・方向性比較を行うときに使う。描画スタイル、Look、題材・レイアウトを分離し、再利用可能なアートディレクションと配色・光・材質感のLookを適用する。
 ---
 
 # Room Art Direction
@@ -11,19 +11,21 @@ YouTube Study Space のルーム背景画像に、再利用可能なアートデ
 
 - 一度合意した「描き方」を、題材が変わっても再現する。
 - 世界観、モチーフ、建築、レイアウトを画風と混同しない。
+- 配色・ライティング・材質感の好みを、Directionそのものへ不用意に焼き込まない。
 - 画像生成モデル固有の偶然の癖を、プロジェクトのデザインルールとして固定しない。
-- 後続の新しい方向性を `references/` に追加できる形で資産化する。
+- 後続の新しいDirectionやLookを再利用可能な形で資産化する。
 
 ## 入力として確認するもの
 
 タスクから次を読み取る。
 
 1. 使用するアートディレクション。
-2. 今回の題材、場所、世界観。未指定なら自由に設計してよい。
-3. 画像用途上の制約。例: 16:9、座席カードを後置きする、人物なし、文字なし。
-4. 今回だけの必須要素・禁止要素。
+2. 使用するLook。未指定なら、CLIでは `auto`、手動の画像生成では目的に応じて選ぶ。
+3. 今回の題材、場所、世界観。未指定なら自由に設計してよい。
+4. 画像用途上の制約。例: 16:9、座席カードを後置きする、人物なし、文字なし。
+5. 今回だけの必須要素・禁止要素。
 
-アートディレクションと題材は別の入力として扱う。
+Direction、Look、題材は別の入力として扱う。
 
 ## 現在のアートディレクション
 
@@ -41,9 +43,28 @@ YouTube Study Space のルーム背景画像に、再利用可能なアートデ
 > [!NOTE]
 > Direction D の品質基準は ChatGPT Chat / GPT-5.6 Sol / High での生成を主とする。Codex / Work / 軽量モデル固有の失敗を補正するための長いnegativeを canonical Direction へ積み増さない。別経路の生成結果はモデル比較として切り分ける。
 
+
+## 現在のLook profiles
+
+Look は、Direction の描画文法を保ったまま、**配色・ライティングのムード・材質感の強調方向**を切り替えるレイヤー。
+
+| ID | Runtime source | 要約 |
+| --- | --- | --- |
+| `indigo-violet-fantasy` | `tools/room-image-prompt/data/look_indigo_violet_fantasy.txt` | 青・インディゴ・紫・シアンを軸にした幻想的な光と色。暗部も色を保ち、発光感を出す |
+| `airy-garden` | `tools/room-image-prompt/data/look_airy_garden.txt` | 空色・緑・アイボリー/ベージュ・温かい木色を軸にした、明るく爽やかな庭園系 |
+| `coral-aqua-glow` | `tools/room-image-prompt/data/look_coral_aqua_glow.txt` | コーラル/ピーチ/アンバーとアクア/ターコイズの暖冷対比。水がある場合は透明感を強調 |
+| `crystal-lucent` | `tools/room-image-prompt/data/look_crystal_lucent.txt` | 淡いシアン・ラベンダー・乳白色と、ガラス/クリスタル/半透明の軽やかな材質感 |
+
+Look のruntime sourceは上記 `data/look_*.txt` とし、Directionのcanonical Markdownとは分けて管理する。
+
+> [!IMPORTANT]
+> Look は指定された時間帯・天候を上書きしない。例えば `indigo-violet-fantasy` を選んでも昼を夜へ変えず、昼ならcool shadowやcolored accentとして表現する。
+>
+> Look はDirectionも上書きしない。Direction Bならアニメとして、Direction Cなら抽象グラフィックとして、Direction Dなら簡略化した2Dデジタルイラストとして、同じLookをそれぞれの描画言語へ翻訳する。
+
 ## ワークフロー
 
-### 1. 用途制約と画風を分ける
+### 1. 用途制約・Direction・Look・題材を分ける
 
 まず、次を別々に整理する。
 
@@ -54,23 +75,30 @@ YouTube Study Space のルーム背景画像に、再利用可能なアートデ
 - 人物・文字の有無
 - 配信画面としての視認性
 
-**アートディレクション**
-- 線
-- 面
-- 色
-- 光
-- 質感
-- 立体感
+**Direction**
+- 線や輪郭の扱い
+- 面・形の整理方法
+- 陰影の作り方
+- 2D / 3D の立体感
+- 素材をどの程度リアル/簡略化して描くか
 - 情報密度
-- 仕上げ
+- エッジと仕上げ
+
+**Look**
+- パレットの色相傾向
+- 暖色 / 寒色の関係
+- ライティングのムード
+- 水・ガラス・クリスタルなどの材質感をどの程度強調するか
+- 透明感・発光感・爽やかさなどの視覚的な印象
 
 `tools/room-image-prompt/data/prompt_template.txt` のような既存資料を参照する場合も、この区別を維持する。
-その資料に含まれる用途制約は利用してよいが、特定の色・レンダリング・質感の指定を、選択中の Direction より優先しない。
+用途制約、Theme、Direction、Lookのどれかを、別レイヤーへ安易に押し込まない。
 
 > [!IMPORTANT]
 > Direction の canonical source は `references/direction-*.md` である。CLI用の `tools/room-image-prompt/data/style_direction_*.generated.txt` は各referenceの **`## Prompt guidance` セクションから自動生成**されるため、生成物を直接編集しない。
 > Direction を変更したら `cd tools/room-image-prompt && go generate ./data` を実行し、生成物も同じ変更に含める。CIはcanonical Markdownと生成物の不一致を拒否する。
 > CLIでは `-style direction-a` / `direction-b` / `direction-c` / `direction-d` で生成済みDirectionを利用できる。未指定時だけ後方互換のため `legacy` を使う。
+> Look は `-look <name>`、任意Lookは `-look-file <path>` で指定する。Look未指定時は `auto` としてbundled Lookから1つ選ぶ。`-look none` で無効化できる。
 
 ### 2. Direction の不変条件を読む
 
@@ -84,6 +112,19 @@ YouTube Study Space のルーム背景画像に、再利用可能なアートデ
 特に Non-goals を重視する。
 過去にうまくいった画像の「何が描かれていたか」を、次回の必須モチーフに昇格させない。
 
+
+### 2.5. Look を独立して適用する
+
+Look が指定されている場合は、対応する `tools/room-image-prompt/data/look_*.txt` を読む。
+
+Look から使うのは次のような要素。
+- 色相と明度の関係
+- 暖冷バランス
+- ライティングのムード
+- 水・ガラス・クリスタル等の材質感の強調方法
+
+Lookから題材・建築・座席配置を逆算しない。例えば `crystal-lucent` だからといってクリスタル宮殿を必須にせず、選ばれたSceneの中で自然に成立する透明感として適用する。
+
 ### 3. 今回の題材を独立して設計する
 
 Direction を保ったまま、題材・建築・地形・時代・世界観・レイアウトは今回の目的に合わせて自由に設計する。
@@ -96,20 +137,22 @@ Direction を保ったまま、題材・建築・地形・時代・世界観・�
 
 ### 4. 画像生成またはプロンプト化する
 
-画像生成を依頼された場合は、選択 Direction と用途制約を統合して生成する。
+画像生成を依頼された場合は、用途制約・Theme・選択Direction・Lookを統合して生成する。
 
 テキストプロンプトを依頼された場合は、特定モデルへの依存を抑えた形で次の順に記述する。
 
 1. 用途と構図
 2. 今回の題材
 3. 選択 Direction の描画ルール
-4. 必須要素
-5. Avoid
-6. 「過去例のモチーフを固定しない」旨
+4. 選択 Look の配色・光・材質感
+5. 必須要素
+6. Avoid
+7. 「過去例のモチーフを固定しない」旨
 
 ### 5. 比較画像では比較条件を固定する
 
-複数 Direction を比較するときは、描画スタイル以外をできるだけ同一にする。
+複数 Direction を比較するときは、Lookを含めて描画スタイル以外をできるだけ同一にする。
+複数 Look を比較するときは、Direction・題材・構図・時間帯・天気を同一にする。
 
 固定する対象:
 - 題材と空間レイアウト
@@ -133,10 +176,14 @@ Direction を保ったまま、題材・建築・地形・時代・世界観・�
 
 ### 6. 結果をレビューする
 
-レビューでは最低でも次の2軸を分けて評価する。
+レビューでは最低でも次の3軸を分けて評価する。
 
 **Style fidelity**
-- Direction の線、色、質感、光、仕上げを守っているか。
+- Direction の線、陰影、立体感、素材の抽象度、仕上げを守っているか。
+
+**Look fidelity**
+- 選択Lookの色関係、ライティングのムード、透明感や材質感が出ているか。
+- Lookが時間帯・天候・Directionを上書きしていないか。
 
 **Content/layout**
 - 今回の空間設計や座席配置としてよいか。
@@ -154,6 +201,17 @@ Direction を新規追加・大幅更新したときは、可能なら次の Sub
 例えば「空中庭園」で確立した Direction を検証するなら、地下施設、未来都市屋上、宇宙船、雪原基地などへ置き換える。
 
 題材を変えると魅力が消える場合、その定義には画風ではなくモチーフが混入している可能性が高い。
+
+## 新しい Look を追加するとき
+
+1. `tools/room-image-prompt/data/look_<name>.txt` を追加する。
+2. 色・光・材質感のルールだけを書き、特定の世界・家具・レイアウトを必須にしない。
+3. 指定された時間帯・天候を上書きしないことを明記する。
+4. Direction A/B/C/D の少なくとも複数で適用可能な表現にする。
+5. `internal/look` の bundled list とテストへ追加する。
+6. `go test ./...` でCLI合成とLook解決を確認する。
+
+既存DirectionへLook固有のパレットを焼き込んで平均化しない。
 
 ## 新しい Direction を追加するとき
 

--- a/tools/room-image-prompt/README.md
+++ b/tools/room-image-prompt/README.md
@@ -14,9 +14,11 @@ go build -o room-image-prompt ./cmd/room-image-prompt
 ./room-image-prompt -version
 ```
 
-引数なしで、上から4テーマ行（各 `data/0N_*.txt` から1行を独立に乱数抽選）に加え、**座席数 10〜15** を1回一様乱数で決定します。`data/prompt_template.txt` の `{{STYLE}}` に既定の `data/style_legacy.txt` を挿入し、最後にテーマ条件を連結した UTF-8 テキストを **`output/prompt-<タイムスタンプ>.txt`** に書き込みます。あわせて**同じ本文をクリップボードへコピー**します（失敗しても終了コードは成功のままです）。
+引数なしで、上から4テーマ行（各 `data/0N_*.txt` から1行を独立に乱数抽選）に加え、**座席数 10〜15** を1回一様乱数で決定します。さらに、色・光・材質感を担当する bundled **Look profile を1つ自動選択**します。`data/prompt_template.txt` の `{{STYLE}}` には Direction / style と Look を合成した visual guidance を挿入し、最後にテーマ条件を連結した UTF-8 テキストを **`output/prompt-<タイムスタンプ>.txt`** に書き込みます。あわせて**同じ本文をクリップボードへコピー**します（失敗しても終了コードは成功のままです）。
 
-`-style direction-a` / `direction-b` / `direction-c` / `direction-d` で管理人のアートディレクションを選択できます。`-style-file <path>` を指定すると、任意の UTF-8 テキストをスタイルとして注入できます。未指定時は後方互換のため `legacy` です。
+`-style direction-a` / `direction-b` / `direction-c` / `direction-d` で管理人のアートディレクションを選択できます。`-style-file <path>` を指定すると任意の UTF-8 テキストをスタイルとして注入できます。style 未指定時は後方互換のため `legacy` です。
+
+Look は `-look <name>` で固定でき、`-look none` で無効化できます。未指定時は `auto` として bundled Look から1つ選びます。`-look-file <path>` では任意の Look guidance を注入できます。
 
 - **標準エラー**: `出力: <ファイル名>` に続き、`クリップボードにコピーしました` または `コピーに失敗しました` を1行ずつ出します。Linux などで `xclip` / `xsel` が無い環境ではコピーが失敗し得ます。
 - **標準出力**: **保存したファイルの絶対パスを1行**だけ出します（スクリプト向け）。
@@ -48,25 +50,44 @@ v1 は4ファイルを**独立抽選**するため、単に概念を細かく分
 - `04_seat_layout.txt`: 並列、島型、リング、段差、ブース分散など、座席同士の位置関係を中心にする
   - UIカードの置きやすさ、画面上の安全地帯、レンダリング条件、時間・天候などを混ぜない
 
-画風・質感・配色・レンダリング言語はテーマ候補ではなく **Direction / style** の責務です。抽象的な「静けさ」「ぬくもり」「爽やかさ」などを独立候補として増やすより、Sceneと選択中のDirectionから自然に立ち上げることを優先します。
+画風・レンダリング言語は **Direction / style**、配色・ライティング・材質感・空気感は **Look** の責務です。これらを Theme 候補へ混ぜません。抽象的な「静けさ」「ぬくもり」「爽やかさ」なども Theme の独立候補として増やさず、Scene・Direction・Look の組み合わせから立ち上げます。
 
 現在の出力ラベル `世界観` は後方互換のため維持しますが、候補データ上の意味は上記の **Scene / World** として扱います。
 
-### 共通用途制約とスタイル
+### 共通用途制約・Direction・Look
 
 | ファイル | 役割 |
 |----------|------|
 | `data/prompt_template.txt` | アスペクト比、UIを重ねる領域、人物・文字の禁止など、スタイルに依存しない共通用途制約。スタイル挿入位置として `{{STYLE}}` を1個だけ持つ |
 | `data/style_legacy.txt` | 後方互換用の従来画風。手動管理 |
 | `data/style_direction_*.generated.txt` | Direction Markdown の `## Prompt guidance` から生成されるCLI用style。**直接編集禁止** |
+| `data/look_*.txt` | bundled Look profile。配色・ライティング・材質感・空気感を担当する。手動管理 |
 
-共通テンプレートの読み込み、style sourceの選択、style適用は別々の責務です。
+共通テンプレート、Direction/style、Look、Theme は別々の責務です。最終的には Direction/style と Look を合成し、1つの visual guidance として `{{STYLE}}` に注入します。
 
 ### Direction の単一の正と生成
 
 Direction A/B/C/D の canonical source は `.agents/skills/room-art-direction/references/direction-*.md` です。各Markdownの **`## Prompt guidance` セクションだけ**をCLI向けの実行用fragmentとして抽出します。Summary / Core / Avoid / Non-goals / Review checklist まで丸ごとCLIへ入れないため、Agent向け文書の表現力と実行プロンプトの簡潔さを両立します。
 
 Direction D の最終品質確認は ChatGPT Chat / GPT-5.6 Sol / High を主基準とします。このCLIは最終画像を生成するものではなく、再利用可能なpromptを組み立てる役割です。Codex / Work / 軽量モデル固有の生成癖を補正するための文言は、canonical styleへ安易に追加しません。
+
+
+### Look layer
+
+Look は「何を描くか」でも「どうレンダリングするか」でもなく、**どの色・光・材質感・空気感で見せるか**を担当します。Direction A/B/C/D のいずれとも組み合わせられ、選択中の Direction の描画文法を上書きしません。
+
+bundled Look:
+
+| Look | 主な意図 |
+| --- | --- |
+| `indigo-violet-fantasy` | 青〜紫〜シアンを中心とした幻想的な色・光。暗部も色を保ち、発光感を出す |
+| `airy-garden` | 空色・緑・アイボリー/ベージュ・温かい木色を軸にした爽やかな庭園系の配色 |
+| `coral-aqua-glow` | コーラル/ピーチ/アンバーと澄んだアクア/ターコイズの暖冷対比。水がある場合は透明感を強調 |
+| `crystal-lucent` | 淡いシアン・ラベンダー・乳白色を軸に、ガラス/クリスタル/半透明の軽やかな材質感を強調 |
+
+Look は必ず、Theme で選ばれた時間帯・天候を尊重します。例えば `indigo-violet-fantasy` が昼を夜へ変えたり、`coral-aqua-glow` が朝を夕焼けへ変えたりしないよう、時間条件に応じて色・光の出し方だけを適応させます。
+
+`auto` は上記4 Lookから一様に1つ選びます。Look選択は Theme と座席数の抽選**後**に同じ RNG から行うため、Look導入前と同じ `-seed` を指定しても既存4テーマと座席数の抽選順は変わりません。`-look none` を使えばLookを完全に外せます。
 
 生成は次で行います。
 
@@ -81,7 +102,7 @@ go generate ./data
 
 ### v1 の挙動と将来拡張
 
-- **v1（現状）**: 4ファイル分は、当該ファイル内の候補から **一様な独立乱数** で1行ずつ選びます。`座席数` は 10〜15 から1回一様乱数で決めます。前段の抽選に依存する重み付けや、相性スコアによる再抽選は行いません。
+- **v1（現状）**: 4ファイル分は、当該ファイル内の候補から **一様な独立乱数** で1行ずつ選びます。`座席数` は 10〜15 から1回一様乱数で決めます。その後、Look 未指定時は bundled Look 4種から1つを一様に選びます。Theme と Look の相性スコアや条件付き再抽選は行いません。
 - **将来拡張（未実装）の例**: 前段に応じた候補の重み付け、相性スコア、条件付き再抽選など。必要になったらアルゴリズムを差し替え可能な位置に集約する想定です。
 
 ### オプション
@@ -93,6 +114,8 @@ go generate ./data
 | `-seed <uint64>` | 乱数シード（10進）。省略時は非固定 |
 | `-style <name>` | `legacy` または生成済み `direction-a` / `direction-b` / `direction-c` / `direction-d`。省略時は `legacy` |
 | `-style-file <path>` | 任意の UTF-8 スタイル本文をファイルから読み込む。 `-style` と同時指定不可 |
+| `-look <name>` | `auto` / `none` / bundled Look名。省略時は `auto` |
+| `-look-file <path>` | 任意の UTF-8 Look guidance を読み込む。`-look` と同時指定不可 |
 
 開発中は `go run` でも可です。
 
@@ -105,7 +128,12 @@ go run ./cmd/room-image-prompt -seed 1 -style direction-a
 go run ./cmd/room-image-prompt -seed 1 -style direction-b
 go run ./cmd/room-image-prompt -seed 1 -style direction-c
 go run ./cmd/room-image-prompt -seed 1 -style direction-d
-go run ./cmd/room-image-prompt -seed 1 -style-file ./my-style.txt
+go run ./cmd/room-image-prompt -seed 1 -style direction-d -look indigo-violet-fantasy
+go run ./cmd/room-image-prompt -seed 1 -style direction-b -look airy-garden
+go run ./cmd/room-image-prompt -seed 1 -style direction-d -look coral-aqua-glow
+go run ./cmd/room-image-prompt -seed 1 -style direction-c -look crystal-lucent
+go run ./cmd/room-image-prompt -seed 1 -style direction-a -look none
+go run ./cmd/room-image-prompt -seed 1 -style-file ./my-style.txt -look-file ./my-look.txt
 ```
 
 ## テスト

--- a/tools/room-image-prompt/cmd/room-image-prompt/main.go
+++ b/tools/room-image-prompt/cmd/room-image-prompt/main.go
@@ -19,11 +19,12 @@ import (
 	"github.com/atotto/clipboard"
 
 	"github.com/kani3camp/youtube-study-space/tools/room-image-prompt/data"
+	lookprofile "github.com/kani3camp/youtube-study-space/tools/room-image-prompt/internal/look"
 	"github.com/kani3camp/youtube-study-space/tools/room-image-prompt/internal/theme"
 )
 
 const (
-	versionString = "room-image-prompt 0.1.0 (dev)"
+	versionString = "room-image-prompt 0.2.0 (dev)"
 	usageText     = `room-image-prompt — ルーム画像生成用プロンプトを生成するCLI
 
 使い方:
@@ -62,6 +63,8 @@ func run() error {
 	seedStr := fs.String("seed", "", "乱数シード（10進 uint64）。省略時は非固定")
 	styleName := fs.String("style", "", "内蔵スタイル名（legacy または生成済み direction-*）。省略時は legacy")
 	styleFile := fs.String("style-file", "", "任意スタイルを読み込む UTF-8 テキストファイル（-style と同時指定不可）")
+	lookName := fs.String("look", "", "内蔵Look名（auto / none / bundled look）。省略時は auto")
+	lookFile := fs.String("look-file", "", "任意Lookを読み込む UTF-8 テキストファイル（-look と同時指定不可）")
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		configureUsage(fs, os.Stderr)
@@ -106,7 +109,12 @@ func run() error {
 	if err != nil {
 		return fmt.Errorf("スタイル読込: %w", err)
 	}
-	styledTemplate, err := theme.ApplyStyle(tmpl, style)
+	look, err := resolveLook(fsys, *lookName, *lookFile, rng)
+	if err != nil {
+		return fmt.Errorf("Look読込: %w", err)
+	}
+	visualGuidance := composeVisualGuidance(style, look.Text)
+	styledTemplate, err := theme.ApplyStyle(tmpl, visualGuidance)
 	if err != nil {
 		return fmt.Errorf("スタイル適用: %w", err)
 	}
@@ -178,6 +186,39 @@ func resolveStyle(fsys fs.FS, styleName, styleFile string) (string, error) {
 		}
 		return "", fmt.Errorf("-style %q は未対応です（legacy または生成済み direction-* を指定してください）", styleName)
 	}
+}
+
+func resolveLook(fsys fs.FS, lookName, lookFile string, rng *rand.Rand) (lookprofile.Selection, error) {
+	if lookName != "" && lookFile != "" {
+		return lookprofile.Selection{}, fmt.Errorf("-look と -look-file は同時指定できません")
+	}
+
+	if lookFile != "" {
+		b, err := os.ReadFile(lookFile)
+		if err != nil {
+			return lookprofile.Selection{}, fmt.Errorf("-look-file %q: %w", lookFile, err)
+		}
+		text := strings.ReplaceAll(string(b), "\r\n", "\n")
+		if strings.TrimSpace(text) == "" {
+			return lookprofile.Selection{}, fmt.Errorf("-look-file %q: テキストが空です", lookFile)
+		}
+		return lookprofile.Selection{Name: "custom", Text: text}, nil
+	}
+
+	selection, err := lookprofile.Resolve(fsys, lookName, rng)
+	if err != nil {
+		return lookprofile.Selection{}, err
+	}
+	return selection, nil
+}
+
+func composeVisualGuidance(style, look string) string {
+	if strings.TrimSpace(look) == "" {
+		return style
+	}
+	style = strings.TrimRight(strings.ReplaceAll(style, "\r\n", "\n"), "\n")
+	look = strings.TrimSpace(strings.ReplaceAll(look, "\r\n", "\n"))
+	return style + "\n\n" + look + "\n"
 }
 
 func configureUsage(fs *flag.FlagSet, output io.Writer) {

--- a/tools/room-image-prompt/cmd/room-image-prompt/main.go
+++ b/tools/room-image-prompt/cmd/room-image-prompt/main.go
@@ -111,7 +111,7 @@ func run() error {
 	}
 	look, err := resolveLook(fsys, *lookName, *lookFile, rng)
 	if err != nil {
-		return fmt.Errorf("Look読込: %w", err)
+		return fmt.Errorf("look読込: %w", err)
 	}
 	visualGuidance := composeVisualGuidance(style, look.Text)
 	styledTemplate, err := theme.ApplyStyle(tmpl, visualGuidance)
@@ -207,7 +207,7 @@ func resolveLook(fsys fs.FS, lookName, lookFile string, rng *rand.Rand) (lookpro
 
 	selection, err := lookprofile.Resolve(fsys, lookName, rng)
 	if err != nil {
-		return lookprofile.Selection{}, err
+		return lookprofile.Selection{}, fmt.Errorf("bundled look解決: %w", err)
 	}
 	return selection, nil
 }

--- a/tools/room-image-prompt/cmd/room-image-prompt/main_e2e_test.go
+++ b/tools/room-image-prompt/cmd/room-image-prompt/main_e2e_test.go
@@ -179,9 +179,9 @@ func TestResolveLook(t *testing.T) {
 
 	fsys := fstest.MapFS{
 		"look_indigo_violet_fantasy.txt": {Data: []byte("INDIGO\n")},
-		"look_airy_garden.txt":            {Data: []byte("AIRY\n")},
-		"look_coral_aqua_glow.txt":        {Data: []byte("CORAL\n")},
-		"look_crystal_lucent.txt":         {Data: []byte("CRYSTAL\n")},
+		"look_airy_garden.txt":           {Data: []byte("AIRY\n")},
+		"look_coral_aqua_glow.txt":       {Data: []byte("CORAL\n")},
+		"look_crystal_lucent.txt":        {Data: []byte("CRYSTAL\n")},
 	}
 	customPath := filepath.Join(t.TempDir(), "custom-look.txt")
 	if err := os.WriteFile(customPath, []byte("CUSTOM_LOOK\n"), 0o644); err != nil {

--- a/tools/room-image-prompt/cmd/room-image-prompt/main_e2e_test.go
+++ b/tools/room-image-prompt/cmd/room-image-prompt/main_e2e_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"errors"
+	"math/rand/v2"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -84,6 +85,9 @@ func TestCLI_StdoutPath_TC_C2_extension(t *testing.T) {
 	if !strings.Contains(string(body), "写真風、3D建築レンダリング風、フォトリアル表現にはしないでください。") {
 		t.Fatalf("default output should keep legacy style:\n%s", body)
 	}
+	if !strings.Contains(string(body), "## Look profile:") {
+		t.Fatalf("default output should auto-select a bundled Look:\n%s", body)
+	}
 }
 
 func TestCLI_StyleFile(t *testing.T) {
@@ -101,6 +105,7 @@ func TestCLI_StyleFile(t *testing.T) {
 		"go", "run", "./cmd/room-image-prompt",
 		"-seed", "1",
 		"-style-file", styleFile,
+		"-look", "none",
 		"-out", outFile,
 	)
 	cmd.Dir = dir
@@ -169,6 +174,110 @@ func TestResolveStyle(t *testing.T) {
 	}
 }
 
+func TestResolveLook(t *testing.T) {
+	t.Parallel()
+
+	fsys := fstest.MapFS{
+		"look_indigo_violet_fantasy.txt": {Data: []byte("INDIGO\n")},
+		"look_airy_garden.txt":            {Data: []byte("AIRY\n")},
+		"look_coral_aqua_glow.txt":        {Data: []byte("CORAL\n")},
+		"look_crystal_lucent.txt":         {Data: []byte("CRYSTAL\n")},
+	}
+	customPath := filepath.Join(t.TempDir(), "custom-look.txt")
+	if err := os.WriteFile(customPath, []byte("CUSTOM_LOOK\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		lookName string
+		lookFile string
+		wantName string
+		wantText string
+		wantAuto bool
+		wantErr  bool
+	}{
+		{name: "default auto", wantAuto: true},
+		{name: "explicit auto", lookName: "auto", wantAuto: true},
+		{name: "none", lookName: "none", wantName: "none"},
+		{name: "named", lookName: "airy-garden", wantName: "airy-garden", wantText: "AIRY\n"},
+		{name: "custom file", lookFile: customPath, wantName: "custom", wantText: "CUSTOM_LOOK\n"},
+		{name: "conflicting sources", lookName: "airy-garden", lookFile: customPath, wantErr: true},
+		{name: "invalid", lookName: "other", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveLook(fsys, tt.lookName, tt.lookFile, rand.New(rand.NewPCG(42, 0)))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tt.wantAuto {
+				if got.Name == "auto" || got.Name == "none" || strings.TrimSpace(got.Text) == "" {
+					t.Fatalf("auto Look was not resolved: %+v", got)
+				}
+				return
+			}
+			if got.Name != tt.wantName || got.Text != tt.wantText {
+				t.Fatalf("look mismatch: got %+v want name=%q text=%q", got, tt.wantName, tt.wantText)
+			}
+		})
+	}
+}
+
+func TestComposeVisualGuidance(t *testing.T) {
+	t.Parallel()
+
+	if got := composeVisualGuidance("STYLE\n", ""); got != "STYLE\n" {
+		t.Fatalf("none Look should preserve style exactly: %q", got)
+	}
+	got := composeVisualGuidance("STYLE\r\n", "LOOK\r\n")
+	want := "STYLE\n\nLOOK\n"
+	if got != want {
+		t.Fatalf("composed guidance mismatch: got %q want %q", got, want)
+	}
+}
+
+func TestCLI_LookProfile(t *testing.T) {
+	t.Parallel()
+
+	dir := moduleRoot(t)
+	outFile := filepath.Join(t.TempDir(), "look.txt")
+	cmd := exec.Command(
+		"go", "run", "./cmd/room-image-prompt",
+		"-seed", "1",
+		"-style", "direction-d",
+		"-look", "crystal-lucent",
+		"-out", outFile,
+	)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("%v\n%s", err, out)
+	}
+
+	body, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(body)
+	for _, required := range []string{
+		"clean 2D digital environment illustration",
+		"## Look profile: Crystal Lucent",
+		"pale cyan, periwinkle, lavender",
+	} {
+		if !strings.Contains(got, required) {
+			t.Fatalf("combined Direction + Look output is missing %q:\n%s", required, got)
+		}
+	}
+}
+
 func TestResolveBundledDirectionStyles(t *testing.T) {
 	t.Parallel()
 
@@ -231,6 +340,7 @@ func TestCLI_DirectionStyle(t *testing.T) {
 		"go", "run", "./cmd/room-image-prompt",
 		"-seed", "1",
 		"-style", "direction-a",
+		"-look", "none",
 		"-out", outFile,
 	)
 	cmd.Dir = dir

--- a/tools/room-image-prompt/data/look_airy_garden.txt
+++ b/tools/room-image-prompt/data/look_airy_garden.txt
@@ -1,0 +1,9 @@
+## Look profile: Airy Garden
+
+- use a fresh palette built from clear sky blue, foliage green, ivory, cream, pale beige and warm medium-brown wood
+- create an airy fantasy-garden feeling with clean light, open color separation and a pleasant balance between cool sky/green areas and warm wood/cream areas
+- favor light stone, tile or architectural surfaces that read clean and luminous without becoming blank white or overexposed
+- keep bookshelves, wood furniture and small warm details visibly richer and browner than the surrounding pale architecture
+- let plants provide confident natural greens instead of muted gray-green; use turquoise or clear blue accents sparingly where they strengthen freshness
+- preserve the requested time of day and weather; at evening or night keep the same palette relationships while adapting their brightness and light source naturally
+- keep the active Direction's rendering language intact; this Look controls palette, lighting mood and material emphasis, not the underlying illustration / anime / CG grammar

--- a/tools/room-image-prompt/data/look_coral_aqua_glow.txt
+++ b/tools/room-image-prompt/data/look_coral_aqua_glow.txt
@@ -1,0 +1,9 @@
+## Look profile: Coral Aqua Glow
+
+- build the color relationship around warm coral, peach, soft amber and rose contrasted with clear aqua, turquoise, cyan and blue-green
+- make the warm/cool contrast feel luminous and inviting, with warm architectural or sky-side accents balanced by cool waterlike or reflected-light accents
+- when water is present, emphasize clarity, depth and clean aqua-to-cyan color separation so the water feels especially fresh and visually important
+- use reflected light selectively to connect warm and cool regions without covering surfaces in physically realistic mirror reflections
+- keep shadows colorful and transparent-looking rather than brown or gray; avoid muddy transitions between coral and aqua regions
+- preserve the requested time of day and weather; this palette may become sunset-like when the chosen time supports it, but must not override a different requested time
+- keep the active Direction's rendering language intact; this Look controls palette, lighting mood and material emphasis, not the underlying illustration / anime / CG grammar

--- a/tools/room-image-prompt/data/look_crystal_lucent.txt
+++ b/tools/room-image-prompt/data/look_crystal_lucent.txt
@@ -1,0 +1,9 @@
+## Look profile: Crystal Lucent
+
+- use a light luminous palette of pale cyan, periwinkle, lavender, soft violet, milky white, faint pink and warm cream accents
+- emphasize transparent, translucent, glasslike or crystalline visual cues where the scene naturally supports them, creating a light and open material impression
+- prefer clean refraction-like color shifts, rim highlights and layered transparency cues over heavy opaque surfaces or dense metallic gloss
+- keep transparent elements readable against the background through clear value and hue separation rather than realistic optical complexity
+- allow water, glass, crystal-like structures and polished details to share a coherent sense of clarity without turning every object into glass
+- preserve the requested time of day and weather, adapting brightness and translucency to the scene instead of forcing a uniformly bright fantasy glow
+- keep the active Direction's rendering language intact; use simplified graphic transparency in 2D Directions and richer material depth only where the selected Direction supports it

--- a/tools/room-image-prompt/data/look_indigo_violet_fantasy.txt
+++ b/tools/room-image-prompt/data/look_indigo_violet_fantasy.txt
@@ -1,0 +1,9 @@
+## Look profile: Indigo Violet Fantasy
+
+- bias the palette toward deep blue, indigo, violet and clear cyan, with restrained warm cream or amber accents for focal contrast
+- create a luminous fantasy atmosphere through colored light relationships and crisp glowing accents, not through foggy haze or bloom
+- keep dark areas chromatic rather than muddy black; preserve readable blue-violet shadow masses and bright cyan or warm highlights
+- let foliage remain recognizably green where appropriate, but allow cool blue-violet shadow notes to tie it into the overall palette
+- when water, glass or polished surfaces are present, let them catch selective cyan, violet and warm highlights while preserving the active Direction's material language
+- preserve the requested time of day and weather; during daytime express this look through cool shadows and colored accents rather than turning the scene into night
+- keep the active Direction's rendering language intact; this Look controls palette, lighting mood and material emphasis, not the underlying illustration / anime / CG grammar

--- a/tools/room-image-prompt/internal/look/look.go
+++ b/tools/room-image-prompt/internal/look/look.go
@@ -1,0 +1,64 @@
+package look
+
+import (
+	"fmt"
+	"io/fs"
+	"math/rand/v2"
+	"strings"
+)
+
+const (
+	AutoName = "auto"
+	NoneName = "none"
+)
+
+var bundledNames = []string{
+	"indigo-violet-fantasy",
+	"airy-garden",
+	"coral-aqua-glow",
+	"crystal-lucent",
+}
+
+type Selection struct {
+	Name string
+	Text string
+}
+
+func BundledNames() []string {
+	return append([]string(nil), bundledNames...)
+}
+
+func Resolve(fsys fs.FS, name string, rng *rand.Rand) (Selection, error) {
+	switch name {
+	case "", AutoName:
+		if rng == nil {
+			return Selection{}, fmt.Errorf("look %q requires RNG", AutoName)
+		}
+		name = bundledNames[rng.IntN(len(bundledNames))]
+	case NoneName:
+		return Selection{Name: NoneName}, nil
+	}
+
+	filename, err := filenameFor(name)
+	if err != nil {
+		return Selection{}, err
+	}
+	body, err := fs.ReadFile(fsys, filename)
+	if err != nil {
+		return Selection{}, fmt.Errorf("read look %q: %w", name, err)
+	}
+	text := strings.ReplaceAll(string(body), "\r\n", "\n")
+	if strings.TrimSpace(text) == "" {
+		return Selection{}, fmt.Errorf("look %q: text is empty", name)
+	}
+	return Selection{Name: name, Text: text}, nil
+}
+
+func filenameFor(name string) (string, error) {
+	for _, bundled := range bundledNames {
+		if name == bundled {
+			return "look_" + strings.ReplaceAll(name, "-", "_") + ".txt", nil
+		}
+	}
+	return "", fmt.Errorf("unknown look %q", name)
+}

--- a/tools/room-image-prompt/internal/look/look_test.go
+++ b/tools/room-image-prompt/internal/look/look_test.go
@@ -1,0 +1,75 @@
+package look
+
+import (
+	"math/rand/v2"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestResolveNamed(t *testing.T) {
+	t.Parallel()
+
+	fsys := fstest.MapFS{
+		"look_airy_garden.txt": {Data: []byte("AIRY\n")},
+	}
+	got, err := Resolve(fsys, "airy-garden", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "airy-garden" || got.Text != "AIRY\n" {
+		t.Fatalf("unexpected selection: %+v", got)
+	}
+}
+
+func TestResolveNone(t *testing.T) {
+	t.Parallel()
+
+	got, err := Resolve(fstest.MapFS{}, NoneName, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != NoneName || got.Text != "" {
+		t.Fatalf("unexpected selection: %+v", got)
+	}
+}
+
+func TestResolveAutoIsDeterministicAndBundled(t *testing.T) {
+	t.Parallel()
+
+	fsys := fstest.MapFS{
+		"look_indigo_violet_fantasy.txt": {Data: []byte("INDIGO\n")},
+		"look_airy_garden.txt":            {Data: []byte("AIRY\n")},
+		"look_coral_aqua_glow.txt":        {Data: []byte("CORAL\n")},
+		"look_crystal_lucent.txt":         {Data: []byte("CRYSTAL\n")},
+	}
+	a, err := Resolve(fsys, AutoName, rand.New(rand.NewPCG(42, 0)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := Resolve(fsys, AutoName, rand.New(rand.NewPCG(42, 0)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a != b {
+		t.Fatalf("auto selection should be deterministic: a=%+v b=%+v", a, b)
+	}
+	if a.Name == AutoName || a.Name == NoneName || strings.TrimSpace(a.Text) == "" {
+		t.Fatalf("auto selection should resolve to bundled content: %+v", a)
+	}
+}
+
+func TestResolveRejectsInvalidOrEmpty(t *testing.T) {
+	t.Parallel()
+
+	if _, err := Resolve(fstest.MapFS{}, "other", nil); err == nil {
+		t.Fatal("expected invalid-look error")
+	}
+
+	fsys := fstest.MapFS{
+		"look_airy_garden.txt": {Data: []byte("\n")},
+	}
+	if _, err := Resolve(fsys, "airy-garden", nil); err == nil {
+		t.Fatal("expected empty-look error")
+	}
+}

--- a/tools/room-image-prompt/internal/look/look_test.go
+++ b/tools/room-image-prompt/internal/look/look_test.go
@@ -39,9 +39,9 @@ func TestResolveAutoIsDeterministicAndBundled(t *testing.T) {
 
 	fsys := fstest.MapFS{
 		"look_indigo_violet_fantasy.txt": {Data: []byte("INDIGO\n")},
-		"look_airy_garden.txt":            {Data: []byte("AIRY\n")},
-		"look_coral_aqua_glow.txt":        {Data: []byte("CORAL\n")},
-		"look_crystal_lucent.txt":         {Data: []byte("CRYSTAL\n")},
+		"look_airy_garden.txt":           {Data: []byte("AIRY\n")},
+		"look_coral_aqua_glow.txt":       {Data: []byte("CORAL\n")},
+		"look_crystal_lucent.txt":        {Data: []byte("CRYSTAL\n")},
 	}
 	a, err := Resolve(fsys, AutoName, rand.New(rand.NewPCG(42, 0)))
 	if err != nil {


### PR DESCRIPTION
## Goal

Room Image Prompt で「何を描くか」と「どう描くか」に加えて、**色・光・材質感・空気感を独立して切り替えられる Look レイヤー**を導入します。

ユーザーの好みとして確認できた以下の視覚要素を、特定のWorldやDirectionへ焼き込まず再利用可能にします。

- 青〜紫〜シアンの幻想的な光
- 空色・緑・アイボリー/ベージュ・温かい木色の爽やかな配色
- コーラル/ピーチとアクア/ターコイズの暖冷対比、水の透明感
- ガラス/クリスタル/半透明の軽やかな材質感

## Architecture

役割を次の3層へ分けます。

- **Theme**: Scene / Time of Day / Workspace Type / Seat Layout
- **Direction**: 線・陰影・2D/3D・素材の抽象度などの描画文法
- **Look**: パレット、ライティングのムード、材質感の強調方向

Look は時間帯・天候・Directionを上書きしません。

## Bundled Looks

- `indigo-violet-fantasy`
- `airy-garden`
- `coral-aqua-glow`
- `crystal-lucent`

## CLI

- `-look <name>`
  - `auto` / `none` / bundled Look
  - 未指定時は `auto`
- `-look-file <path>`
  - 任意のUTF-8 Look guidance
  - `-look` と同時指定不可

`auto` は4つのbundled Lookから一様に1つ選びます。Look抽選は既存Themeと座席数の抽選後に行うため、同じ `-seed` に対する既存Theme/座席数の抽選順は変わりません。

`-look none` を指定すればLook導入前と同じ visual guidance にできます。

## Changes

- `internal/look` にLook解決ロジックを追加
- bundled Look 4種を `data/look_*.txt` として追加
- Direction/style と Look を合成して既存 `{{STYLE}}` へ注入
- `-look` / `-look-file` を追加
- defaultを `auto` にしてLookを自動選択
- Look解決、合成、CLI E2Eテストを追加
- READMEにTheme / Direction / Lookの責務を明文化
- Room Art Direction skillにもLook概念とレビュー軸を追加

## Invariants

- Theme 4軸と座席数の抽選ロジックは変更しない
- Direction A/B/C/Dのcanonical sourceは変更しない
- `prompt_template.txt` のplaceholderは `{{STYLE}}` 1個のまま
- Lookは指定されたTime of Day / Weatherを変更しない
- Lookは選択中Directionの描画文法を変更しない

## Non-goals

- ThemeとLookの相性スコア・条件付き再抽選
- Lookごとに特定の世界観や家具を必須化すること
- Direction A/B/C/Dの平均化
- 画像生成モデル固有の回避策をLookへ積み増すこと

## Verification

追加したテストで以下を固定します。

- bundled Lookのnamed / auto / none解決
- auto選択のseed再現性
- 不正Look・空Lookの拒否
- custom `-look-file`
- Direction + Lookのvisual guidance合成
- default CLIでbundled Lookが自動注入されること
- `-look none` でLookを外せること
- Direction D + `crystal-lucent` のE2E出力

GitHub Actionsを最終ゲートとします。

## Stack

1. #1063 Theme候補軸整理 → `integration/room-theme-axis-cleanup` へmerge済み
2. このPR Lookレイヤー → `integration/room-theme-axis-cleanup`
3. このPR merge後、integration branchから `dev` 向け最終PRを1本作成

このPRは `dev` 向けではないため、CI成功後にChatGPT側でintegration branchへmergeします。
