### PR TITLE
chore: prove WIF has no DynamoDB credential fallback

### DIFF
--- a/aws-cdk/lib/aws-cdk-stack.ts
+++ b/aws-cdk/lib/aws-cdk-stack.ts
@@ -113,13 +113,6 @@ export class AwsCdkStack extends cdk.Stack {
 			},
 		)
 
-		// NOTE: 現状、DynamoDBのテーブルは別途作成しておく必要がある
-		const dynamoDBAccessPolicy = new iam.PolicyStatement({
-			actions: ['dynamodb:GetItem'],
-			effect: iam.Effect.ALLOW,
-			resources: ['arn:aws:dynamodb:*:*:table/secrets'],
-		})
-
 		// =========================
 		// ECS/Fargate: Daily Batch
 		// =========================
@@ -205,9 +198,6 @@ export class AwsCdkStack extends cdk.Stack {
 				},
 			},
 		)
-		// DynamoDB secrets テーブルへのアクセス付与
-		taskDefinition.taskRole.addToPrincipalPolicy(dynamoDBAccessPolicy)
-
 		const batchContainer = taskDefinition.addContainer('daily-batch', {
 			image: ecs.ContainerImage.fromDockerImageAsset(batchImageAsset),
 			logging: ecs.LogDrivers.awsLogs({
@@ -237,9 +227,6 @@ export class AwsCdkStack extends cdk.Stack {
 				reservedConcurrentExecutions: 1,
 				environment: googleAuthEnvironment,
 			},
-		)
-		;(snsNotifyDiscordFunction.role as iam.Role).addToPolicy(
-			dynamoDBAccessPolicy,
 		)
 		alarmsTopic.addSubscription(
 			new subs.LambdaSubscription(snsNotifyDiscordFunction),
@@ -658,9 +645,6 @@ export class AwsCdkStack extends cdk.Stack {
 				environment: googleAuthEnvironment,
 			},
 		)
-		;(setDesiredMaxSeatsFunction.role as iam.Role).addToPolicy(
-			dynamoDBAccessPolicy,
-		)
 		createLambdaErrorAlarm(
 			setDesiredMaxSeatsFunction,
 			'SetDesiredMaxSeatsErrorsAlarm',
@@ -678,9 +662,6 @@ export class AwsCdkStack extends cdk.Stack {
 				environment: googleAuthEnvironment,
 			},
 		)
-		;(youtubeOrganizeDatabaseFunction.role as iam.Role).addToPolicy(
-			dynamoDBAccessPolicy,
-		)
 		createLambdaErrorAlarm(
 			youtubeOrganizeDatabaseFunction,
 			'YoutubeOrganizeDatabaseErrorsAlarm',
@@ -697,9 +678,6 @@ export class AwsCdkStack extends cdk.Stack {
 				reservedConcurrentExecutions: undefined,
 				environment: googleAuthEnvironment,
 			},
-		)
-		;(checkLiveStreamStatusFunction.role as iam.Role).addToPolicy(
-			dynamoDBAccessPolicy,
 		)
 		createLambdaErrorAlarm(
 			checkLiveStreamStatusFunction,
@@ -722,9 +700,6 @@ export class AwsCdkStack extends cdk.Stack {
 			},
 		)
 		openaiApiKeySecret.grantRead(updateWorkNameTrendFunction)
-		;(updateWorkNameTrendFunction.role as iam.Role).addToPolicy(
-			dynamoDBAccessPolicy,
-		)
 		createLambdaErrorAlarm(
 			updateWorkNameTrendFunction,
 			'UpdateWorkNameTrendErrorsAlarm',
@@ -740,9 +715,6 @@ export class AwsCdkStack extends cdk.Stack {
 				timeout: cdk.Duration.seconds(30),
 				environment: googleAuthEnvironment,
 			},
-		)
-		;(errorLogNotifyDiscordFunction.role as iam.Role).addToPolicy(
-			dynamoDBAccessPolicy,
 		)
 		createLambdaErrorAlarm(
 			errorLogNotifyDiscordFunction,

--- a/aws-cdk/test/aws-cdk.test.ts
+++ b/aws-cdk/test/aws-cdk.test.ts
@@ -210,9 +210,17 @@ describe('AwsCdkStack', () => {
 		})
 	})
 
-	test('removes legacy DynamoDB credential reads while retaining the gateway endpoint', () => {
+	test('removes legacy DynamoDB credential reads while retaining the DynamoDB gateway endpoint', () => {
 		const json = createTemplate().toJSON() as {
-			Resources?: Record<string, unknown>
+			Resources?: Record<
+				string,
+				{
+					Type?: string
+					Properties?: {
+						ServiceName?: unknown
+					}
+				}
+			>
 		}
 		const resources = json.Resources ?? {}
 		const serialized = JSON.stringify(resources)
@@ -220,17 +228,12 @@ describe('AwsCdkStack', () => {
 		expect(serialized).not.toContain('dynamodb:GetItem')
 		expect(serialized).not.toContain('arn:aws:dynamodb:*:*:table/secrets')
 
-		const gatewayEndpoints = Object.values(resources).filter((resource) => {
-			if (
-				typeof resource !== 'object' ||
-				resource === null ||
-				!('Type' in resource)
-			) {
-				return false
-			}
-			return (resource as { Type?: string }).Type === 'AWS::EC2::VPCEndpoint'
-		})
-		expect(gatewayEndpoints.length).toBeGreaterThan(0)
+		const dynamodbGatewayEndpoints = Object.values(resources).filter(
+			(resource) =>
+				resource.Type === 'AWS::EC2::VPCEndpoint' &&
+				JSON.stringify(resource.Properties?.ServiceName).includes('dynamodb'),
+		)
+		expect(dynamodbGatewayEndpoints).toHaveLength(1)
 	})
 
 	test('subscribes AlarmsTopic to email and Lambda notifier', () => {

--- a/aws-cdk/test/aws-cdk.test.ts
+++ b/aws-cdk/test/aws-cdk.test.ts
@@ -210,6 +210,29 @@ describe('AwsCdkStack', () => {
 		})
 	})
 
+	test('removes legacy DynamoDB credential reads while retaining the gateway endpoint', () => {
+		const json = createTemplate().toJSON() as {
+			Resources?: Record<string, unknown>
+		}
+		const resources = json.Resources ?? {}
+		const serialized = JSON.stringify(resources)
+
+		expect(serialized).not.toContain('dynamodb:GetItem')
+		expect(serialized).not.toContain('arn:aws:dynamodb:*:*:table/secrets')
+
+		const gatewayEndpoints = Object.values(resources).filter((resource) => {
+			if (
+				typeof resource !== 'object' ||
+				resource === null ||
+				!('Type' in resource)
+			) {
+				return false
+			}
+			return (resource as { Type?: string }).Type === 'AWS::EC2::VPCEndpoint'
+		})
+		expect(gatewayEndpoints.length).toBeGreaterThan(0)
+	})
+
 	test('subscribes AlarmsTopic to email and Lambda notifier', () => {
 		const t = createTemplate()
 		const json = t.toJSON() as {


### PR DESCRIPTION
## Summary

Removes the legacy DynamoDB credential read permission from the Google Cloud-using AWS workloads so the WIF path can be validated without any hidden credential fallback.

### What changes

- remove `dynamodb:GetItem` on the legacy credential table from the daily batch task role
- remove the same permission from the six Google Cloud-using Lambda execution roles
- keep the DynamoDB gateway endpoint, legacy credential code, and auth-mode switch for now
- add a CDK test that asserts the legacy credential read permission is absent while the gateway endpoint remains

### Why

Development and production WIF runtime validation have already passed. This phase proves that workloads continue to function when the old AWS credential-read permission is unavailable.

### Validation

CI is green. The AWS CDK test suite and CDK synth pass with an assertion that the legacy DynamoDB credential read is absent while the DynamoDB gateway endpoint remains.

Development rollout is also verified: all seven runtime roles deny the legacy DynamoDB credential read, a Lambda continues to access Google Cloud successfully through WIF, and the manual Fargate validation task completes successfully with no WIF/IAM authentication errors.

### Rollout plan

1. deploy to development with WIF mode unchanged
2. verify Lambda and Fargate still succeed without the DynamoDB credential permission
3. deploy to production and repeat the checks
4. remove the remaining legacy code and infrastructure only after this no-fallback proof passes

Cloud account IDs, role names, project numbers, and operator commands remain in the private runbook rather than this public repository.