### PR TITLE
Direction C のパステル配色を多色化し紫偏重を抑える

### DIFF
--- a/.agents/skills/room-art-direction/references/direction-c-clean-abstract-graphic.md
+++ b/.agents/skills/room-art-direction/references/direction-c-clean-abstract-graphic.md
@@ -20,8 +20,11 @@
 - シンプルでも「のっぺり」にはせず、形と色の関係で奥行きを作る。
 
 ### パステルを軸にした配色
-- 水色、ミント、淡い青、クリーム、ペールイエロー、ピーチ、淡いラベンダーなどの軽い色を好相性な基準とする。
+- 水色・ミント・淡い青などの寒色、クリーム・ペールイエロー、ピーチ・淡いコーラルなどの暖色を組み合わせ、複数の色相系統が共存する軽い配色を基準とする。
 - 1色のフィルターをかけるのではなく、複数のパステル色を役割ごとに配置する。
+- 大きな色面は寒色・暖色・ニュートラルへ分散させ、複数の色相系統が画面内で明確に読めるようにする。
+- ラベンダー・ペリウィンクル・紫は使ってよいが、小さなアクセントまたは局所的な影色に留め、画面全体の基調色にはしない。
+- 壁・床・背景・照明を同じ紫系へ寄せて、画面全体が紫のフィルターをかけたようになる状態を避ける。
 - 白・明るいニュートラルを余白として使い、色面を呼吸させる。
 - 彩度を落としすぎて灰色っぽくしない。
 - ピンク・紫・ネオン固定にはしない。
@@ -56,7 +59,7 @@
 - PBR的な細かい反射や粗さ
 - 木目・布目・石肌などの写実テクスチャ
 - 暗く重い色調への固定
-- ピンク・紫・ネオン一辺倒
+- ピンク・紫・ラベンダー・ペリウィンクルが画面全体を支配する単色寄りの配色
 - 彩度が低すぎる灰色っぽい画面
 - 手描き・水彩・紙の質感
 - 太い黒輪郭
@@ -79,7 +82,8 @@
 
 - unmistakably abstract graphic spatial illustration built from simplified 2D or gentle 2.5D geometric forms, not a realistic architectural render
 - aggressively simplify furniture, architecture, plants and landscape into clean silhouettes, blocks, curves and color fields
-- soft pastel-forward palette using several coordinated colors such as sky blue, mint, cream, butter yellow, pale peach and periwinkle, with airy light neutrals
+- soft pastel-forward palette with broad hue variety across cool and warm families, using coordinated sky blue, mint, cream, butter yellow, pale peach and soft coral with airy light neutrals; lavender or periwinkle may appear only as small optional accents, never as the dominant overall cast
+- distribute large color fields across distinct hue families; do not tint walls, floor, background and lighting all toward lavender, violet or purple
 - respect the specified time of day, weather and light direction exactly; pastel styling changes the rendering language, not the environmental conditions
 - bold color blocking, elegant negative space, repeated shape rhythm and playful spatial composition are more important than realistic materials
 - use flat or very gently shaded planes with simple graphic shadows; avoid realistic reflections, gloss, roughness, wood grain, grass texture, stone texture and photographic vegetation
@@ -87,13 +91,14 @@
 - keep the workspace and seat zones legible, but do not turn the scene into a conventional office, cafe, lawn garden or real-estate visualization
 - objects must remain intentionally non-realistic even when the subject is familiar
 - clearly distinct from both anime illustration and game-CG rendering: minimal material realism, no PBR look, no cinematic 3D lighting
-- no paper, watercolor, painterly or grain texture; avoid neon-purple default palette
+- no paper, watercolor, painterly or grain texture; avoid monochromatic or purple-biased palettes, lavender/violet/periwinkle washes, and single-hue pastel filters
 
 ## Review checklist
 
 - [ ] 家具・植物・地面を含め、物体がリアルなCG質感や写実テクスチャへ戻っていない
 - [ ] 形・色面・余白・反復リズムが主役で、通常の建築ビジュアライゼーションに見えない
 - [ ] パステル系の配色が複数色で意図的に設計されている
+- [ ] 紫・ラベンダー・ペリウィンクルが大面積を支配せず、寒色・暖色・ニュートラルの色面が分散している
 - [ ] 白・余白が適切に使われ、画面が軽やか
 - [ ] 単純化しても空間構造と座席が読み取れる
 - [ ] 手描き・紙・絵の具の質感がない

--- a/tools/room-image-prompt/cmd/room-image-prompt/main_e2e_test.go
+++ b/tools/room-image-prompt/cmd/room-image-prompt/main_e2e_test.go
@@ -270,7 +270,7 @@ func TestCLI_LookProfile(t *testing.T) {
 	for _, required := range []string{
 		"clean 2D digital environment illustration",
 		"## Look profile: Crystal Lucent",
-		"pale cyan, periwinkle, lavender",
+		"pale cyan, mint, milky white",
 	} {
 		if !strings.Contains(got, required) {
 			t.Fatalf("combined Direction + Look output is missing %q:\n%s", required, got)
@@ -293,6 +293,64 @@ func TestResolveBundledDirectionStyles(t *testing.T) {
 			}
 			if strings.Contains(style, "写真風、3D建築レンダリング風、フォトリアル表現にはしないでください。") {
 				t.Fatalf("style %q unexpectedly contains legacy style: %s", name, style)
+			}
+		})
+	}
+}
+
+func TestDirectionCBalancesPastelHueFamilies(t *testing.T) {
+	t.Parallel()
+
+	style, err := resolveStyle(data.FS, "direction-c", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, required := range []string{
+		"broad hue variety across cool and warm families",
+		"lavender or periwinkle may appear only as small optional accents",
+		"do not tint walls, floor, background and lighting all toward lavender, violet or purple",
+		"avoid monochromatic or purple-biased palettes",
+	} {
+		if !strings.Contains(style, required) {
+			t.Fatalf("direction-c style is missing %q:\n%s", required, style)
+		}
+	}
+	for _, obsolete := range []string{
+		"pale peach and periwinkle",
+		"avoid neon-purple default palette",
+	} {
+		if strings.Contains(style, obsolete) {
+			t.Fatalf("direction-c style still contains purple-biasing guidance %q:\n%s", obsolete, style)
+		}
+	}
+}
+
+func TestPurpleLooksRespectPastelDirections(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		required string
+	}{
+		{
+			name:     "indigo-violet-fantasy",
+			required: "keep large surfaces within that Direction's broader pastel range",
+		},
+		{
+			name:     "crystal-lucent",
+			required: "do not let lavender, violet or periwinkle dominate",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := resolveLook(data.FS, tt.name, "", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(got.Text, tt.required) {
+				t.Fatalf("look %q is missing pastel compatibility guidance %q:\n%s", tt.name, tt.required, got.Text)
 			}
 		})
 	}

--- a/tools/room-image-prompt/data/look_crystal_lucent.txt
+++ b/tools/room-image-prompt/data/look_crystal_lucent.txt
@@ -1,6 +1,7 @@
 ## Look profile: Crystal Lucent
 
-- use a light luminous palette of pale cyan, periwinkle, lavender, soft violet, milky white, faint pink and warm cream accents
+- use a light luminous palette led by pale cyan, mint, milky white, warm cream and very light aqua, with periwinkle, lavender, soft violet and faint pink as secondary accents rather than default base colors
+- when the active Direction calls for broad pastel variety, distribute large color fields across cool, warm and neutral families; do not let lavender, violet or periwinkle dominate walls, floor, background and lighting at the same time
 - emphasize transparent, translucent, glasslike or crystalline visual cues where the scene naturally supports them, creating a light and open material impression
 - prefer clean refraction-like color shifts, rim highlights and layered transparency cues over heavy opaque surfaces or dense metallic gloss
 - keep transparent elements readable against the background through clear value and hue separation rather than realistic optical complexity

--- a/tools/room-image-prompt/data/look_indigo_violet_fantasy.txt
+++ b/tools/room-image-prompt/data/look_indigo_violet_fantasy.txt
@@ -1,6 +1,7 @@
 ## Look profile: Indigo Violet Fantasy
 
 - bias the palette toward deep blue, indigo, violet and clear cyan, with restrained warm cream or amber accents for focal contrast
+- when the active Direction explicitly calls for a light pastel palette, reinterpret deep indigo and violet as small cool accents or soft shadow notes; keep large surfaces within that Direction's broader pastel range instead of turning the whole scene blue-purple
 - create a luminous fantasy atmosphere through colored light relationships and crisp glowing accents, not through foggy haze or bloom
 - keep dark areas chromatic rather than muddy black; preserve readable blue-violet shadow masses and bright cyan or warm highlights
 - let foliage remain recognizably green where appropriate, but allow cool blue-violet shadow notes to tie it into the overall palette

--- a/tools/room-image-prompt/data/style_direction_c.generated.txt
+++ b/tools/room-image-prompt/data/style_direction_c.generated.txt
@@ -1,6 +1,7 @@
 - unmistakably abstract graphic spatial illustration built from simplified 2D or gentle 2.5D geometric forms, not a realistic architectural render
 - aggressively simplify furniture, architecture, plants and landscape into clean silhouettes, blocks, curves and color fields
-- soft pastel-forward palette using several coordinated colors such as sky blue, mint, cream, butter yellow, pale peach and periwinkle, with airy light neutrals
+- soft pastel-forward palette with broad hue variety across cool and warm families, using coordinated sky blue, mint, cream, butter yellow, pale peach and soft coral with airy light neutrals; lavender or periwinkle may appear only as small optional accents, never as the dominant overall cast
+- distribute large color fields across distinct hue families; do not tint walls, floor, background and lighting all toward lavender, violet or purple
 - respect the specified time of day, weather and light direction exactly; pastel styling changes the rendering language, not the environmental conditions
 - bold color blocking, elegant negative space, repeated shape rhythm and playful spatial composition are more important than realistic materials
 - use flat or very gently shaded planes with simple graphic shadows; avoid realistic reflections, gloss, roughness, wood grain, grass texture, stone texture and photographic vegetation
@@ -8,4 +9,4 @@
 - keep the workspace and seat zones legible, but do not turn the scene into a conventional office, cafe, lawn garden or real-estate visualization
 - objects must remain intentionally non-realistic even when the subject is familiar
 - clearly distinct from both anime illustration and game-CG rendering: minimal material realism, no PBR look, no cinematic 3D lighting
-- no paper, watercolor, painterly or grain texture; avoid neon-purple default palette
+- no paper, watercolor, painterly or grain texture; avoid monochromatic or purple-biased palettes, lavender/violet/periwinkle washes, and single-hue pastel filters


### PR DESCRIPTION
## Goal

Direction C でパステル配色を指定していても、紫・ラベンダー系が画面全体を支配しやすい問題を抑えます。

## Cause

- Direction C の例示色に `periwinkle` が他色と同列で含まれていた
- Look は Direction の後段に連結されるため、`indigo-violet-fantasy` / `crystal-lucent` 選択時に紫系指定が強く効きやすかった

## Changes

- Direction C
  - 寒色・暖色・ニュートラルへ大きな色面を分散
  - sky blue / mint / cream / butter yellow / pale peach / soft coral を主軸化
  - lavender / periwinkle / purple は小さなアクセントまたは局所影色に限定
  - 壁・床・背景・照明が一括で紫寄りになる状態を明示的に禁止
  - canonical Markdown と generated style を同期
- Purple-oriented Looks
  - `indigo-violet-fantasy`: pastel Direction では indigo/violet を小さなアクセントへ翻訳
  - `crystal-lucent`: pale cyan / mint / milky white / warm cream / aqua を主軸にし、紫系を secondary accent 化
- Tests
  - Direction C の多色パステル制約を固定
  - 紫系 Look が pastel Direction の大面積を紫支配しないことを固定
  - Crystal Lucent の E2E 期待値を更新

## Expected result

Direction C の軽いパステル感は維持しつつ、生成結果が毎回ラベンダー/紫の単色フィルターへ寄る傾向を弱めます。紫自体は完全禁止せず、必要な場合のアクセントとして残します。

> [!IMPORTANT]
> base は `dev` です。プロジェクト運用ルールに従い、ChatGPT側ではこのPRをマージしません。