### PR TITLE
Live Room Scenes: Scene ClockとAmbientモードを追加

### DIFF
--- a/docs/development/live-room-scenes.md
+++ b/docs/development/live-room-scenes.md
@@ -79,7 +79,7 @@ Layer/asset schema is intentionally deferred until the renderer PR so the config
 ## Rollout stack
 
 1. Static compatibility boundary and types.
-2. Continuous Scene Clock and Ambient mode.
+2. Continuous Scene Clock and Ambient mode. **Implemented:** one JST clock writes CSS variables without per-frame React state; Ambient rooms consume a conservative CSS color-grade filter.
 3. PixiJS/WebGL renderer lifecycle and fallback.
 4. One Living Room PoC.
 5. Performance, asset lifecycle, context-loss/error handling.
@@ -106,3 +106,17 @@ Every stage keeps the smallest deterministic contract possible:
 - real weather API integration
 - changing room seat counts or ordering
 - requiring scene assets for every new room
+
+## Scene Clock debug controls
+
+Debug query parameters are honored only when `NEXT_PUBLIC_DEBUG=true`.
+
+- `?sceneTime=17:30` freezes the Scene Clock at 17:30 JST.
+- `?sceneSpeed=720` accelerates the current Scene Clock 720x.
+- `?sceneTime=00:00&sceneSpeed=720` reviews a full 24-hour cycle in two real minutes.
+
+The normal clock updates root CSS variables once per second without putting Scene Clock state into React render state. Static rooms do not consume these variables.
+
+### Ambient implementation
+
+Ambient remains an opt-in room mode and requires no assets beyond `floor_image`. The initial implementation applies a deliberately conservative CSS filter driven by continuous Scene Clock parameters. No existing production room is opted in by this PR, so rollout can be reviewed separately from the clock/runtime change.

--- a/youtube-monitor/src/components/RoomVisual.test.tsx
+++ b/youtube-monitor/src/components/RoomVisual.test.tsx
@@ -30,10 +30,7 @@ describe('RoomVisual static compatibility', () => {
 		)
 
 		const image = screen.getByRole('img', { name: 'room image' })
-		expect(image).toHaveAttribute(
-		'data-src',
-		'/images/rooms/test-room.png',
-	)
+		expect(image).toHaveAttribute('data-src', '/images/rooms/test-room.png')
 		expect(image).toHaveAttribute('data-width', '1520')
 		expect(image).toHaveAttribute('data-height', '900')
 		expect(image).not.toHaveAttribute('data-filter')

--- a/youtube-monitor/src/components/RoomVisual.test.tsx
+++ b/youtube-monitor/src/components/RoomVisual.test.tsx
@@ -5,11 +5,12 @@ import RoomVisual from './RoomVisual'
 jest.mock('next/image', () => ({
 	__esModule: true,
 	default: (props: ComponentPropsWithoutRef<'img'>) => {
-		const { alt, height, src, width } = props
+		const { alt, height, src, style, width } = props
 		return (
 			<span
 				role="img"
 				aria-label={alt}
+				data-filter={style?.filter}
 				data-height={height}
 				data-src={typeof src === 'string' ? src : ''}
 				data-width={width}
@@ -32,6 +33,7 @@ describe('RoomVisual static compatibility', () => {
 		expect(image).toHaveAttribute('data-src', '/images/rooms/test-room.png')
 		expect(image).toHaveAttribute('data-width', '1520')
 		expect(image).toHaveAttribute('data-height', '900')
+		expect(image).not.toHaveAttribute('data-filter')
 	})
 
 	test('keeps rendering the static floor image when a scene config is present', () => {
@@ -44,9 +46,11 @@ describe('RoomVisual static compatibility', () => {
 			/>,
 		)
 
-		expect(screen.getByRole('img', { name: 'room image' })).toHaveAttribute(
-			'data-src',
-			'/images/rooms/test-room.png',
+		const image = screen.getByRole('img', { name: 'room image' })
+		expect(image).toHaveAttribute('data-src', '/images/rooms/test-room.png')
+		expect(image).toHaveAttribute(
+			'data-filter',
+			'var(--scene-ambient-filter, none)',
 		)
 	})
 

--- a/youtube-monitor/src/components/RoomVisual.test.tsx
+++ b/youtube-monitor/src/components/RoomVisual.test.tsx
@@ -30,7 +30,10 @@ describe('RoomVisual static compatibility', () => {
 		)
 
 		const image = screen.getByRole('img', { name: 'room image' })
-		expect(image).toHaveAttribute('data-src', '/images/rooms/test-room.png')
+		expect(image).toHaveAttribute(
+		'data-src',
+		'/images/rooms/test-room.png',
+	)
 		expect(image).toHaveAttribute('data-width', '1520')
 		expect(image).toHaveAttribute('data-height', '900')
 		expect(image).not.toHaveAttribute('data-filter')

--- a/youtube-monitor/src/components/RoomVisual.tsx
+++ b/youtube-monitor/src/components/RoomVisual.tsx
@@ -16,7 +16,12 @@ export type RoomVisualProps = {
  * prop is accepted so later ambient/living renderers can be introduced behind
  * this component without changing seat/layout ownership.
  */
-const RoomVisual: FC<RoomVisualProps> = ({ floorImage, width, height, scene }) => {
+const RoomVisual: FC<RoomVisualProps> = ({
+	floorImage,
+	width,
+	height,
+	scene,
+}) => {
 	if (!floorImage) {
 		return null
 	}

--- a/youtube-monitor/src/components/RoomVisual.tsx
+++ b/youtube-monitor/src/components/RoomVisual.tsx
@@ -16,10 +16,18 @@ export type RoomVisualProps = {
  * prop is accepted so later ambient/living renderers can be introduced behind
  * this component without changing seat/layout ownership.
  */
-const RoomVisual: FC<RoomVisualProps> = ({ floorImage, width, height }) => {
+const RoomVisual: FC<RoomVisualProps> = ({ floorImage, width, height, scene }) => {
 	if (!floorImage) {
 		return null
 	}
+
+	const ambientStyle =
+		scene?.mode === 'ambient'
+			? {
+					filter: 'var(--scene-ambient-filter, none)',
+					transition: 'filter 1s linear',
+				}
+			: undefined
 
 	return (
 		<Image
@@ -28,6 +36,7 @@ const RoomVisual: FC<RoomVisualProps> = ({ floorImage, width, height }) => {
 			width={width}
 			height={height}
 			priority={true}
+			style={ambientStyle}
 		/>
 	)
 }

--- a/youtube-monitor/src/hooks/use-scene-clock-css-variables.ts
+++ b/youtube-monitor/src/hooks/use-scene-clock-css-variables.ts
@@ -48,13 +48,31 @@ export function useSceneClockCssVariables(
 				'--scene-ambient-filter',
 				buildAmbientSceneFilter(state),
 			)
-			target.style.setProperty('--scene-brightness', String(state.brightness))
-			target.style.setProperty('--scene-saturation', String(state.saturation))
+			target.style.setProperty(
+			'--scene-brightness',
+			String(state.brightness),
+		)
+			target.style.setProperty(
+			'--scene-saturation',
+			String(state.saturation),
+		)
 			target.style.setProperty('--scene-warmth', String(state.warmth))
-			target.style.setProperty('--scene-sunset-amount', String(state.sunsetAmount))
-			target.style.setProperty('--scene-night-amount', String(state.nightAmount))
-			target.style.setProperty('--scene-lamp-intensity', String(state.lampIntensity))
-			target.style.setProperty('--scene-sky-brightness', String(state.skyBrightness))
+			target.style.setProperty(
+			'--scene-sunset-amount',
+			String(state.sunsetAmount),
+		)
+			target.style.setProperty(
+			'--scene-night-amount',
+			String(state.nightAmount),
+		)
+			target.style.setProperty(
+			'--scene-lamp-intensity',
+			String(state.lampIntensity),
+		)
+			target.style.setProperty(
+			'--scene-sky-brightness',
+			String(state.skyBrightness),
+		)
 		}
 
 		update()

--- a/youtube-monitor/src/hooks/use-scene-clock-css-variables.ts
+++ b/youtube-monitor/src/hooks/use-scene-clock-css-variables.ts
@@ -1,0 +1,69 @@
+import { useRouter } from 'next/router'
+import { type RefObject, useEffect } from 'react'
+import { DEBUG } from '../lib/constants'
+import {
+	buildAmbientSceneFilter,
+	createSceneClockAnchor,
+	getSceneClockSecondsAt,
+	getSceneStateAtClockSeconds,
+} from '../lib/scene-clock'
+
+const SCENE_CLOCK_UPDATE_INTERVAL_MS = 1000
+
+const SCENE_VARIABLES = [
+	'--scene-ambient-filter',
+	'--scene-brightness',
+	'--scene-saturation',
+	'--scene-warmth',
+	'--scene-sunset-amount',
+	'--scene-night-amount',
+	'--scene-lamp-intensity',
+	'--scene-sky-brightness',
+] as const
+
+export function useSceneClockCssVariables(
+	targetRef: RefObject<HTMLElement | null>,
+): void {
+	const router = useRouter()
+	const sceneTimeQuery = router.query.sceneTime
+	const sceneSpeedQuery = router.query.sceneSpeed
+
+	useEffect(() => {
+		if (!router.isReady || targetRef.current === null) {
+			return
+		}
+
+		const target = targetRef.current
+		const anchor = createSceneClockAnchor(
+			new Date(),
+			sceneTimeQuery,
+			sceneSpeedQuery,
+			DEBUG,
+		)
+
+		const update = () => {
+			const clockSeconds = getSceneClockSecondsAt(anchor, Date.now())
+			const state = getSceneStateAtClockSeconds(clockSeconds)
+			target.style.setProperty(
+				'--scene-ambient-filter',
+				buildAmbientSceneFilter(state),
+			)
+			target.style.setProperty('--scene-brightness', String(state.brightness))
+			target.style.setProperty('--scene-saturation', String(state.saturation))
+			target.style.setProperty('--scene-warmth', String(state.warmth))
+			target.style.setProperty('--scene-sunset-amount', String(state.sunsetAmount))
+			target.style.setProperty('--scene-night-amount', String(state.nightAmount))
+			target.style.setProperty('--scene-lamp-intensity', String(state.lampIntensity))
+			target.style.setProperty('--scene-sky-brightness', String(state.skyBrightness))
+		}
+
+		update()
+		const intervalId = window.setInterval(update, SCENE_CLOCK_UPDATE_INTERVAL_MS)
+		return () => {
+			window.clearInterval(intervalId)
+			for (const variable of SCENE_VARIABLES) {
+				target.style.removeProperty(variable)
+			}
+		}
+	}, [router.isReady, sceneSpeedQuery, sceneTimeQuery, targetRef])
+}

--- a/youtube-monitor/src/hooks/use-scene-clock-css-variables.ts
+++ b/youtube-monitor/src/hooks/use-scene-clock-css-variables.ts
@@ -48,35 +48,32 @@ export function useSceneClockCssVariables(
 				'--scene-ambient-filter',
 				buildAmbientSceneFilter(state),
 			)
-			target.style.setProperty(
-			'--scene-brightness',
-			String(state.brightness),
-		)
-			target.style.setProperty(
-			'--scene-saturation',
-			String(state.saturation),
-		)
+			target.style.setProperty('--scene-brightness', String(state.brightness))
+			target.style.setProperty('--scene-saturation', String(state.saturation))
 			target.style.setProperty('--scene-warmth', String(state.warmth))
 			target.style.setProperty(
-			'--scene-sunset-amount',
-			String(state.sunsetAmount),
-		)
+				'--scene-sunset-amount',
+				String(state.sunsetAmount),
+			)
 			target.style.setProperty(
-			'--scene-night-amount',
-			String(state.nightAmount),
-		)
+				'--scene-night-amount',
+				String(state.nightAmount),
+			)
 			target.style.setProperty(
-			'--scene-lamp-intensity',
-			String(state.lampIntensity),
-		)
+				'--scene-lamp-intensity',
+				String(state.lampIntensity),
+			)
 			target.style.setProperty(
-			'--scene-sky-brightness',
-			String(state.skyBrightness),
-		)
+				'--scene-sky-brightness',
+				String(state.skyBrightness),
+			)
 		}
 
 		update()
-		const intervalId = window.setInterval(update, SCENE_CLOCK_UPDATE_INTERVAL_MS)
+		const intervalId = window.setInterval(
+			update,
+			SCENE_CLOCK_UPDATE_INTERVAL_MS,
+		)
 		return () => {
 			window.clearInterval(intervalId)
 			for (const variable of SCENE_VARIABLES) {

--- a/youtube-monitor/src/lib/scene-clock.test.ts
+++ b/youtube-monitor/src/lib/scene-clock.test.ts
@@ -1,0 +1,95 @@
+import {
+	buildAmbientSceneFilter,
+	createSceneClockAnchor,
+	getJapanClockSeconds,
+	getSceneClockSecondsAt,
+	getSceneStateAtClockSeconds,
+	parseDebugSceneSpeed,
+	parseDebugSceneTime,
+	SCENE_DAY_SECONDS,
+} from './scene-clock'
+
+describe('Scene Clock', () => {
+	test('日本時間の壁時計秒へ変換する', () => {
+		expect(getJapanClockSeconds(new Date('2026-08-01T21:00:15Z'))).toBe(
+			6 * 60 * 60 + 15,
+		)
+	})
+
+	test('day keyframeは昼の明るさを返す', () => {
+		const state = getSceneStateAtClockSeconds((9 * 60 + 15) * 60)
+		expect(state.brightness).toBe(1)
+		expect(state.nightAmount).toBe(0)
+		expect(state.lampIntensity).toBe(0)
+	})
+
+	test('keyframe間を連続補間する', () => {
+		const left = getSceneStateAtClockSeconds((15 * 60 + 15) * 60)
+		const middle = getSceneStateAtClockSeconds((16 * 60 + 27.5) * 60)
+		const right = getSceneStateAtClockSeconds((17 * 60 + 40) * 60)
+
+		expect(middle.brightness).toBeLessThan(left.brightness)
+		expect(middle.brightness).toBeGreaterThan(right.brightness)
+		expect(middle.sunsetAmount).toBeGreaterThan(left.sunsetAmount)
+		expect(middle.sunsetAmount).toBeLessThan(right.sunsetAmount)
+	})
+
+	test('24時を越えて循環する', () => {
+		expect(getSceneStateAtClockSeconds(SCENE_DAY_SECONDS)).toEqual(
+			getSceneStateAtClockSeconds(0),
+		)
+		expect(getSceneStateAtClockSeconds(-1)).toEqual(
+			getSceneStateAtClockSeconds(SCENE_DAY_SECONDS - 1),
+		)
+	})
+})
+
+describe('Scene Clock debug query', () => {
+	test('sceneTime HH:mmを受け入れる', () => {
+		expect(parseDebugSceneTime('17:30', true)).toBe((17 * 60 + 30) * 60)
+	})
+
+	test.each(['24:00', '12:60', '7:30', 'unknown'])(
+		'不正なsceneTime %sを拒否する',
+		(value) => {
+			expect(parseDebugSceneTime(value, true)).toBeUndefined()
+		},
+	)
+
+	test('sceneSpeedは0〜1440倍を受け入れる', () => {
+		expect(parseDebugSceneSpeed('0', true)).toBe(0)
+		expect(parseDebugSceneSpeed('720', true)).toBe(720)
+		expect(parseDebugSceneSpeed('1440', true)).toBe(1440)
+	})
+
+	test('デバッグ無効時はqueryを無視する', () => {
+		expect(parseDebugSceneTime('17:30', false)).toBeUndefined()
+		expect(parseDebugSceneSpeed('720', false)).toBeUndefined()
+	})
+
+	test('sceneTimeだけなら固定し、sceneSpeed併用なら加速する', () => {
+		const now = new Date('2026-08-01T00:00:00Z')
+		const frozen = createSceneClockAnchor(now, '17:30', undefined, true)
+		const accelerated = createSceneClockAnchor(now, '17:30', '720', true)
+
+		expect(getSceneClockSecondsAt(frozen, now.getTime() + 60_000)).toBe(
+			(17 * 60 + 30) * 60,
+		)
+		expect(
+			getSceneClockSecondsAt(accelerated, now.getTime() + 60_000),
+		).toBe((5 * 60 + 30) * 60)
+	})
+})
+
+describe('Ambient filter', () => {
+	test('SceneStateをCSS filterへ変換する', () => {
+		const filter = buildAmbientSceneFilter(
+			getSceneStateAtClockSeconds((17 * 60 + 40) * 60),
+		)
+		expect(filter).toContain('brightness(')
+		expect(filter).toContain('saturate(')
+		expect(filter).toContain('sepia(')
+		expect(filter).toContain('hue-rotate(')
+		expect(filter).toContain('contrast(')
+	})
+})

--- a/youtube-monitor/src/lib/scene-clock.test.ts
+++ b/youtube-monitor/src/lib/scene-clock.test.ts
@@ -46,9 +46,7 @@ describe('Scene Clock', () => {
 
 describe('Scene Clock debug query', () => {
 	test('sceneTime HH:mmを受け入れる', () => {
-		expect(parseDebugSceneTime('17:30', true)).toBe(
-			(17 * 60 + 30) * 60,
-		)
+		expect(parseDebugSceneTime('17:30', true)).toBe((17 * 60 + 30) * 60)
 	})
 
 	test.each(['24:00', '12:60', '7:30', 'unknown'])(
@@ -77,9 +75,9 @@ describe('Scene Clock debug query', () => {
 		expect(getSceneClockSecondsAt(frozen, now.getTime() + 60_000)).toBe(
 			(17 * 60 + 30) * 60,
 		)
-		expect(
-			getSceneClockSecondsAt(accelerated, now.getTime() + 60_000),
-		).toBe((5 * 60 + 30) * 60)
+		expect(getSceneClockSecondsAt(accelerated, now.getTime() + 60_000)).toBe(
+			(5 * 60 + 30) * 60,
+		)
 	})
 })
 

--- a/youtube-monitor/src/lib/scene-clock.test.ts
+++ b/youtube-monitor/src/lib/scene-clock.test.ts
@@ -46,7 +46,9 @@ describe('Scene Clock', () => {
 
 describe('Scene Clock debug query', () => {
 	test('sceneTime HH:mmを受け入れる', () => {
-		expect(parseDebugSceneTime('17:30', true)).toBe((17 * 60 + 30) * 60)
+		expect(parseDebugSceneTime('17:30', true)).toBe(
+			(17 * 60 + 30) * 60,
+		)
 	})
 
 	test.each(['24:00', '12:60', '7:30', 'unknown'])(

--- a/youtube-monitor/src/lib/scene-clock.ts
+++ b/youtube-monitor/src/lib/scene-clock.ts
@@ -131,7 +131,9 @@ export function getJapanClockSeconds(date: Date): number {
 	return hours * 60 * 60 + minutes * 60 + seconds
 }
 
-export function getSceneStateAtClockSeconds(clockSeconds: number): SceneState {
+export function getSceneStateAtClockSeconds(
+	clockSeconds: number,
+): SceneState {
 	const normalized = normalizeSceneClockSeconds(clockSeconds)
 	const nextIndex = SCENE_KEYFRAMES.findIndex(
 		(keyframe) => keyframe.atSeconds > normalized,
@@ -179,7 +181,11 @@ export function parseDebugSceneSpeed(
 		return undefined
 	}
 	const parsed = Number(value)
-	if (!Number.isFinite(parsed) || parsed < 0 || parsed > MAX_DEBUG_SCENE_SPEED) {
+	if (
+		!Number.isFinite(parsed) ||
+		parsed < 0 ||
+		parsed > MAX_DEBUG_SCENE_SPEED
+	) {
 		return undefined
 	}
 	return parsed
@@ -213,7 +219,9 @@ export function getSceneClockSecondsAt(
 const compactNumber = (value: number) => Number(value.toFixed(4))
 
 export function buildAmbientSceneFilter(state: SceneState): string {
-	const sepia = clamp01(state.warmth * 0.14 + state.nightAmount * 0.025)
+	const sepia = clamp01(
+		state.warmth * 0.14 + state.nightAmount * 0.025,
+	)
 	const hueRotateDeg = state.nightAmount * 8 - state.sunsetAmount * 5
 	const contrast = 1 - state.nightAmount * 0.04
 	return [

--- a/youtube-monitor/src/lib/scene-clock.ts
+++ b/youtube-monitor/src/lib/scene-clock.ts
@@ -1,0 +1,226 @@
+import { getJapanTimeParts } from './time-theme'
+
+export const SCENE_DAY_SECONDS = 24 * 60 * 60
+export const MAX_DEBUG_SCENE_SPEED = 1440
+
+export type SceneState = {
+	brightness: number
+	saturation: number
+	warmth: number
+	sunsetAmount: number
+	nightAmount: number
+	lampIntensity: number
+	skyBrightness: number
+}
+
+type SceneKeyframe = SceneState & {
+	atSeconds: number
+}
+
+export type SceneClockAnchor = {
+	realStartedAtMs: number
+	sceneStartedAtSeconds: number
+	speed: number
+}
+
+const minutes = (hours: number, mins: number) => (hours * 60 + mins) * 60
+
+const SCENE_KEYFRAMES: readonly SceneKeyframe[] = [
+	{
+		atSeconds: 0,
+		brightness: 0.78,
+		saturation: 0.88,
+		warmth: 0.08,
+		sunsetAmount: 0,
+		nightAmount: 0.82,
+		lampIntensity: 0.95,
+		skyBrightness: 0.2,
+	},
+	{
+		atSeconds: minutes(0, 25),
+		brightness: 0.72,
+		saturation: 0.82,
+		warmth: 0.04,
+		sunsetAmount: 0,
+		nightAmount: 1,
+		lampIntensity: 1,
+		skyBrightness: 0.12,
+	},
+	{
+		atSeconds: minutes(4, 55),
+		brightness: 0.84,
+		saturation: 0.9,
+		warmth: 0.38,
+		sunsetAmount: 0.06,
+		nightAmount: 0.5,
+		lampIntensity: 0.72,
+		skyBrightness: 0.45,
+	},
+	{
+		atSeconds: minutes(9, 15),
+		brightness: 1,
+		saturation: 1,
+		warmth: 0.16,
+		sunsetAmount: 0,
+		nightAmount: 0,
+		lampIntensity: 0,
+		skyBrightness: 1,
+	},
+	{
+		atSeconds: minutes(15, 15),
+		brightness: 0.98,
+		saturation: 1.02,
+		warmth: 0.36,
+		sunsetAmount: 0.18,
+		nightAmount: 0,
+		lampIntensity: 0.04,
+		skyBrightness: 0.94,
+	},
+	{
+		atSeconds: minutes(17, 40),
+		brightness: 0.9,
+		saturation: 1.04,
+		warmth: 1,
+		sunsetAmount: 1,
+		nightAmount: 0.12,
+		lampIntensity: 0.28,
+		skyBrightness: 0.68,
+	},
+	{
+		atSeconds: minutes(18, 47),
+		brightness: 0.83,
+		saturation: 0.96,
+		warmth: 0.5,
+		sunsetAmount: 0.48,
+		nightAmount: 0.5,
+		lampIntensity: 0.7,
+		skyBrightness: 0.42,
+	},
+	{
+		atSeconds: minutes(19, 55),
+		brightness: 0.78,
+		saturation: 0.88,
+		warmth: 0.12,
+		sunsetAmount: 0.04,
+		nightAmount: 0.88,
+		lampIntensity: 1,
+		skyBrightness: 0.2,
+	},
+	{
+		atSeconds: SCENE_DAY_SECONDS,
+		brightness: 0.78,
+		saturation: 0.88,
+		warmth: 0.08,
+		sunsetAmount: 0,
+		nightAmount: 0.82,
+		lampIntensity: 0.95,
+		skyBrightness: 0.2,
+	},
+]
+
+const clamp01 = (value: number) => Math.min(1, Math.max(0, value))
+const lerp = (from: number, to: number, progress: number) =>
+	from + (to - from) * progress
+
+export function normalizeSceneClockSeconds(seconds: number): number {
+	return ((seconds % SCENE_DAY_SECONDS) + SCENE_DAY_SECONDS) % SCENE_DAY_SECONDS
+}
+
+export function getJapanClockSeconds(date: Date): number {
+	const { hours, minutes, seconds } = getJapanTimeParts(date)
+	return hours * 60 * 60 + minutes * 60 + seconds
+}
+
+export function getSceneStateAtClockSeconds(clockSeconds: number): SceneState {
+	const normalized = normalizeSceneClockSeconds(clockSeconds)
+	const nextIndex = SCENE_KEYFRAMES.findIndex(
+		(keyframe) => keyframe.atSeconds > normalized,
+	)
+	const right = SCENE_KEYFRAMES[nextIndex]
+	const left = SCENE_KEYFRAMES[Math.max(0, nextIndex - 1)]
+	const duration = right.atSeconds - left.atSeconds
+	const progress = duration === 0 ? 0 : (normalized - left.atSeconds) / duration
+
+	return {
+		brightness: lerp(left.brightness, right.brightness, progress),
+		saturation: lerp(left.saturation, right.saturation, progress),
+		warmth: lerp(left.warmth, right.warmth, progress),
+		sunsetAmount: lerp(left.sunsetAmount, right.sunsetAmount, progress),
+		nightAmount: lerp(left.nightAmount, right.nightAmount, progress),
+		lampIntensity: lerp(left.lampIntensity, right.lampIntensity, progress),
+		skyBrightness: lerp(left.skyBrightness, right.skyBrightness, progress),
+	}
+}
+
+export function parseDebugSceneTime(
+	value: string | string[] | undefined,
+	debugEnabled: boolean,
+): number | undefined {
+	if (!debugEnabled || typeof value !== 'string') {
+		return undefined
+	}
+	const match = /^(\\d{2}):(\\d{2})$/.exec(value)
+	if (!match) {
+		return undefined
+	}
+	const hours = Number(match[1])
+	const mins = Number(match[2])
+	if (hours < 0 || hours > 23 || mins < 0 || mins > 59) {
+		return undefined
+	}
+	return minutes(hours, mins)
+}
+
+export function parseDebugSceneSpeed(
+	value: string | string[] | undefined,
+	debugEnabled: boolean,
+): number | undefined {
+	if (!debugEnabled || typeof value !== 'string' || value.trim() === '') {
+		return undefined
+	}
+	const parsed = Number(value)
+	if (!Number.isFinite(parsed) || parsed < 0 || parsed > MAX_DEBUG_SCENE_SPEED) {
+		return undefined
+	}
+	return parsed
+}
+
+export function createSceneClockAnchor(
+	now: Date,
+	sceneTimeQuery: string | string[] | undefined,
+	sceneSpeedQuery: string | string[] | undefined,
+	debugEnabled: boolean,
+): SceneClockAnchor {
+	const debugTime = parseDebugSceneTime(sceneTimeQuery, debugEnabled)
+	const debugSpeed = parseDebugSceneSpeed(sceneSpeedQuery, debugEnabled)
+	return {
+		realStartedAtMs: now.getTime(),
+		sceneStartedAtSeconds: debugTime ?? getJapanClockSeconds(now),
+		speed: debugSpeed ?? (debugTime === undefined ? 1 : 0),
+	}
+}
+
+export function getSceneClockSecondsAt(
+	anchor: SceneClockAnchor,
+	realNowMs: number,
+): number {
+	const elapsedRealSeconds = (realNowMs - anchor.realStartedAtMs) / 1000
+	return normalizeSceneClockSeconds(
+		anchor.sceneStartedAtSeconds + elapsedRealSeconds * anchor.speed,
+	)
+}
+
+const compactNumber = (value: number) => Number(value.toFixed(4))
+
+export function buildAmbientSceneFilter(state: SceneState): string {
+	const sepia = clamp01(state.warmth * 0.14 + state.nightAmount * 0.025)
+	const hueRotateDeg = state.nightAmount * 8 - state.sunsetAmount * 5
+	const contrast = 1 - state.nightAmount * 0.04
+	return [
+		`brightness(${compactNumber(state.brightness)})`,
+		`saturate(${compactNumber(state.saturation)})`,
+		`sepia(${compactNumber(sepia)})`,
+		`hue-rotate(${compactNumber(hueRotateDeg)}deg)`,
+		`contrast(${compactNumber(contrast)})`,
+	].join(' ')
+}

--- a/youtube-monitor/src/lib/scene-clock.ts
+++ b/youtube-monitor/src/lib/scene-clock.ts
@@ -131,9 +131,7 @@ export function getJapanClockSeconds(date: Date): number {
 	return hours * 60 * 60 + minutes * 60 + seconds
 }
 
-export function getSceneStateAtClockSeconds(
-	clockSeconds: number,
-): SceneState {
+export function getSceneStateAtClockSeconds(clockSeconds: number): SceneState {
 	const normalized = normalizeSceneClockSeconds(clockSeconds)
 	const nextIndex = SCENE_KEYFRAMES.findIndex(
 		(keyframe) => keyframe.atSeconds > normalized,
@@ -219,9 +217,7 @@ export function getSceneClockSecondsAt(
 const compactNumber = (value: number) => Number(value.toFixed(4))
 
 export function buildAmbientSceneFilter(state: SceneState): string {
-	const sepia = clamp01(
-		state.warmth * 0.14 + state.nightAmount * 0.025,
-	)
+	const sepia = clamp01(state.warmth * 0.14 + state.nightAmount * 0.025)
 	const hueRotateDeg = state.nightAmount * 8 - state.sunsetAmount * 5
 	const contrast = 1 - state.nightAmount * 0.04
 	return [

--- a/youtube-monitor/src/lib/scene-clock.ts
+++ b/youtube-monitor/src/lib/scene-clock.ts
@@ -159,7 +159,7 @@ export function parseDebugSceneTime(
 	if (!debugEnabled || typeof value !== 'string') {
 		return undefined
 	}
-	const match = /^(\\d{2}):(\\d{2})$/.exec(value)
+	const match = /^(\d{2}):(\d{2})$/.exec(value)
 	if (!match) {
 		return undefined
 	}

--- a/youtube-monitor/src/pages/index.tsx
+++ b/youtube-monitor/src/pages/index.tsx
@@ -7,7 +7,7 @@ import {
 } from 'firebase/firestore'
 import type { GetStaticProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
-import { type FC, useEffect, useState } from 'react'
+import { type FC, useEffect, useRef, useState } from 'react'
 import AmbientFrame from '../components/AmbientFrame'
 import BackgroundImage from '../components/BackgroundImage'
 import BgmPlayer from '../components/BgmPlayer'
@@ -17,6 +17,7 @@ import Seats from '../components/MainContent'
 import MenuDisplay from '../components/MenuDisplay'
 import Timer from '../components/Timer'
 import Usage from '../components/Usage'
+import { useSceneClockCssVariables } from '../hooks/use-scene-clock-css-variables'
 import { useTimeTheme } from '../hooks/use-time-theme'
 import { firestoreMenuConverter, getFirebaseApp } from '../lib/firestore'
 import { themedRoot } from '../styles/AmbientFrame.styles'
@@ -24,7 +25,9 @@ import type { Menu } from '../types/api'
 
 const Home: FC = () => {
 	const [menuItems, setMenuItems] = useState<Menu[]>([])
+	const sceneRootRef = useRef<HTMLDivElement>(null)
 	const { timeTheme, textTone, contrastBridge } = useTimeTheme()
+	useSceneClockCssVariables(sceneRootRef)
 
 	useEffect(() => {
 		const app = getFirebaseApp()
@@ -50,6 +53,7 @@ const Home: FC = () => {
 
 	return (
 		<div
+			ref={sceneRootRef}
 			css={themedRoot}
 			data-time-theme={timeTheme}
 			data-text-tone={textTone}


### PR DESCRIPTION
## Goal

Live Room Scenesの第2段階として、JSTに同期する連続Scene Clockと、静止画1枚だけでopt-inできるAmbientモードを追加する。

Tracks #1069.

## Stack

- PR1 #1070: Static compatibility boundary ✅
- **PR2 (this PR)**: Scene Clock + Ambient
- PR3: PixiJS renderer lifecycle/fallback
- PR4: Living Room PoC
- PR5: performance/asset lifecycle
- PR6: production docs/hardening
- Final: `feature/live-room-scenes -> dev` (agent merge prohibited)

Base is intentionally `feature/live-room-scenes`, not `dev`.

## Invariants

- 既存Roomは`scene`未設定なので視覚変更なし。
- Static RoomはScene Clock CSS variablesを消費しない。
- SeatBox / username / work content / seat count / page order / max-seat logicは変更しない。
- React stateを毎秒更新しない。Scene Clockはroot CSS variablesをimperativeに更新する。
- debug queryは`NEXT_PUBLIC_DEBUG=true`のときのみ有効。

## Changes

- JST wall clockから連続Scene stateを補間する`scene-clock.ts`
- keyframe間のbrightness / saturation / warmth / sunset / night / lamp / sky parameters
- root CSS variablesを1秒ごとに更新するhook
- Ambient Roomだけに保守的なCSS color-grade filterを適用
- debug:
  - `?sceneTime=17:30`: 時刻固定
  - `?sceneSpeed=720`: 720倍速
  - `?sceneTime=00:00&sceneSpeed=720`: 24hを2分でレビュー
- Scene Clock / Ambient compatibility tests
- technical design更新

## Rollout note

このPRでは既存production RoomをAmbientへopt-inしないため、マージしても既存Roomの見た目は変わらない。実際の視覚評価は後続PoCで行う。

## Non-goals

- PixiJS/WebGL
- Living scene assets/effects
- page transitions
- real weather API
- room seat/layout changes

## Verification

ローカルコマンドはこのconnector環境では実行していない。GitHub ActionsのBuild / Biome / Jest / CI Gateを最終ゲートとする。
