### PR TITLE
Live Room Scenes: Static互換のRoomVisual境界を追加

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -85,3 +85,15 @@ Changes to storage, forwarding, archival, or deletion must also be checked again
 **Current fact:** the monitor participates in max-seat control as described above.
 
 **Design direction:** prefer moving control decisions out of the presentation client so the monitor can eventually become a read/render-only component. This is a target boundary, not a statement that migration is complete. Until code changes remove the request path, reviews and tests must assume the current control loop exists.
+
+## Livestream room visual boundary
+
+Room visuals are being evolved behind a compatibility boundary so room/seat control semantics stay independent from optional visual enhancement.
+
+- `RoomLayout.floor_image` remains the required static room asset and fallback.
+- `RoomLayout.scene` is optional. Omission means the room stays static.
+- Seat boxes, names, work content, room capacity, and paging remain in the existing React/DOM and layout paths.
+- Scene loading must never block page navigation.
+- Dynamic scene rendering must not change basic/temporary room seat counts or desired-seat calculations.
+
+The staged design and rollout contract are documented in [`live-room-scenes.md`](./live-room-scenes.md).

--- a/docs/development/live-room-scenes.md
+++ b/docs/development/live-room-scenes.md
@@ -1,0 +1,108 @@
+# Live Room Scenes technical design
+
+This document is the implementation contract for incremental 2D motion in the YouTube livestream monitor. Product/visual intent is maintained in Notion's **Live Scene / Motion Bible v0.1**; this file records repository/runtime boundaries.
+
+- Notion: https://app.notion.com/p/3d5357a8d0ce81748b20fe925228ab54
+- Tracking issue: https://github.com/kani3camp/youtube-study-space/issues/1069
+
+## Goal
+
+Allow rooms to opt into time-aware ambient or living 2D visuals without making scene authoring a prerequisite for adding a room.
+
+## Invariants
+
+1. `floor_image` remains the static source and fallback.
+2. A room with no `scene` config behaves as it does before this project.
+3. Seat DOM, user/work labels, room capacity, page order, and max-seat control stay outside the scene renderer.
+4. Page navigation is not delayed by scene initialization or asset loading.
+5. Hidden pages must not keep expensive animation work running.
+6. Runtime failures fall back to static rendering rather than blanking the room.
+
+## Ownership boundary
+
+```mermaid
+flowchart TD
+    Clock[JST Clock] --> SceneTime[Scene time model]
+    Layout[RoomLayout] --> Visual[RoomVisual]
+    Static[floor_image] --> Visual
+    SceneTime --> Enhancement[Optional scene enhancement]
+    Layout --> Seats[Existing seat/layout DOM]
+    Enhancement --> Visual
+    Visual --> Frame[Room frame]
+    Seats --> Frame
+```
+
+### React / DOM owns
+
+- room page selection and immediate page switching
+- seat positions and seat state
+- user display name and work content
+- existing monitor UI
+- current max-seat control behavior
+
+### Scene layer owns
+
+- background color grading
+- sky/outside layers
+- ambient/window/lamp light
+- slow weather/environment motion
+- renderer lifecycle and fallback
+
+## Configuration levels
+
+### Static
+
+No `scene` property. Only `floor_image` is required.
+
+### Ambient
+
+```ts
+scene: {
+  mode: 'ambient',
+  profile: 'neutral-interior',
+}
+```
+
+Ambient must remain possible with the room image alone. Profile names and actual grading parameters are deferred to the Scene Clock/Ambient PR.
+
+### Living
+
+```ts
+scene: {
+  mode: 'living',
+  profile: 'window-lounge',
+}
+```
+
+Layer/asset schema is intentionally deferred until the renderer PR so the configuration is derived from implemented primitives instead of speculative types.
+
+## Rollout stack
+
+1. Static compatibility boundary and types.
+2. Continuous Scene Clock and Ambient mode.
+3. PixiJS/WebGL renderer lifecycle and fallback.
+4. One Living Room PoC.
+5. Performance, asset lifecycle, context-loss/error handling.
+6. Production documentation, soak-test procedure, rollout controls.
+
+All intermediate PRs target `feature/live-room-scenes`. Only the final integration PR targets `dev`, and that PR must not be merged by an agent.
+
+## Verification strategy
+
+Every stage keeps the smallest deterministic contract possible:
+
+- component tests for static fallback/compatibility;
+- unit tests for time interpolation and debug time;
+- lifecycle/error tests around renderer activation and cleanup;
+- normal monitor gates: `pnpm check`, `pnpm test --runInBand`, `pnpm build`;
+- final runtime acceptance on the streaming PC in OBS at 1920x1080 / 30fps;
+- long-running soak test before production enablement.
+
+## Explicit non-goals
+
+- 3D rendering
+- camera-heavy room transitions
+- changing page-switch behavior
+- real weather API integration
+- changing room seat counts or ordering
+- requiring scene assets for every new room

--- a/youtube-monitor/src/components/RoomVisual.test.tsx
+++ b/youtube-monitor/src/components/RoomVisual.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import type { ComponentPropsWithoutRef } from 'react'
+import RoomVisual from './RoomVisual'
+
+jest.mock('next/image', () => ({
+	__esModule: true,
+	default: (props: ComponentPropsWithoutRef<'img'>) => {
+		const { alt, height, src, width } = props
+		return (
+			<span
+				role="img"
+				aria-label={alt}
+				data-height={height}
+				data-src={typeof src === 'string' ? src : ''}
+				data-width={width}
+			/>
+		)
+	},
+}))
+
+describe('RoomVisual static compatibility', () => {
+	test('renders the static floor image when no scene is configured', () => {
+		render(
+			<RoomVisual
+				floorImage="/images/rooms/test-room.png"
+				width={1520}
+				height={900}
+			/>,
+		)
+
+		const image = screen.getByRole('img', { name: 'room image' })
+		expect(image).toHaveAttribute('data-src', '/images/rooms/test-room.png')
+		expect(image).toHaveAttribute('data-width', '1520')
+		expect(image).toHaveAttribute('data-height', '900')
+	})
+
+	test('keeps rendering the static floor image when a scene config is present', () => {
+		render(
+			<RoomVisual
+				floorImage="/images/rooms/test-room.png"
+				scene={{ mode: 'ambient' }}
+				width={1520}
+				height={900}
+			/>,
+		)
+
+		expect(screen.getByRole('img', { name: 'room image' })).toHaveAttribute(
+			'data-src',
+			'/images/rooms/test-room.png',
+		)
+	})
+
+	test('renders nothing when the room has no floor image', () => {
+		const { container } = render(
+			<RoomVisual floorImage="" width={1520} height={900} />,
+		)
+
+		expect(container).toBeEmptyDOMElement()
+	})
+})

--- a/youtube-monitor/src/components/RoomVisual.tsx
+++ b/youtube-monitor/src/components/RoomVisual.tsx
@@ -1,0 +1,35 @@
+import Image from 'next/image'
+import type { FC } from 'react'
+import type { RoomSceneConfig } from '../types/room-scene'
+
+export type RoomVisualProps = {
+	floorImage: string
+	width: number
+	height: number
+	scene?: RoomSceneConfig
+}
+
+/**
+ * Compatibility boundary for room visuals.
+ *
+ * Static room rendering remains authoritative in this PR. The optional scene
+ * prop is accepted so later ambient/living renderers can be introduced behind
+ * this component without changing seat/layout ownership.
+ */
+const RoomVisual: FC<RoomVisualProps> = ({ floorImage, width, height }) => {
+	if (!floorImage) {
+		return null
+	}
+
+	return (
+		<Image
+			alt="room image"
+			src={floorImage}
+			width={width}
+			height={height}
+			priority={true}
+		/>
+	)
+}
+
+export default RoomVisual

--- a/youtube-monitor/src/components/SeatsPage.tsx
+++ b/youtube-monitor/src/components/SeatsPage.tsx
@@ -1,9 +1,9 @@
-import Image from 'next/image'
 import { type FC, useMemo } from 'react'
 import { Constants } from '../lib/constants'
 import * as styles from '../styles/SeatsPage.styles'
 import type { Seat } from '../types/api'
 import type { RoomLayout } from '../types/room-layout'
+import RoomVisual from './RoomVisual'
 import SeatBox from './SeatBox'
 
 export type LayoutPageProps = {
@@ -202,15 +202,12 @@ const SeatsPage: FC<LayoutPageProps> = (props) => {
 						}
 			}
 		>
-			{propsMemo.roomLayout.floor_image && (
-				<Image
-					alt="room image"
-					src={propsMemo.roomLayout.floor_image}
-					width={roomShape.widthPx}
-					height={roomShape.heightPx}
-					priority={true}
-				/>
-			)}
+			<RoomVisual
+				floorImage={propsMemo.roomLayout.floor_image}
+				scene={propsMemo.roomLayout.scene}
+				width={roomShape.widthPx}
+				height={roomShape.heightPx}
+			/>
 
 			{seatList}
 

--- a/youtube-monitor/src/types/room-layout.d.ts
+++ b/youtube-monitor/src/types/room-layout.d.ts
@@ -1,5 +1,8 @@
+import type { RoomSceneConfig } from './room-scene'
+
 export type RoomLayout = {
 	floor_image: string
+	scene?: RoomSceneConfig
 	font_size_ratio: number
 	room_shape: {
 		height: number

--- a/youtube-monitor/src/types/room-scene.ts
+++ b/youtube-monitor/src/types/room-scene.ts
@@ -1,0 +1,15 @@
+export const ROOM_SCENE_MODES = ['ambient', 'living'] as const
+
+export type RoomSceneMode = (typeof ROOM_SCENE_MODES)[number]
+
+/**
+ * Optional visual enhancement for a room.
+ *
+ * Omitting scene keeps the room fully static. The schema is intentionally
+ * minimal here; renderer/layer details are introduced only when their runtime
+ * contracts are implemented by later Live Room Scenes PRs.
+ */
+export type RoomSceneConfig = {
+	mode: RoomSceneMode
+	profile?: string
+}


### PR DESCRIPTION
## Goal

Live Room Scenesの最初の境界として、既存Static Room表示を変えずに将来のAmbient / Living Sceneを差し込める `RoomVisual` と `RoomSceneConfig` を追加する。

Tracks #1069.

## Stack

- **PR1 (this PR)**: Static compatibility boundary
- PR2: Scene Clock + Ambient
- PR3: PixiJS renderer lifecycle/fallback
- PR4: Living Room PoC
- PR5: performance/asset lifecycle
- PR6: production docs/hardening
- Final: `feature/live-room-scenes -> dev` (agent merge prohibited)

Base is intentionally `feature/live-room-scenes`, not `dev`.

## Invariants

- Existing `floor_image` remains authoritative.
- Existing rooms have no `scene` config and retain static behavior.
- No seat count/order changes.
- No max-seat calculation changes.
- No page-switch behavior changes.
- No renderer dependency is introduced yet.

## Changes

- add minimal `RoomSceneConfig` (`ambient | living`)
- add optional `RoomLayout.scene`
- extract existing floor image rendering into `RoomVisual`
- add static compatibility tests
- add staged technical design and architecture boundary docs

## Non-goals

- actual Ambient rendering
- PixiJS/WebGL
- scene asset schema
- Living effects
- page transitions

## Verification

Local commands have not been run from this connector environment. GitHub Actions is the repository gate; this PR adds deterministic component tests for the compatibility boundary.
