### PR TITLE
Live Room Scenes: 2D動的ルーム基盤とLume PoCを統合

### DIFF
--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -85,3 +85,15 @@ Changes to storage, forwarding, archival, or deletion must also be checked again
 **Current fact:** the monitor participates in max-seat control as described above.
 
 **Design direction:** prefer moving control decisions out of the presentation client so the monitor can eventually become a read/render-only component. This is a target boundary, not a statement that migration is complete. Until code changes remove the request path, reviews and tests must assume the current control loop exists.
+
+## Livestream room visual boundary
+
+Room visuals are being evolved behind a compatibility boundary so room/seat control semantics stay independent from optional visual enhancement.
+
+- `RoomLayout.floor_image` remains the required static room asset and fallback.
+- `RoomLayout.scene` is optional. Omission means the room stays static.
+- Seat boxes, names, work content, room capacity, and paging remain in the existing React/DOM and layout paths.
+- Scene loading must never block page navigation.
+- Dynamic scene rendering must not change basic/temporary room seat counts or desired-seat calculations.
+
+The staged design and rollout contract are documented in [`live-room-scenes.md`](./live-room-scenes.md).

--- a/docs/development/live-room-scenes-rollout.md
+++ b/docs/development/live-room-scenes-rollout.md
@@ -1,0 +1,258 @@
+# Live Room Scenes rollout runbook
+
+This runbook covers preview, OBS acceptance, production enablement, monitoring, and rollback for Live Room Scenes.
+
+Technical architecture: [Live Room Scenes technical design](./live-room-scenes.md)
+
+## Safety model
+
+Static rendering is the authoritative fallback.
+
+A room may contain a `scene` config while production remains completely Static. Ambient/Living rendering requires an explicit build-time opt-in:
+
+```text
+NEXT_PUBLIC_LIVE_ROOM_SCENES_ENABLED=true
+```
+
+If the variable is missing or not exactly `true`, Live Room Scenes stay disabled.
+
+The runtime emergency kill switch is:
+
+```text
+?liveScenes=off
+```
+
+It overrides an enabled build without requiring a rebuild.
+
+## Phase 0: Static baseline
+
+Before enabling scenes, verify the same build with:
+
+```text
+NEXT_PUBLIC_LIVE_ROOM_SCENES_ENABLED=false
+```
+
+or with the variable omitted.
+
+Acceptance:
+
+- room paging behaves exactly as before;
+- seat count/order and max-seat behavior are unchanged;
+- `CafeRainyRoom` renders its existing `floor_image`;
+- no Living canvas is mounted;
+- the root element exposes `data-live-room-scenes="off"`.
+
+Do not proceed if the Static baseline differs from the current production monitor.
+
+## Phase 1: compressed visual preview
+
+Use a non-production DEBUG build. DEBUG changes other monitor behavior, so do not use this URL as the public production source.
+
+Build with:
+
+```text
+NEXT_PUBLIC_DEBUG=true
+NEXT_PUBLIC_LIVE_ROOM_SCENES_ENABLED=false
+```
+
+Then open:
+
+```text
+?liveScenes=on&sceneTime=00:00&sceneSpeed=720
+```
+
+This compresses 24 scene hours into two real minutes.
+
+Review at minimum:
+
+- dawn transition around 04:55 JST;
+- day around 09:15 JST;
+- sunset around 17:40 JST;
+- night around 19:55 JST;
+- midnight around 00:25 JST.
+
+For Lume / Main Café Floor / Rainy, verify:
+
+- rain stays visually sparse and slow;
+- rain remains inside the intended window area;
+- sunset/night grading does not obscure furniture or room identity;
+- lamp glow strengthens gradually rather than flashing;
+- seat boxes, names, work labels, and partitions remain above the scene;
+- there is no camera or furniture motion.
+
+Also check the exact anchor states with frozen time, for example:
+
+```text
+?liveScenes=on&sceneTime=09:15
+?liveScenes=on&sceneTime=17:40
+?liveScenes=on&sceneTime=19:55
+?liveScenes=on&sceneTime=00:25
+```
+
+## Phase 2: OBS smoke test
+
+Use the same browser-source dimensions and output path as production:
+
+- browser source: 1920x1080;
+- target scene animation: max 30fps;
+- normal production room paging;
+- existing stream encoder settings unchanged.
+
+Run both states against the same machine/session:
+
+1. Static baseline with `?liveScenes=off`.
+2. Living enabled with the query override removed.
+
+Observe:
+
+- OBS rendering lag;
+- OBS encoding lag;
+- dropped frames;
+- browser/CEF process CPU and GPU usage;
+- browser/CEF memory;
+- room-switch latency;
+- visible tearing, blank frames, or canvas flashes.
+
+Acceptance is comparative, not an invented absolute GPU percentage: enabling scenes must not introduce sustained render/encode lag, a new dropped-frame pattern, or a steadily growing browser-memory trend relative to the Static baseline.
+
+Run the smoke comparison for at least 30 minutes and include repeated page switches through Lume.
+
+## Phase 3: recovery checks
+
+Before production enablement, prove each fallback path.
+
+### Runtime kill switch
+
+While scenes are enabled, append:
+
+```text
+?liveScenes=off
+```
+
+Refresh the OBS browser source.
+
+Expected:
+
+- Lume immediately returns to the original Static image;
+- seat/UI behavior is unchanged;
+- no rebuild is required.
+
+Remove the query parameter and refresh to re-enable only after the issue is understood.
+
+### WebGL context loss
+
+Where browser developer tooling permits safe context-loss simulation:
+
+1. Keep Lume active.
+2. Trigger WebGL context loss.
+3. Confirm the Living layer disappears and Static remains.
+4. Restore the context.
+5. Confirm Living resumes only if Lume is still the active attached room.
+
+Repeat while switching away from Lume before context restoration.
+
+Expected: the old room must not restart after the delayed restore.
+
+### Initialization failure
+
+Use a test/debug environment where WebGL/Pixi initialization can be made unavailable.
+
+Expected:
+
+- Static image remains visible;
+- page switching continues;
+- a later activation can retry initialization.
+
+## Phase 4: soak test
+
+Before treating Live Room Scenes as production-stable:
+
+1. Run at least a two-hour non-public OBS soak with normal room paging.
+2. Record browser/CEF memory near the start and periodically during the run.
+3. Confirm memory reaches a stable range rather than increasing with every Lume activation.
+4. Confirm no accumulation of canvases or additional WebGL contexts.
+5. Confirm no render/encode lag appears after repeated activation/deactivation.
+
+After initial production enablement, keep the first 24 hours as a monitored canary period. The feature should not be considered fully rolled out until that period completes without a scene-related rollback.
+
+## Production enablement
+
+Only after the preceding checks pass:
+
+1. Build/deploy with:
+
+   ```text
+   NEXT_PUBLIC_LIVE_ROOM_SCENES_ENABLED=true
+   ```
+
+2. Keep the normal production URL without a `liveScenes` force-on parameter.
+3. Confirm the root element exposes `data-live-room-scenes="on"`.
+4. Observe the first Lume activation and at least one room switch away/back.
+5. Keep `?liveScenes=off` ready as the first rollback action.
+
+Because `NEXT_PUBLIC_*` configuration is bundled into client code, changing the environment variable requires rebuilding/redeploying the monitor. The URL kill switch does not.
+
+## Rollback
+
+Use the smallest rollback that restores a stable stream.
+
+### Level 1: immediate runtime rollback
+
+Append `?liveScenes=off` to the OBS browser-source URL and refresh the source.
+
+Use this first for:
+
+- unexpected visual artifacts;
+- GPU/CPU pressure;
+- rendering/encoding lag;
+- WebGL instability;
+- suspected memory growth.
+
+### Level 2: persistent configuration rollback
+
+Set:
+
+```text
+NEXT_PUBLIC_LIVE_ROOM_SCENES_ENABLED=false
+```
+
+then rebuild/redeploy.
+
+This restores Static rendering without reverting the feature code.
+
+### Level 3: code rollback
+
+Only if Static behavior is affected despite the feature switch being off, revert the Live Room Scenes integration. This would violate the project invariant and should be treated as a release-blocking defect.
+
+## Go / no-go checklist
+
+Code/CI:
+
+- [ ] Biome passes
+- [ ] Jest passes
+- [ ] Next production build passes
+- [ ] Static fallback tests pass
+- [ ] rollout switch tests pass
+- [ ] WebGL recovery tests pass
+
+Visual:
+
+- [ ] compressed 24h Lume preview reviewed
+- [ ] anchor times reviewed
+- [ ] seat/name/work readability preserved
+- [ ] motion remains calm enough for a work stream
+
+OBS:
+
+- [ ] 30-minute Static vs Living smoke comparison passes
+- [ ] runtime kill switch verified
+- [ ] context-loss fallback verified where tooling allows
+- [ ] two-hour soak passes
+- [ ] no monotonic memory growth observed
+
+Production:
+
+- [ ] explicit enable flag set only after acceptance
+- [ ] first activation monitored
+- [ ] first 24 hours treated as canary
+- [ ] rollback URL documented for the operator

--- a/docs/development/live-room-scenes.md
+++ b/docs/development/live-room-scenes.md
@@ -147,9 +147,10 @@ The first Living profile is `lume-rainy-poc`, attached only to `CafeRainyRoom`.
 The source room image already contains the architectural composition, rain-streaked glass, and warm practical lighting. The PoC therefore does **not** replace or split the static image. It adds only transparent vector primitives:
 
 - 24 deterministic, slow rain streaks placed inside selected window panes;
-- a conservative full-room cool veil controlled by `--scene-night-amount`;
+- continuous base-image color grading from Scene Clock brightness / saturation / warmth / night values;
+- a light full-room cool veil controlled by `--scene-night-amount`;
 - a slightly stronger cool tint over window panes;
-- a small sunset warmth veil controlled by `--scene-sunset-amount`;
+- a restrained sunset warmth veil controlled by `--scene-sunset-amount`;
 - layered warm circles around existing lamp positions controlled by `--scene-lamp-intensity`.
 
 Scene Clock CSS variables are sampled once per second and eased on the Pixi ticker. Rain position updates every frame, but the particle count is deliberately small to avoid high-frequency compression noise.

--- a/docs/development/live-room-scenes.md
+++ b/docs/development/live-room-scenes.md
@@ -83,7 +83,7 @@ Layer/asset schema is intentionally deferred until the renderer PR so the config
 3. PixiJS/WebGL renderer lifecycle and fallback. **Implemented:** PixiJS is loaded only for Living rooms; one shared WebGL Application moves between active room hosts and stops on hidden pages.
 4. One Living Room PoC. **Implemented on the integration branch:** Lume / Main Café Floor / Rainy uses slow window rain, continuous time tint, and lamp glow over the existing static room image.
 5. Performance, asset lifecycle, context-loss/error handling. **Implemented:** Living rendering is capped at 30fps, transient initialization can retry, and an active scene can resume after WebGL context restoration without reviving a hidden room.
-6. Production documentation, soak-test procedure, rollout controls.
+6. Production documentation, soak-test procedure, rollout controls. **Implemented:** fail-closed environment opt-in, production URL kill switch, and an OBS acceptance/rollback runbook.
 
 All intermediate PRs target `feature/live-room-scenes`. Only the final integration PR targets `dev`, and that PR must not be merged by an agent.
 
@@ -179,3 +179,17 @@ The Living runtime is designed for a long-running OBS browser source rather than
 - Destroy removes both context-loss and context-restored listeners and invalidates pending recovery.
 
 This recovery path deliberately does not add a separate timer/polling loop. Browser context restoration remains event-driven, while ordinary page activity remains controlled by the existing room `display` state.
+
+
+## Rollout controls
+
+Live Room Scenes do not activate merely because a room contains a `scene` config.
+
+- `NEXT_PUBLIC_LIVE_ROOM_SCENES_ENABLED=true` is required to enable Ambient/Living rendering in a normal build.
+- Missing, `false`, or any other value keeps room rendering Static.
+- `?liveScenes=off`, `false`, or `0` disables scenes at runtime even when the build is enabled. This is the production emergency kill switch.
+- URL force-on is restricted to DEBUG builds: `?liveScenes=on`, `true`, or `1`.
+- Until Next router query state is ready, scenes remain disabled. This prevents a short Living flash before a URL kill switch is parsed.
+- When scenes are disabled, the Scene Clock CSS-variable interval does not run and Living canvases are not mounted.
+
+Operational verification and rollback steps are documented in [Live Room Scenes rollout runbook](./live-room-scenes-rollout.md).

--- a/docs/development/live-room-scenes.md
+++ b/docs/development/live-room-scenes.md
@@ -79,7 +79,7 @@ Layer/asset schema is intentionally deferred until the renderer PR so the config
 ## Rollout stack
 
 1. Static compatibility boundary and types.
-2. Continuous Scene Clock and Ambient mode.
+2. Continuous Scene Clock and Ambient mode. **Implemented:** one JST clock writes CSS variables without per-frame React state; Ambient rooms consume a conservative CSS color-grade filter.
 3. PixiJS/WebGL renderer lifecycle and fallback.
 4. One Living Room PoC.
 5. Performance, asset lifecycle, context-loss/error handling.
@@ -106,3 +106,17 @@ Every stage keeps the smallest deterministic contract possible:
 - real weather API integration
 - changing room seat counts or ordering
 - requiring scene assets for every new room
+
+## Scene Clock debug controls
+
+Debug query parameters are honored only when `NEXT_PUBLIC_DEBUG=true`.
+
+- `?sceneTime=17:30` freezes the Scene Clock at 17:30 JST.
+- `?sceneSpeed=720` accelerates the current Scene Clock 720x.
+- `?sceneTime=00:00&sceneSpeed=720` reviews a full 24-hour cycle in two real minutes.
+
+The normal clock updates root CSS variables once per second without putting Scene Clock state into React render state. Static rooms do not consume these variables.
+
+### Ambient implementation
+
+Ambient remains an opt-in room mode and requires no assets beyond `floor_image`. The initial implementation applies a deliberately conservative CSS filter driven by continuous Scene Clock parameters. No existing production room is opted in by this PR, so rollout can be reviewed separately from the clock/runtime change.

--- a/docs/development/live-room-scenes.md
+++ b/docs/development/live-room-scenes.md
@@ -1,0 +1,108 @@
+# Live Room Scenes technical design
+
+This document is the implementation contract for incremental 2D motion in the YouTube livestream monitor. Product/visual intent is maintained in Notion's **Live Scene / Motion Bible v0.1**; this file records repository/runtime boundaries.
+
+- Notion: https://app.notion.com/p/3d5357a8d0ce81748b20fe925228ab54
+- Tracking issue: https://github.com/kani3camp/youtube-study-space/issues/1069
+
+## Goal
+
+Allow rooms to opt into time-aware ambient or living 2D visuals without making scene authoring a prerequisite for adding a room.
+
+## Invariants
+
+1. `floor_image` remains the static source and fallback.
+2. A room with no `scene` config behaves as it does before this project.
+3. Seat DOM, user/work labels, room capacity, page order, and max-seat control stay outside the scene renderer.
+4. Page navigation is not delayed by scene initialization or asset loading.
+5. Hidden pages must not keep expensive animation work running.
+6. Runtime failures fall back to static rendering rather than blanking the room.
+
+## Ownership boundary
+
+```mermaid
+flowchart TD
+    Clock[JST Clock] --> SceneTime[Scene time model]
+    Layout[RoomLayout] --> Visual[RoomVisual]
+    Static[floor_image] --> Visual
+    SceneTime --> Enhancement[Optional scene enhancement]
+    Layout --> Seats[Existing seat/layout DOM]
+    Enhancement --> Visual
+    Visual --> Frame[Room frame]
+    Seats --> Frame
+```
+
+### React / DOM owns
+
+- room page selection and immediate page switching
+- seat positions and seat state
+- user display name and work content
+- existing monitor UI
+- current max-seat control behavior
+
+### Scene layer owns
+
+- background color grading
+- sky/outside layers
+- ambient/window/lamp light
+- slow weather/environment motion
+- renderer lifecycle and fallback
+
+## Configuration levels
+
+### Static
+
+No `scene` property. Only `floor_image` is required.
+
+### Ambient
+
+```ts
+scene: {
+  mode: 'ambient',
+  profile: 'neutral-interior',
+}
+```
+
+Ambient must remain possible with the room image alone. Profile names and actual grading parameters are deferred to the Scene Clock/Ambient PR.
+
+### Living
+
+```ts
+scene: {
+  mode: 'living',
+  profile: 'window-lounge',
+}
+```
+
+Layer/asset schema is intentionally deferred until the renderer PR so the configuration is derived from implemented primitives instead of speculative types.
+
+## Rollout stack
+
+1. Static compatibility boundary and types.
+2. Continuous Scene Clock and Ambient mode.
+3. PixiJS/WebGL renderer lifecycle and fallback.
+4. One Living Room PoC.
+5. Performance, asset lifecycle, context-loss/error handling.
+6. Production documentation, soak-test procedure, rollout controls.
+
+All intermediate PRs target `feature/live-room-scenes`. Only the final integration PR targets `dev`, and that PR must not be merged by an agent.
+
+## Verification strategy
+
+Every stage keeps the smallest deterministic contract possible:
+
+- component tests for static fallback/compatibility;
+- unit tests for time interpolation and debug time;
+- lifecycle/error tests around renderer activation and cleanup;
+- normal monitor gates: `pnpm check`, `pnpm test --runInBand`, `pnpm build`;
+- final runtime acceptance on the streaming PC in OBS at 1920x1080 / 30fps;
+- long-running soak test before production enablement.
+
+## Explicit non-goals
+
+- 3D rendering
+- camera-heavy room transitions
+- changing page-switch behavior
+- real weather API integration
+- changing room seat counts or ordering
+- requiring scene assets for every new room

--- a/docs/development/live-room-scenes.md
+++ b/docs/development/live-room-scenes.md
@@ -82,7 +82,7 @@ Layer/asset schema is intentionally deferred until the renderer PR so the config
 2. Continuous Scene Clock and Ambient mode. **Implemented:** one JST clock writes CSS variables without per-frame React state; Ambient rooms consume a conservative CSS color-grade filter.
 3. PixiJS/WebGL renderer lifecycle and fallback. **Implemented:** PixiJS is loaded only for Living rooms; one shared WebGL Application moves between active room hosts and stops on hidden pages.
 4. One Living Room PoC. **Implemented on the integration branch:** Lume / Main Café Floor / Rainy uses slow window rain, continuous time tint, and lamp glow over the existing static room image.
-5. Performance, asset lifecycle, context-loss/error handling.
+5. Performance, asset lifecycle, context-loss/error handling. **Implemented:** Living rendering is capped at 30fps, transient initialization can retry, and an active scene can resume after WebGL context restoration without reviving a hidden room.
 6. Production documentation, soak-test procedure, rollout controls.
 
 All intermediate PRs target `feature/live-room-scenes`. Only the final integration PR targets `dev`, and that PR must not be merged by an agent.
@@ -165,3 +165,17 @@ Living effects render above the room image but below seat and partition UI:
 3. seat / partition UI
 
 This ensures environmental motion cannot reduce seat text readability.
+
+
+## Runtime hardening
+
+The Living runtime is designed for a long-running OBS browser source rather than a short interactive session.
+
+- Pixi's private ticker is capped at **30fps**, matching the target livestream frame rate and avoiding unnecessary 60fps scene updates.
+- A failed initial Pixi/WebGL initialization leaves the static room visible and clears the cached failed promise. A later room activation can retry instead of permanently disabling Living scenes for the tab.
+- On `webglcontextlost`, the active enhancement is stopped and hidden immediately while the static room remains visible.
+- On `webglcontextrestored`, the previous Living scene is reactivated only when its host is still attached and has not been deactivated during the outage.
+- Page switching or unmounting clears any pending recovery, so a previously visible room cannot unexpectedly restart after a delayed WebGL restore.
+- Destroy removes both context-loss and context-restored listeners and invalidates pending recovery.
+
+This recovery path deliberately does not add a separate timer/polling loop. Browser context restoration remains event-driven, while ordinary page activity remains controlled by the existing room `display` state.

--- a/docs/development/live-room-scenes.md
+++ b/docs/development/live-room-scenes.md
@@ -81,7 +81,7 @@ Layer/asset schema is intentionally deferred until the renderer PR so the config
 1. Static compatibility boundary and types.
 2. Continuous Scene Clock and Ambient mode. **Implemented:** one JST clock writes CSS variables without per-frame React state; Ambient rooms consume a conservative CSS color-grade filter.
 3. PixiJS/WebGL renderer lifecycle and fallback. **Implemented:** PixiJS is loaded only for Living rooms; one shared WebGL Application moves between active room hosts and stops on hidden pages.
-4. One Living Room PoC.
+4. One Living Room PoC. **Implemented on the integration branch:** Lume / Main Café Floor / Rainy uses slow window rain, continuous time tint, and lamp glow over the existing static room image.
 5. Performance, asset lifecycle, context-loss/error handling.
 6. Production documentation, soak-test procedure, rollout controls.
 
@@ -138,3 +138,30 @@ Runtime rules:
 - The renderer explicitly prefers WebGL 2, transparent output, one physical output pixel per scene pixel, and a private ticker.
 
 The renderer currently has no Living primitives or assets. Those are introduced by the PoC PR after the lifecycle boundary is verified.
+
+
+## Lume Living PoC
+
+The first Living profile is `lume-rainy-poc`, attached only to `CafeRainyRoom`.
+
+The source room image already contains the architectural composition, rain-streaked glass, and warm practical lighting. The PoC therefore does **not** replace or split the static image. It adds only transparent vector primitives:
+
+- 24 deterministic, slow rain streaks placed inside selected window panes;
+- a conservative full-room cool veil controlled by `--scene-night-amount`;
+- a slightly stronger cool tint over window panes;
+- a small sunset warmth veil controlled by `--scene-sunset-amount`;
+- layered warm circles around existing lamp positions controlled by `--scene-lamp-intensity`.
+
+Scene Clock CSS variables are sampled once per second and eased on the Pixi ticker. Rain position updates every frame, but the particle count is deliberately small to avoid high-frequency compression noise.
+
+The profile is defined in the public codebase and requires no new binary scene assets. The existing room image remains deployment-provided and is still the complete fallback.
+
+### Stacking invariant
+
+Living effects render above the room image but below seat and partition UI:
+
+1. static room image
+2. Living Scene canvas
+3. seat / partition UI
+
+This ensures environmental motion cannot reduce seat text readability.

--- a/docs/development/live-room-scenes.md
+++ b/docs/development/live-room-scenes.md
@@ -80,7 +80,7 @@ Layer/asset schema is intentionally deferred until the renderer PR so the config
 
 1. Static compatibility boundary and types.
 2. Continuous Scene Clock and Ambient mode. **Implemented:** one JST clock writes CSS variables without per-frame React state; Ambient rooms consume a conservative CSS color-grade filter.
-3. PixiJS/WebGL renderer lifecycle and fallback.
+3. PixiJS/WebGL renderer lifecycle and fallback. **Implemented:** PixiJS is loaded only for Living rooms; one shared WebGL Application moves between active room hosts and stops on hidden pages.
 4. One Living Room PoC.
 5. Performance, asset lifecycle, context-loss/error handling.
 6. Production documentation, soak-test procedure, rollout controls.
@@ -120,3 +120,21 @@ The normal clock updates root CSS variables once per second without putting Scen
 ### Ambient implementation
 
 Ambient remains an opt-in room mode and requires no assets beyond `floor_image`. The initial implementation applies a deliberately conservative CSS filter driven by continuous Scene Clock parameters. No existing production room is opted in by this PR, so rollout can be reviewed separately from the clock/runtime change.
+
+
+## Living renderer runtime
+
+Living mode keeps the static `floor_image` in the DOM at all times. The PixiJS canvas is a transparent enhancement layer above it.
+
+Runtime rules:
+
+- PixiJS is dynamically imported only when a Living room becomes active.
+- One `Application` is shared by the browser tab rather than one WebGL context per room.
+- The shared canvas is moved to the currently active Living room host.
+- Hidden room pages deactivate the runtime and stop its ticker.
+- A page switch never waits for PixiJS initialization; the static image is already visible.
+- Initialization failure leaves the static image untouched.
+- `webglcontextlost` hides/stops the enhancement layer and keeps the static fallback visible.
+- The renderer explicitly prefers WebGL 2, transparent output, one physical output pixel per scene pixel, and a private ticker.
+
+The renderer currently has no Living primitives or assets. Those are introduced by the PoC PR after the lifecycle boundary is verified.

--- a/youtube-monitor/README.md
+++ b/youtube-monitor/README.md
@@ -23,12 +23,15 @@ All variables below use the `NEXT_PUBLIC_` prefix and are bundled into browser-v
 | `NEXT_PUBLIC_DEBUG` | Enables monitor debug behavior. Must be `true` or `false`. | Yes |
 | `NEXT_PUBLIC_CHANNEL_GL` | Selects channel-specific behavior. Must be `true` or `false`. | Yes |
 | `NEXT_PUBLIC_ROOM_CONFIG` | Selects the room/layout configuration. Must be a non-empty string. | Yes |
+| `NEXT_PUBLIC_LIVE_ROOM_SCENES_ENABLED` | Opt-in rollout switch for Ambient/Living room scenes. Only the literal `true` enables scenes; missing/other values stay Static. | Yes |
 | `NEXT_PUBLIC_API_ENDPOINT` | Base URL for monitor API calls such as `/set_desired_max_seats`. | Yes |
 | `NEXT_PUBLIC_API_KEY` | Client-side API request configuration used by the fetcher. It must not be treated as a server secret because it is shipped to the browser. | Yes |
 | `NEXT_PUBLIC_FIREBASE_PROJECT_ID` | Firebase/Firestore project identifier used by the client. | Yes |
 | `NEXT_PUBLIC_FIREBASE_API_KEY` | Firebase web API key used by the client SDK. It is browser-visible configuration, not a server credential. | Yes |
 
-The validation/consumers are in `src/lib/constants.ts`, `src/lib/api-config.ts`, `src/lib/fetcher.ts`, and `src/lib/firestore.ts`.
+The validation/consumers are in `src/lib/constants.ts`, `src/lib/api-config.ts`, `src/lib/fetcher.ts`, `src/lib/firestore.ts`, and `src/lib/live-room-scenes.ts`.
+
+Live Room Scenes are fail-closed for rollout: omitting `NEXT_PUBLIC_LIVE_ROOM_SCENES_ENABLED` keeps every room on its Static `floor_image`. When scenes are enabled, appending `?liveScenes=off` to the monitor URL is a production-safe runtime kill switch. URL force-on (`?liveScenes=on`) is accepted only when `NEXT_PUBLIC_DEBUG=true`.
 
 ## Verification without real external connections
 
@@ -45,6 +48,7 @@ For a production build, use the same non-secret dummy configuration as CI when t
 NEXT_PUBLIC_DEBUG=false \
 NEXT_PUBLIC_CHANNEL_GL=false \
 NEXT_PUBLIC_ROOM_CONFIG=DEV \
+NEXT_PUBLIC_LIVE_ROOM_SCENES_ENABLED=false \
 NEXT_PUBLIC_API_ENDPOINT=http://localhost:3000 \
 NEXT_PUBLIC_API_KEY=ci-dummy-api-key \
 NEXT_PUBLIC_FIREBASE_PROJECT_ID=ci-dummy-project \

--- a/youtube-monitor/package.json
+++ b/youtube-monitor/package.json
@@ -37,6 +37,7 @@
 		"music-metadata": "^11.14.0",
 		"next": "^16.2.12",
 		"next-i18next": "^16.0.8",
+		"pixi.js": "^8.20.1",
 		"react": "^18.3.1",
 		"react-circular-progressbar": "^2.2.0",
 		"react-dom": "^18.3.1",

--- a/youtube-monitor/pnpm-lock.yaml
+++ b/youtube-monitor/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       next-i18next:
         specifier: ^16.0.8
         version: 16.0.8(@types/react@18.3.28)(i18next@26.0.9(typescript@5.9.3))(next@16.2.12(@babel/core@7.29.7)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.102.0))(react-i18next@17.0.6(i18next@26.0.9(typescript@5.9.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(react@18.3.1)
+      pixi.js:
+        specifier: ^8.20.1
+        version: 8.20.1
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -2165,6 +2168,9 @@ packages:
     resolution: {integrity: sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==}
     engines: {node: '>= 10.0.0'}
 
+  '@pixi/colord@2.9.6':
+    resolution: {integrity: sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -2554,6 +2560,9 @@ packages:
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
+  '@types/earcut@3.0.0':
+    resolution: {integrity: sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==}
+
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
@@ -2802,6 +2811,13 @@ packages:
 
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
+
+  '@webgpu/types@0.1.72':
+    resolution: {integrity: sha512-0cF7RFM2edNoiIS1ODJp0/Gzv4/xSXhwoR0YCza+OWpJWtn4wmo9DvK91aLlH9+uUnwIriP7ZiC3WitmyhuzBw==}
+
+  '@xmldom/xmldom@0.8.15':
+    resolution: {integrity: sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==}
+    engines: {node: '>=10.0.0'}
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -3199,6 +3215,9 @@ packages:
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
+  earcut@3.2.3:
+    resolution: {integrity: sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==}
+
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
@@ -3290,6 +3309,9 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -3400,6 +3422,9 @@ packages:
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
+
+  gifuct-js@2.1.2:
+    resolution: {integrity: sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==}
 
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
@@ -3578,6 +3603,9 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  ismobilejs@1.1.1:
+    resolution: {integrity: sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -3770,6 +3798,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  js-binary-schema-parser@2.0.3:
+    resolution: {integrity: sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -4046,6 +4077,9 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parse-svg-path@0.2.0:
+    resolution: {integrity: sha512-Tf7FFIrguPKQwzD4pWnYkR2VOv3raoHeKED80Bm+BYHI3KxC8KsgsGC5+fSMzAGDA6UEk4bHvmi+RsjmL3khpg==}
+
   parse5@7.3.0:
     resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
@@ -4094,6 +4128,9 @@ packages:
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
+
+  pixi.js@8.20.1:
+    resolution: {integrity: sha512-akLVBMLvQbaEViqsmVraK0Njer1q4Q4lm4iNKuzvBiFrV8q+6/+HluJN3sWIwO663IBeQtUUS/CaXFJZs6ffXQ==}
 
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
@@ -4540,6 +4577,10 @@ packages:
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tiny-lru@11.4.7:
+    resolution: {integrity: sha512-w/Te7uMUVeH0CR8vZIjr+XiN41V+30lkDdK+NRIDCUYKKuL9VcmaUEmaPISuwGhLlrTGh5yu18lENtR9axSxYw==}
+    engines: {node: '>=12'}
 
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
@@ -7038,6 +7079,8 @@ snapshots:
       '@parcel/watcher-win32-x64': 2.6.0
     optional: true
 
+  '@pixi/colord@2.9.6': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -7395,6 +7438,8 @@ snapshots:
 
   '@types/doctrine@0.0.9': {}
 
+  '@types/earcut@3.0.0': {}
+
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
@@ -7650,6 +7695,10 @@ snapshots:
       '@xtuc/long': 4.2.2
 
   '@webcontainer/env@1.1.1': {}
+
+  '@webgpu/types@0.1.72': {}
+
+  '@xmldom/xmldom@0.8.15': {}
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -8012,6 +8061,8 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
+  earcut@3.2.3: {}
+
   eastasianwidth@0.2.0: {}
 
   electron-to-chromium@1.5.376: {}
@@ -8123,6 +8174,8 @@ snapshots:
   estree-walker@2.0.2: {}
 
   esutils@2.0.3: {}
+
+  eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
 
@@ -8260,6 +8313,10 @@ snapshots:
   get-package-type@0.1.0: {}
 
   get-stream@6.0.1: {}
+
+  gifuct-js@2.1.2:
+    dependencies:
+      js-binary-schema-parser: 2.0.3
 
   glob-to-regexp@0.4.1: {}
 
@@ -8424,6 +8481,8 @@ snapshots:
       is-inside-container: 1.0.0
 
   isexe@2.0.0: {}
+
+  ismobilejs@1.1.1: {}
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -8836,6 +8895,8 @@ snapshots:
   jiti@2.6.1:
     optional: true
 
+  js-binary-schema-parser@2.0.3: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
@@ -9146,6 +9207,8 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parse-svg-path@0.2.0: {}
+
   parse5@7.3.0:
     dependencies:
       entities: 6.0.1
@@ -9179,6 +9242,19 @@ snapshots:
   picomatch@4.0.5: {}
 
   pirates@4.0.7: {}
+
+  pixi.js@8.20.1:
+    dependencies:
+      '@pixi/colord': 2.9.6
+      '@types/earcut': 3.0.0
+      '@webgpu/types': 0.1.72
+      '@xmldom/xmldom': 0.8.15
+      earcut: 3.2.3
+      eventemitter3: 5.0.4
+      gifuct-js: 2.1.2
+      ismobilejs: 1.1.1
+      parse-svg-path: 0.2.0
+      tiny-lru: 11.4.7
 
   pkg-dir@4.2.0:
     dependencies:
@@ -9647,6 +9723,8 @@ snapshots:
       minimatch: 3.1.5
 
   tiny-invariant@1.3.3: {}
+
+  tiny-lru@11.4.7: {}
 
   tinyglobby@0.2.17:
     dependencies:

--- a/youtube-monitor/src/components/LivingSceneLayer.test.tsx
+++ b/youtube-monitor/src/components/LivingSceneLayer.test.tsx
@@ -18,7 +18,12 @@ describe('LivingSceneLayer', () => {
 
 	test('activates the shared runtime only while the room page is visible', async () => {
 		const { container, rerender } = render(
-			<LivingSceneLayer active={false} width={1520} height={900} />,
+			<LivingSceneLayer
+				active={false}
+				width={1520}
+				height={900}
+				profile="lume-rainy-poc"
+			/>,
 		)
 		const host = container.firstElementChild
 		expect(host).toBeInstanceOf(HTMLElement)
@@ -30,16 +35,31 @@ describe('LivingSceneLayer', () => {
 		expect(runtimeMock.deactivate).toHaveBeenCalledWith(host)
 
 		await act(async () => {
-			rerender(<LivingSceneLayer active={true} width={1520} height={900} />)
+			rerender(
+				<LivingSceneLayer
+					active={true}
+					width={1520}
+					height={900}
+					profile="lume-rainy-poc"
+				/>,
+			)
 		})
 
 		expect(runtimeMock.activate).toHaveBeenCalledWith({
 			host,
 			width: 1520,
 			height: 900,
+			profile: 'lume-rainy-poc',
 		})
 
-		rerender(<LivingSceneLayer active={false} width={1520} height={900} />)
+		rerender(
+			<LivingSceneLayer
+				active={false}
+				width={1520}
+				height={900}
+				profile="lume-rainy-poc"
+			/>,
+		)
 		expect(runtimeMock.deactivate).toHaveBeenCalledWith(host)
 	})
 })

--- a/youtube-monitor/src/components/LivingSceneLayer.test.tsx
+++ b/youtube-monitor/src/components/LivingSceneLayer.test.tsx
@@ -1,0 +1,45 @@
+import { act, render } from '@testing-library/react'
+import { livingSceneRuntime } from '../lib/living-scene-runtime'
+import LivingSceneLayer from './LivingSceneLayer'
+
+jest.mock('../lib/living-scene-runtime', () => ({
+	livingSceneRuntime: {
+		activate: jest.fn(() => Promise.resolve(true)),
+		deactivate: jest.fn(),
+	},
+}))
+
+const runtimeMock = livingSceneRuntime as jest.Mocked<typeof livingSceneRuntime>
+
+describe('LivingSceneLayer', () => {
+	beforeEach(() => {
+		jest.clearAllMocks()
+	})
+
+	test('activates the shared runtime only while the room page is visible', async () => {
+		const { container, rerender } = render(
+			<LivingSceneLayer active={false} width={1520} height={900} />,
+		)
+		const host = container.firstElementChild
+		expect(host).toBeInstanceOf(HTMLElement)
+		if (!(host instanceof HTMLElement)) {
+			throw new Error('living scene host was not rendered')
+		}
+
+		expect(runtimeMock.activate).not.toHaveBeenCalled()
+		expect(runtimeMock.deactivate).toHaveBeenCalledWith(host)
+
+		await act(async () => {
+			rerender(<LivingSceneLayer active={true} width={1520} height={900} />)
+		})
+
+		expect(runtimeMock.activate).toHaveBeenCalledWith({
+			host,
+			width: 1520,
+			height: 900,
+		})
+
+		rerender(<LivingSceneLayer active={false} width={1520} height={900} />)
+		expect(runtimeMock.deactivate).toHaveBeenCalledWith(host)
+	})
+})

--- a/youtube-monitor/src/components/LivingSceneLayer.tsx
+++ b/youtube-monitor/src/components/LivingSceneLayer.tsx
@@ -2,17 +2,20 @@ import type { FC } from 'react'
 import { useEffect, useRef } from 'react'
 import { livingSceneRuntime } from '../lib/living-scene-runtime'
 import * as styles from '../styles/LivingSceneLayer.styles'
+import type { LivingSceneProfile } from '../types/room-scene'
 
 type LivingSceneLayerProps = {
 	active: boolean
 	width: number
 	height: number
+	profile: LivingSceneProfile
 }
 
 const LivingSceneLayer: FC<LivingSceneLayerProps> = ({
 	active,
 	width,
 	height,
+	profile,
 }) => {
 	const hostRef = useRef<HTMLDivElement>(null)
 
@@ -27,11 +30,11 @@ const LivingSceneLayer: FC<LivingSceneLayerProps> = ({
 			return
 		}
 
-		void livingSceneRuntime.activate({ host, width, height })
+		void livingSceneRuntime.activate({ host, width, height, profile })
 		return () => {
 			livingSceneRuntime.deactivate(host)
 		}
-	}, [active, height, width])
+	}, [active, height, profile, width])
 
 	return <div ref={hostRef} css={styles.host} aria-hidden="true" />
 }

--- a/youtube-monitor/src/components/LivingSceneLayer.tsx
+++ b/youtube-monitor/src/components/LivingSceneLayer.tsx
@@ -1,0 +1,39 @@
+import type { FC } from 'react'
+import { useEffect, useRef } from 'react'
+import { livingSceneRuntime } from '../lib/living-scene-runtime'
+import * as styles from '../styles/LivingSceneLayer.styles'
+
+type LivingSceneLayerProps = {
+	active: boolean
+	width: number
+	height: number
+}
+
+const LivingSceneLayer: FC<LivingSceneLayerProps> = ({
+	active,
+	width,
+	height,
+}) => {
+	const hostRef = useRef<HTMLDivElement>(null)
+
+	useEffect(() => {
+		const host = hostRef.current
+		if (host === null) {
+			return
+		}
+
+		if (!active) {
+			livingSceneRuntime.deactivate(host)
+			return
+		}
+
+		void livingSceneRuntime.activate({ host, width, height })
+		return () => {
+			livingSceneRuntime.deactivate(host)
+		}
+	}, [active, height, width])
+
+	return <div ref={hostRef} css={styles.host} aria-hidden="true" />
+}
+
+export default LivingSceneLayer

--- a/youtube-monitor/src/components/RoomVisual.test.tsx
+++ b/youtube-monitor/src/components/RoomVisual.test.tsx
@@ -5,11 +5,12 @@ import RoomVisual from './RoomVisual'
 jest.mock('next/image', () => ({
 	__esModule: true,
 	default: (props: ComponentPropsWithoutRef<'img'>) => {
-		const { alt, height, src, width } = props
+		const { alt, height, src, style, width } = props
 		return (
 			<span
 				role="img"
 				aria-label={alt}
+				data-filter={style?.filter}
 				data-height={height}
 				data-src={typeof src === 'string' ? src : ''}
 				data-width={width}
@@ -32,6 +33,7 @@ describe('RoomVisual static compatibility', () => {
 		expect(image).toHaveAttribute('data-src', '/images/rooms/test-room.png')
 		expect(image).toHaveAttribute('data-width', '1520')
 		expect(image).toHaveAttribute('data-height', '900')
+		expect(image).not.toHaveAttribute('data-filter')
 	})
 
 	test('keeps rendering the static floor image when a scene config is present', () => {
@@ -44,9 +46,11 @@ describe('RoomVisual static compatibility', () => {
 			/>,
 		)
 
-		expect(screen.getByRole('img', { name: 'room image' })).toHaveAttribute(
-			'data-src',
-			'/images/rooms/test-room.png',
+		const image = screen.getByRole('img', { name: 'room image' })
+		expect(image).toHaveAttribute('data-src', '/images/rooms/test-room.png')
+		expect(image).toHaveAttribute(
+			'data-filter',
+			'var(--scene-ambient-filter, none)',
 		)
 	})
 

--- a/youtube-monitor/src/components/RoomVisual.test.tsx
+++ b/youtube-monitor/src/components/RoomVisual.test.tsx
@@ -4,8 +4,12 @@ import RoomVisual from './RoomVisual'
 
 jest.mock('./LivingSceneLayer', () => ({
 	__esModule: true,
-	default: ({ active }: { active: boolean }) => (
-		<span data-testid="living-scene-layer" data-active={String(active)} />
+	default: ({ active, profile }: { active: boolean; profile: string }) => (
+		<span
+			data-testid="living-scene-layer"
+			data-active={String(active)}
+			data-profile={profile}
+		/>
 	),
 }))
 
@@ -68,7 +72,7 @@ describe('RoomVisual static compatibility', () => {
 			<RoomVisual
 				active={true}
 				floorImage="/images/rooms/test-room.png"
-				scene={{ mode: 'living' }}
+				scene={{ mode: 'living', profile: 'lume-rainy-poc' }}
 				width={1520}
 				height={900}
 			/>,
@@ -78,10 +82,9 @@ describe('RoomVisual static compatibility', () => {
 			'data-src',
 			'/images/rooms/test-room.png',
 		)
-		expect(screen.getByTestId('living-scene-layer')).toHaveAttribute(
-			'data-active',
-			'true',
-		)
+		const livingLayer = screen.getByTestId('living-scene-layer')
+		expect(livingLayer).toHaveAttribute('data-active', 'true')
+		expect(livingLayer).toHaveAttribute('data-profile', 'lume-rainy-poc')
 	})
 
 	test('renders nothing when the room has no floor image', () => {

--- a/youtube-monitor/src/components/RoomVisual.test.tsx
+++ b/youtube-monitor/src/components/RoomVisual.test.tsx
@@ -2,6 +2,13 @@ import { render, screen } from '@testing-library/react'
 import type { ComponentPropsWithoutRef } from 'react'
 import RoomVisual from './RoomVisual'
 
+jest.mock('./LivingSceneLayer', () => ({
+	__esModule: true,
+	default: ({ active }: { active: boolean }) => (
+		<span data-testid="living-scene-layer" data-active={String(active)} />
+	),
+}))
+
 jest.mock('next/image', () => ({
 	__esModule: true,
 	default: (props: ComponentPropsWithoutRef<'img'>) => {
@@ -23,6 +30,7 @@ describe('RoomVisual static compatibility', () => {
 	test('renders the static floor image when no scene is configured', () => {
 		render(
 			<RoomVisual
+				active={true}
 				floorImage="/images/rooms/test-room.png"
 				width={1520}
 				height={900}
@@ -39,6 +47,7 @@ describe('RoomVisual static compatibility', () => {
 	test('keeps rendering the static floor image when a scene config is present', () => {
 		render(
 			<RoomVisual
+				active={true}
 				floorImage="/images/rooms/test-room.png"
 				scene={{ mode: 'ambient' }}
 				width={1520}
@@ -54,9 +63,30 @@ describe('RoomVisual static compatibility', () => {
 		)
 	})
 
+	test('keeps the static fallback while a living scene layer is active', () => {
+		render(
+			<RoomVisual
+				active={true}
+				floorImage="/images/rooms/test-room.png"
+				scene={{ mode: 'living' }}
+				width={1520}
+				height={900}
+			/>,
+		)
+
+		expect(screen.getByRole('img', { name: 'room image' })).toHaveAttribute(
+			'data-src',
+			'/images/rooms/test-room.png',
+		)
+		expect(screen.getByTestId('living-scene-layer')).toHaveAttribute(
+			'data-active',
+			'true',
+		)
+	})
+
 	test('renders nothing when the room has no floor image', () => {
 		const { container } = render(
-			<RoomVisual floorImage="" width={1520} height={900} />,
+			<RoomVisual active={true} floorImage="" width={1520} height={900} />,
 		)
 
 		expect(container).toBeEmptyDOMElement()

--- a/youtube-monitor/src/components/RoomVisual.test.tsx
+++ b/youtube-monitor/src/components/RoomVisual.test.tsx
@@ -62,7 +62,7 @@ describe('RoomVisual static compatibility', () => {
 		expect(image).not.toHaveAttribute('data-filter')
 	})
 
-	test('keeps rendering the static floor image when a scene config is present', () => {
+	test('color-grades an Ambient room while keeping its static floor image', () => {
 		render(
 			<RoomVisual
 				active={true}
@@ -81,7 +81,7 @@ describe('RoomVisual static compatibility', () => {
 		)
 	})
 
-	test('keeps the static fallback while a living scene layer is active', () => {
+	test('color-grades the static fallback while a Living scene layer is active', () => {
 		render(
 			<RoomVisual
 				active={true}
@@ -93,15 +93,15 @@ describe('RoomVisual static compatibility', () => {
 		)
 
 		expect(screen.getByRole('img', { name: 'room image' })).toHaveAttribute(
-			'data-src',
-			'/images/rooms/test-room.png',
+			'data-filter',
+			'var(--scene-ambient-filter, none)',
 		)
 		const livingLayer = screen.getByTestId('living-scene-layer')
 		expect(livingLayer).toHaveAttribute('data-active', 'true')
 		expect(livingLayer).toHaveAttribute('data-profile', 'lume-rainy-poc')
 	})
 
-	test('renders only the static fallback while Live Room Scenes is disabled', () => {
+	test('renders only the ungraded static fallback while Live Room Scenes is disabled', () => {
 		liveRoomScenesEnabledMock.mockReturnValue(false)
 		render(
 			<RoomVisual
@@ -113,9 +113,8 @@ describe('RoomVisual static compatibility', () => {
 			/>,
 		)
 
-		expect(screen.getByRole('img', { name: 'room image' })).toHaveAttribute(
-			'data-src',
-			'/images/rooms/test-room.png',
+		expect(screen.getByRole('img', { name: 'room image' })).not.toHaveAttribute(
+			'data-filter',
 		)
 		expect(screen.queryByTestId('living-scene-layer')).not.toBeInTheDocument()
 	})

--- a/youtube-monitor/src/components/RoomVisual.test.tsx
+++ b/youtube-monitor/src/components/RoomVisual.test.tsx
@@ -1,6 +1,16 @@
 import { render, screen } from '@testing-library/react'
 import type { ComponentPropsWithoutRef } from 'react'
+import { useLiveRoomScenesEnabled } from '../hooks/use-live-room-scenes-enabled'
 import RoomVisual from './RoomVisual'
+
+jest.mock('../hooks/use-live-room-scenes-enabled', () => ({
+	useLiveRoomScenesEnabled: jest.fn(() => true),
+}))
+
+const liveRoomScenesEnabledMock =
+	useLiveRoomScenesEnabled as jest.MockedFunction<
+		typeof useLiveRoomScenesEnabled
+	>
 
 jest.mock('./LivingSceneLayer', () => ({
 	__esModule: true,
@@ -31,6 +41,10 @@ jest.mock('next/image', () => ({
 }))
 
 describe('RoomVisual static compatibility', () => {
+	beforeEach(() => {
+		liveRoomScenesEnabledMock.mockReturnValue(true)
+	})
+
 	test('renders the static floor image when no scene is configured', () => {
 		render(
 			<RoomVisual
@@ -85,6 +99,42 @@ describe('RoomVisual static compatibility', () => {
 		const livingLayer = screen.getByTestId('living-scene-layer')
 		expect(livingLayer).toHaveAttribute('data-active', 'true')
 		expect(livingLayer).toHaveAttribute('data-profile', 'lume-rainy-poc')
+	})
+
+	test('renders only the static fallback while Live Room Scenes is disabled', () => {
+		liveRoomScenesEnabledMock.mockReturnValue(false)
+		render(
+			<RoomVisual
+				active={true}
+				floorImage="/images/rooms/test-room.png"
+				scene={{ mode: 'living', profile: 'lume-rainy-poc' }}
+				width={1520}
+				height={900}
+			/>,
+		)
+
+		expect(screen.getByRole('img', { name: 'room image' })).toHaveAttribute(
+			'data-src',
+			'/images/rooms/test-room.png',
+		)
+		expect(screen.queryByTestId('living-scene-layer')).not.toBeInTheDocument()
+	})
+
+	test('does not apply Ambient grading while Live Room Scenes is disabled', () => {
+		liveRoomScenesEnabledMock.mockReturnValue(false)
+		render(
+			<RoomVisual
+				active={true}
+				floorImage="/images/rooms/test-room.png"
+				scene={{ mode: 'ambient' }}
+				width={1520}
+				height={900}
+			/>,
+		)
+
+		expect(screen.getByRole('img', { name: 'room image' })).not.toHaveAttribute(
+			'data-filter',
+		)
 	})
 
 	test('renders nothing when the room has no floor image', () => {

--- a/youtube-monitor/src/components/RoomVisual.test.tsx
+++ b/youtube-monitor/src/components/RoomVisual.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react'
+import type { ComponentPropsWithoutRef } from 'react'
+import RoomVisual from './RoomVisual'
+
+jest.mock('next/image', () => ({
+	__esModule: true,
+	default: (props: ComponentPropsWithoutRef<'img'>) => {
+		const { alt, height, src, width } = props
+		return (
+			<span
+				role="img"
+				aria-label={alt}
+				data-height={height}
+				data-src={typeof src === 'string' ? src : ''}
+				data-width={width}
+			/>
+		)
+	},
+}))
+
+describe('RoomVisual static compatibility', () => {
+	test('renders the static floor image when no scene is configured', () => {
+		render(
+			<RoomVisual
+				floorImage="/images/rooms/test-room.png"
+				width={1520}
+				height={900}
+			/>,
+		)
+
+		const image = screen.getByRole('img', { name: 'room image' })
+		expect(image).toHaveAttribute('data-src', '/images/rooms/test-room.png')
+		expect(image).toHaveAttribute('data-width', '1520')
+		expect(image).toHaveAttribute('data-height', '900')
+	})
+
+	test('keeps rendering the static floor image when a scene config is present', () => {
+		render(
+			<RoomVisual
+				floorImage="/images/rooms/test-room.png"
+				scene={{ mode: 'ambient' }}
+				width={1520}
+				height={900}
+			/>,
+		)
+
+		expect(screen.getByRole('img', { name: 'room image' })).toHaveAttribute(
+			'data-src',
+			'/images/rooms/test-room.png',
+		)
+	})
+
+	test('renders nothing when the room has no floor image', () => {
+		const { container } = render(
+			<RoomVisual floorImage="" width={1520} height={900} />,
+		)
+
+		expect(container).toBeEmptyDOMElement()
+	})
+})

--- a/youtube-monitor/src/components/RoomVisual.tsx
+++ b/youtube-monitor/src/components/RoomVisual.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image'
 import type { FC } from 'react'
+import { useLiveRoomScenesEnabled } from '../hooks/use-live-room-scenes-enabled'
 import type { RoomSceneConfig } from '../types/room-scene'
 import LivingSceneLayer from './LivingSceneLayer'
 
@@ -25,12 +26,14 @@ const RoomVisual: FC<RoomVisualProps> = ({
 	active,
 	scene,
 }) => {
+	const liveRoomScenesEnabled = useLiveRoomScenesEnabled()
+
 	if (!floorImage) {
 		return null
 	}
 
 	const ambientStyle =
-		scene?.mode === 'ambient'
+		liveRoomScenesEnabled && scene?.mode === 'ambient'
 			? {
 					filter: 'var(--scene-ambient-filter, none)',
 					transition: 'filter 1s linear',
@@ -47,7 +50,7 @@ const RoomVisual: FC<RoomVisualProps> = ({
 				priority={true}
 				style={ambientStyle}
 			/>
-			{scene?.mode === 'living' && (
+			{liveRoomScenesEnabled && scene?.mode === 'living' && (
 				<LivingSceneLayer
 					active={active}
 					width={width}

--- a/youtube-monitor/src/components/RoomVisual.tsx
+++ b/youtube-monitor/src/components/RoomVisual.tsx
@@ -48,7 +48,12 @@ const RoomVisual: FC<RoomVisualProps> = ({
 				style={ambientStyle}
 			/>
 			{scene?.mode === 'living' && (
-				<LivingSceneLayer active={active} width={width} height={height} />
+				<LivingSceneLayer
+					active={active}
+					width={width}
+					height={height}
+					profile={scene.profile}
+				/>
 			)}
 		</>
 	)

--- a/youtube-monitor/src/components/RoomVisual.tsx
+++ b/youtube-monitor/src/components/RoomVisual.tsx
@@ -15,9 +15,9 @@ export type RoomVisualProps = {
 /**
  * Compatibility boundary for room visuals.
  *
- * Static room rendering remains authoritative in this PR. The optional scene
- * prop is accepted so later ambient/living renderers can be introduced behind
- * this component without changing seat/layout ownership.
+ * Static room rendering remains authoritative in this PR. Optional scene
+ * rendering only color-grades or layers on top of the existing floor image,
+ * so disabling scenes always returns to the original static room.
  */
 const RoomVisual: FC<RoomVisualProps> = ({
 	floorImage,
@@ -32,8 +32,8 @@ const RoomVisual: FC<RoomVisualProps> = ({
 		return null
 	}
 
-	const ambientStyle =
-		liveRoomScenesEnabled && scene?.mode === 'ambient'
+	const sceneColorGradeStyle =
+		liveRoomScenesEnabled && scene !== undefined
 			? {
 					filter: 'var(--scene-ambient-filter, none)',
 					transition: 'filter 1s linear',
@@ -48,7 +48,7 @@ const RoomVisual: FC<RoomVisualProps> = ({
 				width={width}
 				height={height}
 				priority={true}
-				style={ambientStyle}
+				style={sceneColorGradeStyle}
 			/>
 			{liveRoomScenesEnabled && scene?.mode === 'living' && (
 				<LivingSceneLayer

--- a/youtube-monitor/src/components/RoomVisual.tsx
+++ b/youtube-monitor/src/components/RoomVisual.tsx
@@ -1,11 +1,13 @@
 import Image from 'next/image'
 import type { FC } from 'react'
 import type { RoomSceneConfig } from '../types/room-scene'
+import LivingSceneLayer from './LivingSceneLayer'
 
 export type RoomVisualProps = {
 	floorImage: string
 	width: number
 	height: number
+	active: boolean
 	scene?: RoomSceneConfig
 }
 
@@ -20,6 +22,7 @@ const RoomVisual: FC<RoomVisualProps> = ({
 	floorImage,
 	width,
 	height,
+	active,
 	scene,
 }) => {
 	if (!floorImage) {
@@ -35,14 +38,19 @@ const RoomVisual: FC<RoomVisualProps> = ({
 			: undefined
 
 	return (
-		<Image
-			alt="room image"
-			src={floorImage}
-			width={width}
-			height={height}
-			priority={true}
-			style={ambientStyle}
-		/>
+		<>
+			<Image
+				alt="room image"
+				src={floorImage}
+				width={width}
+				height={height}
+				priority={true}
+				style={ambientStyle}
+			/>
+			{scene?.mode === 'living' && (
+				<LivingSceneLayer active={active} width={width} height={height} />
+			)}
+		</>
 	)
 }
 

--- a/youtube-monitor/src/components/RoomVisual.tsx
+++ b/youtube-monitor/src/components/RoomVisual.tsx
@@ -16,10 +16,23 @@ export type RoomVisualProps = {
  * prop is accepted so later ambient/living renderers can be introduced behind
  * this component without changing seat/layout ownership.
  */
-const RoomVisual: FC<RoomVisualProps> = ({ floorImage, width, height }) => {
+const RoomVisual: FC<RoomVisualProps> = ({
+	floorImage,
+	width,
+	height,
+	scene,
+}) => {
 	if (!floorImage) {
 		return null
 	}
+
+	const ambientStyle =
+		scene?.mode === 'ambient'
+			? {
+					filter: 'var(--scene-ambient-filter, none)',
+					transition: 'filter 1s linear',
+				}
+			: undefined
 
 	return (
 		<Image
@@ -28,6 +41,7 @@ const RoomVisual: FC<RoomVisualProps> = ({ floorImage, width, height }) => {
 			width={width}
 			height={height}
 			priority={true}
+			style={ambientStyle}
 		/>
 	)
 }

--- a/youtube-monitor/src/components/RoomVisual.tsx
+++ b/youtube-monitor/src/components/RoomVisual.tsx
@@ -1,0 +1,35 @@
+import Image from 'next/image'
+import type { FC } from 'react'
+import type { RoomSceneConfig } from '../types/room-scene'
+
+export type RoomVisualProps = {
+	floorImage: string
+	width: number
+	height: number
+	scene?: RoomSceneConfig
+}
+
+/**
+ * Compatibility boundary for room visuals.
+ *
+ * Static room rendering remains authoritative in this PR. The optional scene
+ * prop is accepted so later ambient/living renderers can be introduced behind
+ * this component without changing seat/layout ownership.
+ */
+const RoomVisual: FC<RoomVisualProps> = ({ floorImage, width, height }) => {
+	if (!floorImage) {
+		return null
+	}
+
+	return (
+		<Image
+			alt="room image"
+			src={floorImage}
+			width={width}
+			height={height}
+			priority={true}
+		/>
+	)
+}
+
+export default RoomVisual

--- a/youtube-monitor/src/components/SeatsPage.tsx
+++ b/youtube-monitor/src/components/SeatsPage.tsx
@@ -1,9 +1,9 @@
-import Image from 'next/image'
 import { type FC, useMemo } from 'react'
 import { Constants } from '../lib/constants'
 import * as styles from '../styles/SeatsPage.styles'
 import type { Seat } from '../types/api'
 import type { RoomLayout } from '../types/room-layout'
+import RoomVisual from './RoomVisual'
 import SeatBox from './SeatBox'
 
 export type LayoutPageProps = {
@@ -202,15 +202,12 @@ const SeatsPage: FC<LayoutPageProps> = (props) => {
 						}
 			}
 		>
-			{propsMemo.roomLayout.floor_image && (
-				<Image
-					alt="room image"
-					src={propsMemo.roomLayout.floor_image}
-					width={roomShape.widthPx}
-					height={roomShape.heightPx}
-					priority={true}
-				/>
-			)}
+			<RoomVisual
+				floorImage={propsMemo.roomLayout.floor_image}
+				scene={propsMemo.roomLayout.scene}
+				width={roomShape.widthPx}
+				height={roomShape.heightPx}
+			/>
 
 			{seatList}
 

--- a/youtube-monitor/src/components/SeatsPage.tsx
+++ b/youtube-monitor/src/components/SeatsPage.tsx
@@ -203,6 +203,7 @@ const SeatsPage: FC<LayoutPageProps> = (props) => {
 			}
 		>
 			<RoomVisual
+				active={propsMemo.display}
 				floorImage={propsMemo.roomLayout.floor_image}
 				scene={propsMemo.roomLayout.scene}
 				width={roomShape.widthPx}

--- a/youtube-monitor/src/hooks/use-live-room-scenes-enabled.test.tsx
+++ b/youtube-monitor/src/hooks/use-live-room-scenes-enabled.test.tsx
@@ -1,7 +1,7 @@
+import { TextEncoder } from 'node:util'
 import { render, screen } from '@testing-library/react'
 import type { NextRouter } from 'next/router'
 import { useRouter } from 'next/router'
-import { renderToString } from 'react-dom/server'
 import { useLiveRoomScenesEnabled } from './use-live-room-scenes-enabled'
 
 jest.mock('next/router', () => ({
@@ -31,8 +31,10 @@ describe('useLiveRoomScenesEnabled', () => {
 		useRouterMock.mockReset()
 	})
 
-	test('keeps the server render hydration-safe even when debug force-on is present', () => {
+	test('keeps the server render hydration-safe even when debug force-on is present', async () => {
 		useRouterMock.mockReturnValue(createRouter({ liveScenes: 'on' }))
+		Object.assign(globalThis, { TextEncoder })
+		const { renderToString } = await import('react-dom/server')
 
 		const html = renderToString(<Probe />)
 

--- a/youtube-monitor/src/hooks/use-live-room-scenes-enabled.test.tsx
+++ b/youtube-monitor/src/hooks/use-live-room-scenes-enabled.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react'
+import type { NextRouter } from 'next/router'
+import { useRouter } from 'next/router'
+import { renderToString } from 'react-dom/server'
+import { useLiveRoomScenesEnabled } from './use-live-room-scenes-enabled'
+
+jest.mock('next/router', () => ({
+	useRouter: jest.fn(),
+}))
+
+jest.mock('../lib/constants', () => ({
+	DEBUG: true,
+}))
+
+const useRouterMock = useRouter as jest.MockedFunction<typeof useRouter>
+
+const Probe = () => {
+	const enabled = useLiveRoomScenesEnabled()
+	return <span data-testid="status">{enabled ? 'on' : 'off'}</span>
+}
+
+function createRouter(query: NextRouter['query']): NextRouter {
+	return {
+		isReady: true,
+		query,
+	} as NextRouter
+}
+
+describe('useLiveRoomScenesEnabled', () => {
+	beforeEach(() => {
+		useRouterMock.mockReset()
+	})
+
+	test('keeps the server render hydration-safe even when debug force-on is present', () => {
+		useRouterMock.mockReturnValue(createRouter({ liveScenes: 'on' }))
+
+		const html = renderToString(<Probe />)
+
+		expect(html).toContain('off')
+		expect(html).not.toContain('>on<')
+	})
+
+	test('enables after mount when debug force-on is present', () => {
+		useRouterMock.mockReturnValue(createRouter({ liveScenes: 'on' }))
+
+		render(<Probe />)
+
+		expect(screen.getByTestId('status')).toHaveTextContent('on')
+	})
+
+	test('keeps the runtime kill switch disabled after mount', () => {
+		useRouterMock.mockReturnValue(createRouter({ liveScenes: 'off' }))
+
+		render(<Probe />)
+
+		expect(screen.getByTestId('status')).toHaveTextContent('off')
+	})
+})

--- a/youtube-monitor/src/hooks/use-live-room-scenes-enabled.ts
+++ b/youtube-monitor/src/hooks/use-live-room-scenes-enabled.ts
@@ -1,4 +1,5 @@
 import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
 import { DEBUG } from '../lib/constants'
 import {
 	LIVE_ROOM_SCENES_ENABLED_BY_DEFAULT,
@@ -7,10 +8,19 @@ import {
 
 export function useLiveRoomScenesEnabled(): boolean {
 	const router = useRouter()
-	return resolveLiveRoomScenesEnabled({
-		defaultEnabled: LIVE_ROOM_SCENES_ENABLED_BY_DEFAULT,
-		queryValue: router.query.liveScenes,
-		debugEnabled: DEBUG,
-		routerReady: router.isReady,
-	})
+	const liveScenesQuery = router.query.liveScenes
+	const [enabled, setEnabled] = useState(false)
+
+	useEffect(() => {
+		setEnabled(
+			resolveLiveRoomScenesEnabled({
+				defaultEnabled: LIVE_ROOM_SCENES_ENABLED_BY_DEFAULT,
+				queryValue: liveScenesQuery,
+				debugEnabled: DEBUG,
+				routerReady: router.isReady,
+			}),
+		)
+	}, [liveScenesQuery, router.isReady])
+
+	return enabled
 }

--- a/youtube-monitor/src/hooks/use-live-room-scenes-enabled.ts
+++ b/youtube-monitor/src/hooks/use-live-room-scenes-enabled.ts
@@ -1,0 +1,16 @@
+import { useRouter } from 'next/router'
+import { DEBUG } from '../lib/constants'
+import {
+	LIVE_ROOM_SCENES_ENABLED_BY_DEFAULT,
+	resolveLiveRoomScenesEnabled,
+} from '../lib/live-room-scenes'
+
+export function useLiveRoomScenesEnabled(): boolean {
+	const router = useRouter()
+	return resolveLiveRoomScenesEnabled({
+		defaultEnabled: LIVE_ROOM_SCENES_ENABLED_BY_DEFAULT,
+		queryValue: router.query.liveScenes,
+		debugEnabled: DEBUG,
+		routerReady: router.isReady,
+	})
+}

--- a/youtube-monitor/src/hooks/use-scene-clock-css-variables.ts
+++ b/youtube-monitor/src/hooks/use-scene-clock-css-variables.ts
@@ -1,0 +1,84 @@
+import { useRouter } from 'next/router'
+import { type RefObject, useEffect } from 'react'
+import { DEBUG } from '../lib/constants'
+import {
+	buildAmbientSceneFilter,
+	createSceneClockAnchor,
+	getSceneClockSecondsAt,
+	getSceneStateAtClockSeconds,
+} from '../lib/scene-clock'
+
+const SCENE_CLOCK_UPDATE_INTERVAL_MS = 1000
+
+const SCENE_VARIABLES = [
+	'--scene-ambient-filter',
+	'--scene-brightness',
+	'--scene-saturation',
+	'--scene-warmth',
+	'--scene-sunset-amount',
+	'--scene-night-amount',
+	'--scene-lamp-intensity',
+	'--scene-sky-brightness',
+] as const
+
+export function useSceneClockCssVariables(
+	targetRef: RefObject<HTMLElement | null>,
+): void {
+	const router = useRouter()
+	const sceneTimeQuery = router.query.sceneTime
+	const sceneSpeedQuery = router.query.sceneSpeed
+
+	useEffect(() => {
+		if (!router.isReady || targetRef.current === null) {
+			return
+		}
+
+		const target = targetRef.current
+		const anchor = createSceneClockAnchor(
+			new Date(),
+			sceneTimeQuery,
+			sceneSpeedQuery,
+			DEBUG,
+		)
+
+		const update = () => {
+			const clockSeconds = getSceneClockSecondsAt(anchor, Date.now())
+			const state = getSceneStateAtClockSeconds(clockSeconds)
+			target.style.setProperty(
+				'--scene-ambient-filter',
+				buildAmbientSceneFilter(state),
+			)
+			target.style.setProperty('--scene-brightness', String(state.brightness))
+			target.style.setProperty('--scene-saturation', String(state.saturation))
+			target.style.setProperty('--scene-warmth', String(state.warmth))
+			target.style.setProperty(
+				'--scene-sunset-amount',
+				String(state.sunsetAmount),
+			)
+			target.style.setProperty(
+				'--scene-night-amount',
+				String(state.nightAmount),
+			)
+			target.style.setProperty(
+				'--scene-lamp-intensity',
+				String(state.lampIntensity),
+			)
+			target.style.setProperty(
+				'--scene-sky-brightness',
+				String(state.skyBrightness),
+			)
+		}
+
+		update()
+		const intervalId = window.setInterval(
+			update,
+			SCENE_CLOCK_UPDATE_INTERVAL_MS,
+		)
+		return () => {
+			window.clearInterval(intervalId)
+			for (const variable of SCENE_VARIABLES) {
+				target.style.removeProperty(variable)
+			}
+		}
+	}, [router.isReady, sceneSpeedQuery, sceneTimeQuery, targetRef])
+}

--- a/youtube-monitor/src/hooks/use-scene-clock-css-variables.ts
+++ b/youtube-monitor/src/hooks/use-scene-clock-css-variables.ts
@@ -23,13 +23,14 @@ const SCENE_VARIABLES = [
 
 export function useSceneClockCssVariables(
 	targetRef: RefObject<HTMLElement | null>,
+	enabled = true,
 ): void {
 	const router = useRouter()
 	const sceneTimeQuery = router.query.sceneTime
 	const sceneSpeedQuery = router.query.sceneSpeed
 
 	useEffect(() => {
-		if (!router.isReady || targetRef.current === null) {
+		if (!enabled || !router.isReady || targetRef.current === null) {
 			return
 		}
 
@@ -80,5 +81,5 @@ export function useSceneClockCssVariables(
 				target.style.removeProperty(variable)
 			}
 		}
-	}, [router.isReady, sceneSpeedQuery, sceneTimeQuery, targetRef])
+	}, [enabled, router.isReady, sceneSpeedQuery, sceneTimeQuery, targetRef])
 }

--- a/youtube-monitor/src/lib/live-room-scenes.test.ts
+++ b/youtube-monitor/src/lib/live-room-scenes.test.ts
@@ -1,0 +1,69 @@
+import { resolveLiveRoomScenesEnabled } from './live-room-scenes'
+
+describe('resolveLiveRoomScenesEnabled', () => {
+	test('stays disabled until router query state is ready', () => {
+		expect(
+			resolveLiveRoomScenesEnabled({
+				defaultEnabled: true,
+				queryValue: undefined,
+				debugEnabled: false,
+				routerReady: false,
+			}),
+		).toBe(false)
+	})
+
+	test('uses the environment default when no override is present', () => {
+		expect(
+			resolveLiveRoomScenesEnabled({
+				defaultEnabled: true,
+				queryValue: undefined,
+				debugEnabled: false,
+				routerReady: true,
+			}),
+		).toBe(true)
+		expect(
+			resolveLiveRoomScenesEnabled({
+				defaultEnabled: false,
+				queryValue: undefined,
+				debugEnabled: false,
+				routerReady: true,
+			}),
+		).toBe(false)
+	})
+
+	test.each(['off', 'false', '0'])(
+		'allows a production-safe URL kill switch: %s',
+		(queryValue) => {
+			expect(
+				resolveLiveRoomScenesEnabled({
+					defaultEnabled: true,
+					queryValue,
+					debugEnabled: false,
+					routerReady: true,
+				}),
+			).toBe(false)
+		},
+	)
+
+	test.each(['on', 'true', '1'])(
+		'allows URL force-on only in debug builds: %s',
+		(queryValue) => {
+			expect(
+				resolveLiveRoomScenesEnabled({
+					defaultEnabled: false,
+					queryValue,
+					debugEnabled: false,
+					routerReady: true,
+				}),
+			).toBe(false)
+			expect(
+				resolveLiveRoomScenesEnabled({
+					defaultEnabled: false,
+					queryValue,
+					debugEnabled: true,
+					routerReady: true,
+				}),
+			).toBe(true)
+		},
+	)
+})

--- a/youtube-monitor/src/lib/live-room-scenes.ts
+++ b/youtube-monitor/src/lib/live-room-scenes.ts
@@ -1,0 +1,33 @@
+export const LIVE_ROOM_SCENES_ENABLED_BY_DEFAULT =
+	process.env.NEXT_PUBLIC_LIVE_ROOM_SCENES_ENABLED === 'true'
+
+const OFF_VALUES = new Set(['off', 'false', '0'])
+const ON_VALUES = new Set(['on', 'true', '1'])
+
+export function resolveLiveRoomScenesEnabled({
+	defaultEnabled,
+	queryValue,
+	debugEnabled,
+	routerReady,
+}: {
+	defaultEnabled: boolean
+	queryValue: string | string[] | undefined
+	debugEnabled: boolean
+	routerReady: boolean
+}): boolean {
+	if (!routerReady) {
+		return false
+	}
+	if (typeof queryValue !== 'string') {
+		return defaultEnabled
+	}
+
+	const normalized = queryValue.trim().toLowerCase()
+	if (OFF_VALUES.has(normalized)) {
+		return false
+	}
+	if (debugEnabled && ON_VALUES.has(normalized)) {
+		return true
+	}
+	return defaultEnabled
+}

--- a/youtube-monitor/src/lib/living-scene-runtime.test.ts
+++ b/youtube-monitor/src/lib/living-scene-runtime.test.ts
@@ -1,0 +1,104 @@
+import {
+	type CreateLivingSceneApplication,
+	type LivingSceneApplication,
+	LivingSceneRuntimeManager,
+} from './living-scene-runtime'
+
+function createFakeApplication(): LivingSceneApplication & {
+	start: jest.Mock
+	stop: jest.Mock
+	resize: jest.Mock
+	destroy: jest.Mock
+} {
+	return {
+		canvas: document.createElement('canvas'),
+		start: jest.fn(),
+		stop: jest.fn(),
+		resize: jest.fn(),
+		destroy: jest.fn(),
+	}
+}
+
+describe('LivingSceneRuntimeManager', () => {
+	test('reuses one application while moving the canvas between active room hosts', async () => {
+		const application = createFakeApplication()
+		const createApplication: jest.MockedFunction<CreateLivingSceneApplication> =
+			jest.fn().mockResolvedValue(application)
+		const manager = new LivingSceneRuntimeManager(createApplication)
+		const firstHost = document.createElement('div')
+		const secondHost = document.createElement('div')
+
+		await expect(
+			manager.activate({ host: firstHost, width: 1520, height: 900 }),
+		).resolves.toBe(true)
+		expect(createApplication).toHaveBeenCalledTimes(1)
+		expect(firstHost).toContainElement(application.canvas)
+		expect(application.resize).toHaveBeenLastCalledWith(1520, 900)
+		expect(application.start).toHaveBeenCalledTimes(1)
+
+		manager.deactivate(firstHost)
+		expect(application.stop).toHaveBeenCalledTimes(1)
+
+		await expect(
+			manager.activate({ host: secondHost, width: 1200, height: 800 }),
+		).resolves.toBe(true)
+		expect(createApplication).toHaveBeenCalledTimes(1)
+		expect(secondHost).toContainElement(application.canvas)
+		expect(application.resize).toHaveBeenLastCalledWith(1200, 800)
+		expect(application.start).toHaveBeenCalledTimes(2)
+	})
+
+	test('does not attach an async initialization result after the room was hidden', async () => {
+		const application = createFakeApplication()
+		let resolveApplication:
+			| ((value: LivingSceneApplication) => void)
+			| undefined
+		const createApplication: CreateLivingSceneApplication = () =>
+			new Promise((resolve) => {
+				resolveApplication = resolve
+			})
+		const manager = new LivingSceneRuntimeManager(createApplication)
+		const host = document.createElement('div')
+
+		const activation = manager.activate({ host, width: 1520, height: 900 })
+		manager.deactivate(host)
+		resolveApplication?.(application)
+
+		await expect(activation).resolves.toBe(false)
+		expect(host).not.toContainElement(application.canvas)
+		expect(application.start).not.toHaveBeenCalled()
+	})
+
+	test('falls back after WebGL context loss', async () => {
+		const application = createFakeApplication()
+		const manager = new LivingSceneRuntimeManager(() =>
+			Promise.resolve(application),
+		)
+		const host = document.createElement('div')
+
+		await manager.activate({ host, width: 1520, height: 900 })
+		application.canvas.dispatchEvent(
+			new Event('webglcontextlost', { cancelable: true }),
+		)
+
+		expect(application.canvas.hidden).toBe(true)
+		expect(application.stop).toHaveBeenCalled()
+		await expect(
+			manager.activate({ host, width: 1520, height: 900 }),
+		).resolves.toBe(false)
+	})
+
+	test('destroy releases the shared application', async () => {
+		const application = createFakeApplication()
+		const manager = new LivingSceneRuntimeManager(() =>
+			Promise.resolve(application),
+		)
+		const host = document.createElement('div')
+
+		await manager.activate({ host, width: 1520, height: 900 })
+		manager.destroy()
+
+		expect(application.stop).toHaveBeenCalled()
+		expect(application.destroy).toHaveBeenCalledTimes(1)
+	})
+})

--- a/youtube-monitor/src/lib/living-scene-runtime.test.ts
+++ b/youtube-monitor/src/lib/living-scene-runtime.test.ts
@@ -21,6 +21,20 @@ function createFakeApplication(): LivingSceneApplication & {
 	}
 }
 
+const createActivation = (
+	host: HTMLElement,
+): {
+	host: HTMLElement
+	width: number
+	height: number
+	profile: 'lume-rainy-poc'
+} => ({
+	host,
+	width: 1520,
+	height: 900,
+	profile: 'lume-rainy-poc',
+})
+
 describe('LivingSceneRuntimeManager', () => {
 	test('reuses one application while moving the canvas between active room hosts', async () => {
 		const application = createFakeApplication()
@@ -30,14 +44,9 @@ describe('LivingSceneRuntimeManager', () => {
 		const firstHost = document.createElement('div')
 		const secondHost = document.createElement('div')
 
-		await expect(
-			manager.activate({
-				host: firstHost,
-				width: 1520,
-				height: 900,
-				profile: 'lume-rainy-poc',
-			}),
-		).resolves.toBe(true)
+		await expect(manager.activate(createActivation(firstHost))).resolves.toBe(
+			true,
+		)
 		expect(createApplication).toHaveBeenCalledTimes(1)
 		expect(application.setProfile).toHaveBeenLastCalledWith('lume-rainy-poc')
 		expect(firstHost).toContainElement(application.canvas)
@@ -49,10 +58,9 @@ describe('LivingSceneRuntimeManager', () => {
 
 		await expect(
 			manager.activate({
-				host: secondHost,
+				...createActivation(secondHost),
 				width: 1200,
 				height: 800,
-				profile: 'lume-rainy-poc',
 			}),
 		).resolves.toBe(true)
 		expect(createApplication).toHaveBeenCalledTimes(1)
@@ -73,18 +81,36 @@ describe('LivingSceneRuntimeManager', () => {
 		const manager = new LivingSceneRuntimeManager(createApplication)
 		const host = document.createElement('div')
 
-		const activation = manager.activate({
-			host,
-			width: 1520,
-			height: 900,
-			profile: 'lume-rainy-poc',
-		})
+		const activation = manager.activate(createActivation(host))
 		manager.deactivate(host)
 		resolveApplication?.(application)
 
 		await expect(activation).resolves.toBe(false)
 		expect(host).not.toContainElement(application.canvas)
 		expect(application.start).not.toHaveBeenCalled()
+	})
+
+	test('retries a transient initialization failure on the next activation', async () => {
+		const application = createFakeApplication()
+		const createApplication: jest.MockedFunction<CreateLivingSceneApplication> =
+			jest
+				.fn()
+				.mockRejectedValueOnce(
+					new Error('temporary WebGL initialization error'),
+				)
+				.mockResolvedValue(application)
+		const manager = new LivingSceneRuntimeManager(createApplication)
+		const host = document.createElement('div')
+		const consoleError = jest
+			.spyOn(console, 'error')
+			.mockImplementation(() => undefined)
+
+		await expect(manager.activate(createActivation(host))).resolves.toBe(false)
+		await expect(manager.activate(createActivation(host))).resolves.toBe(true)
+
+		expect(createApplication).toHaveBeenCalledTimes(2)
+		expect(host).toContainElement(application.canvas)
+		consoleError.mockRestore()
 	})
 
 	test('keeps the static fallback when a profile cannot be configured', async () => {
@@ -95,64 +121,97 @@ describe('LivingSceneRuntimeManager', () => {
 		)
 		const host = document.createElement('div')
 
-		await expect(
-			manager.activate({
-				host,
-				width: 1520,
-				height: 900,
-				profile: 'lume-rainy-poc',
-			}),
-		).resolves.toBe(false)
+		await expect(manager.activate(createActivation(host))).resolves.toBe(false)
 		expect(host).not.toContainElement(application.canvas)
 		expect(application.start).not.toHaveBeenCalled()
 		expect(application.canvas.hidden).toBe(true)
 	})
 
-	test('falls back after WebGL context loss', async () => {
+	test('restores the active scene after WebGL context recovery', async () => {
 		const application = createFakeApplication()
 		const manager = new LivingSceneRuntimeManager(() =>
 			Promise.resolve(application),
 		)
 		const host = document.createElement('div')
+		document.body.appendChild(host)
 
-		await manager.activate({
-			host,
-			width: 1520,
-			height: 900,
-			profile: 'lume-rainy-poc',
-		})
+		await manager.activate(createActivation(host))
 		application.canvas.dispatchEvent(
 			new Event('webglcontextlost', { cancelable: true }),
 		)
-
 		expect(application.canvas.hidden).toBe(true)
 		expect(application.stop).toHaveBeenCalled()
-		await expect(
-			manager.activate({
-				host,
-				width: 1520,
-				height: 900,
-				profile: 'lume-rainy-poc',
-			}),
-		).resolves.toBe(false)
+
+		application.canvas.dispatchEvent(new Event('webglcontextrestored'))
+		await Promise.resolve()
+		await Promise.resolve()
+
+		expect(application.canvas.hidden).toBe(false)
+		expect(application.start).toHaveBeenCalledTimes(2)
+		host.remove()
 	})
 
-	test('destroy releases the shared application', async () => {
+	test('does not restart a scene hidden before WebGL context recovery', async () => {
 		const application = createFakeApplication()
 		const manager = new LivingSceneRuntimeManager(() =>
 			Promise.resolve(application),
 		)
 		const host = document.createElement('div')
+		document.body.appendChild(host)
 
-		await manager.activate({
-			host,
-			width: 1520,
-			height: 900,
-			profile: 'lume-rainy-poc',
-		})
+		await manager.activate(createActivation(host))
+		application.canvas.dispatchEvent(
+			new Event('webglcontextlost', { cancelable: true }),
+		)
+		manager.deactivate(host)
+		application.canvas.dispatchEvent(new Event('webglcontextrestored'))
+		await Promise.resolve()
+		await Promise.resolve()
+
+		expect(application.canvas.hidden).toBe(true)
+		expect(application.start).toHaveBeenCalledTimes(1)
+		host.remove()
+	})
+
+	test('does not restart a detached host after WebGL context recovery', async () => {
+		const application = createFakeApplication()
+		const manager = new LivingSceneRuntimeManager(() =>
+			Promise.resolve(application),
+		)
+		const host = document.createElement('div')
+		document.body.appendChild(host)
+
+		await manager.activate(createActivation(host))
+		application.canvas.dispatchEvent(
+			new Event('webglcontextlost', { cancelable: true }),
+		)
+		host.remove()
+		application.canvas.dispatchEvent(new Event('webglcontextrestored'))
+		await Promise.resolve()
+		await Promise.resolve()
+
+		expect(application.canvas.hidden).toBe(true)
+		expect(application.start).toHaveBeenCalledTimes(1)
+	})
+
+	test('destroy releases the shared application and prevents later recovery', async () => {
+		const application = createFakeApplication()
+		const manager = new LivingSceneRuntimeManager(() =>
+			Promise.resolve(application),
+		)
+		const host = document.createElement('div')
+		document.body.appendChild(host)
+
+		await manager.activate(createActivation(host))
+		application.canvas.dispatchEvent(
+			new Event('webglcontextlost', { cancelable: true }),
+		)
 		manager.destroy()
+		application.canvas.dispatchEvent(new Event('webglcontextrestored'))
+		await Promise.resolve()
 
-		expect(application.stop).toHaveBeenCalled()
 		expect(application.destroy).toHaveBeenCalledTimes(1)
+		expect(application.start).toHaveBeenCalledTimes(1)
+		host.remove()
 	})
 })

--- a/youtube-monitor/src/lib/living-scene-runtime.test.ts
+++ b/youtube-monitor/src/lib/living-scene-runtime.test.ts
@@ -8,6 +8,7 @@ function createFakeApplication(): LivingSceneApplication & {
 	start: jest.Mock
 	stop: jest.Mock
 	resize: jest.Mock
+	setProfile: jest.Mock
 	destroy: jest.Mock
 } {
 	return {
@@ -15,6 +16,7 @@ function createFakeApplication(): LivingSceneApplication & {
 		start: jest.fn(),
 		stop: jest.fn(),
 		resize: jest.fn(),
+		setProfile: jest.fn(() => true),
 		destroy: jest.fn(),
 	}
 }
@@ -29,9 +31,15 @@ describe('LivingSceneRuntimeManager', () => {
 		const secondHost = document.createElement('div')
 
 		await expect(
-			manager.activate({ host: firstHost, width: 1520, height: 900 }),
+			manager.activate({
+				host: firstHost,
+				width: 1520,
+				height: 900,
+				profile: 'lume-rainy-poc',
+			}),
 		).resolves.toBe(true)
 		expect(createApplication).toHaveBeenCalledTimes(1)
+		expect(application.setProfile).toHaveBeenLastCalledWith('lume-rainy-poc')
 		expect(firstHost).toContainElement(application.canvas)
 		expect(application.resize).toHaveBeenLastCalledWith(1520, 900)
 		expect(application.start).toHaveBeenCalledTimes(1)
@@ -40,7 +48,12 @@ describe('LivingSceneRuntimeManager', () => {
 		expect(application.stop).toHaveBeenCalledTimes(1)
 
 		await expect(
-			manager.activate({ host: secondHost, width: 1200, height: 800 }),
+			manager.activate({
+				host: secondHost,
+				width: 1200,
+				height: 800,
+				profile: 'lume-rainy-poc',
+			}),
 		).resolves.toBe(true)
 		expect(createApplication).toHaveBeenCalledTimes(1)
 		expect(secondHost).toContainElement(application.canvas)
@@ -60,13 +73,39 @@ describe('LivingSceneRuntimeManager', () => {
 		const manager = new LivingSceneRuntimeManager(createApplication)
 		const host = document.createElement('div')
 
-		const activation = manager.activate({ host, width: 1520, height: 900 })
+		const activation = manager.activate({
+			host,
+			width: 1520,
+			height: 900,
+			profile: 'lume-rainy-poc',
+		})
 		manager.deactivate(host)
 		resolveApplication?.(application)
 
 		await expect(activation).resolves.toBe(false)
 		expect(host).not.toContainElement(application.canvas)
 		expect(application.start).not.toHaveBeenCalled()
+	})
+
+	test('keeps the static fallback when a profile cannot be configured', async () => {
+		const application = createFakeApplication()
+		application.setProfile.mockReturnValue(false)
+		const manager = new LivingSceneRuntimeManager(() =>
+			Promise.resolve(application),
+		)
+		const host = document.createElement('div')
+
+		await expect(
+			manager.activate({
+				host,
+				width: 1520,
+				height: 900,
+				profile: 'lume-rainy-poc',
+			}),
+		).resolves.toBe(false)
+		expect(host).not.toContainElement(application.canvas)
+		expect(application.start).not.toHaveBeenCalled()
+		expect(application.canvas.hidden).toBe(true)
 	})
 
 	test('falls back after WebGL context loss', async () => {
@@ -76,7 +115,12 @@ describe('LivingSceneRuntimeManager', () => {
 		)
 		const host = document.createElement('div')
 
-		await manager.activate({ host, width: 1520, height: 900 })
+		await manager.activate({
+			host,
+			width: 1520,
+			height: 900,
+			profile: 'lume-rainy-poc',
+		})
 		application.canvas.dispatchEvent(
 			new Event('webglcontextlost', { cancelable: true }),
 		)
@@ -84,7 +128,12 @@ describe('LivingSceneRuntimeManager', () => {
 		expect(application.canvas.hidden).toBe(true)
 		expect(application.stop).toHaveBeenCalled()
 		await expect(
-			manager.activate({ host, width: 1520, height: 900 }),
+			manager.activate({
+				host,
+				width: 1520,
+				height: 900,
+				profile: 'lume-rainy-poc',
+			}),
 		).resolves.toBe(false)
 	})
 
@@ -95,7 +144,12 @@ describe('LivingSceneRuntimeManager', () => {
 		)
 		const host = document.createElement('div')
 
-		await manager.activate({ host, width: 1520, height: 900 })
+		await manager.activate({
+			host,
+			width: 1520,
+			height: 900,
+			profile: 'lume-rainy-poc',
+		})
 		manager.destroy()
 
 		expect(application.stop).toHaveBeenCalled()

--- a/youtube-monitor/src/lib/living-scene-runtime.ts
+++ b/youtube-monitor/src/lib/living-scene-runtime.ts
@@ -2,6 +2,8 @@ import type { LivingSceneInstance } from '../scenes/living-scene-profile'
 import { createLivingSceneForProfile } from '../scenes/living-scene-profile'
 import type { LivingSceneProfile } from '../types/room-scene'
 
+export const LIVING_SCENE_MAX_FPS = 30
+
 export type LivingSceneApplication = {
 	canvas: HTMLCanvasElement
 	start: () => void
@@ -43,6 +45,7 @@ async function createPixiLivingSceneApplication(
 		preferWebGLVersion: 2,
 		powerPreference: 'high-performance',
 	})
+	app.ticker.maxFPS = LIVING_SCENE_MAX_FPS
 
 	const canvas = app.canvas as HTMLCanvasElement
 	canvas.setAttribute('aria-hidden', 'true')
@@ -115,8 +118,9 @@ export class LivingSceneRuntimeManager {
 	private applicationPromise: Promise<LivingSceneApplication> | undefined
 	private requestedHost: HTMLElement | undefined
 	private activeHost: HTMLElement | undefined
+	private activeActivation: LivingSceneActivation | undefined
+	private recoveryActivation: LivingSceneActivation | undefined
 	private activationRevision = 0
-	private unavailable = false
 
 	constructor(
 		private readonly createApplication: CreateLivingSceneApplication = (
@@ -125,33 +129,24 @@ export class LivingSceneRuntimeManager {
 		) => createPixiLivingSceneApplication(width, height),
 	) {}
 
-	async activate({
-		host,
-		width,
-		height,
-		profile,
-	}: LivingSceneActivation): Promise<boolean> {
+	async activate(activation: LivingSceneActivation): Promise<boolean> {
+		const { host, width, height, profile } = activation
 		const revision = ++this.activationRevision
 		this.requestedHost = host
-
-		if (this.unavailable) {
-			return false
-		}
+		this.recoveryActivation = undefined
 
 		let application: LivingSceneApplication
 		try {
 			application = await this.ensureApplication(width, height)
 		} catch (error) {
-			this.unavailable = true
+			if (revision === this.activationRevision && this.requestedHost === host) {
+				this.requestedHost = undefined
+			}
 			console.error('[living-scene] failed to initialize PixiJS', error)
 			return false
 		}
 
-		if (
-			revision !== this.activationRevision ||
-			this.requestedHost !== host ||
-			this.unavailable
-		) {
+		if (revision !== this.activationRevision || this.requestedHost !== host) {
 			return false
 		}
 
@@ -164,6 +159,7 @@ export class LivingSceneRuntimeManager {
 			application.canvas.hidden = true
 			this.requestedHost = undefined
 			this.activeHost = undefined
+			this.activeActivation = undefined
 			return false
 		}
 
@@ -173,6 +169,7 @@ export class LivingSceneRuntimeManager {
 		}
 		application.canvas.hidden = false
 		this.activeHost = host
+		this.activeActivation = activation
 		application.start()
 		return true
 	}
@@ -181,6 +178,12 @@ export class LivingSceneRuntimeManager {
 		if (this.requestedHost === host) {
 			this.requestedHost = undefined
 			this.activationRevision++
+		}
+		if (this.recoveryActivation?.host === host) {
+			this.recoveryActivation = undefined
+		}
+		if (this.activeActivation?.host === host) {
+			this.activeActivation = undefined
 		}
 
 		if (this.activeHost !== host) {
@@ -195,7 +198,8 @@ export class LivingSceneRuntimeManager {
 		this.activationRevision++
 		this.requestedHost = undefined
 		this.activeHost = undefined
-		this.unavailable = false
+		this.activeActivation = undefined
+		this.recoveryActivation = undefined
 
 		const application = this.application
 		this.application = undefined
@@ -207,6 +211,10 @@ export class LivingSceneRuntimeManager {
 		application.canvas.removeEventListener(
 			'webglcontextlost',
 			this.handleContextLost,
+		)
+		application.canvas.removeEventListener(
+			'webglcontextrestored',
+			this.handleContextRestored,
 		)
 		application.stop()
 		application.destroy()
@@ -224,12 +232,23 @@ export class LivingSceneRuntimeManager {
 			this.applicationPromise = this.createApplication(width, height)
 		}
 
-		const application = await this.applicationPromise
+		let application: LivingSceneApplication
+		try {
+			application = await this.applicationPromise
+		} catch (error) {
+			this.applicationPromise = undefined
+			throw error
+		}
+
 		if (this.application === undefined) {
 			this.application = application
 			application.canvas.addEventListener(
 				'webglcontextlost',
 				this.handleContextLost,
+			)
+			application.canvas.addEventListener(
+				'webglcontextrestored',
+				this.handleContextRestored,
 			)
 		}
 		return this.application
@@ -238,14 +257,31 @@ export class LivingSceneRuntimeManager {
 	private readonly handleContextLost = (event: Event): void => {
 		event.preventDefault()
 		this.activationRevision++
+		this.recoveryActivation = this.activeActivation
 		this.requestedHost = undefined
 		this.activeHost = undefined
-		this.unavailable = true
+		this.activeActivation = undefined
 
 		if (this.application !== undefined) {
 			this.application.stop()
 			this.application.canvas.hidden = true
 		}
+	}
+
+	private readonly handleContextRestored = (): void => {
+		const recovery = this.recoveryActivation
+		if (recovery === undefined || !recovery.host.isConnected) {
+			this.recoveryActivation = undefined
+			return
+		}
+
+		queueMicrotask(() => {
+			if (this.recoveryActivation !== recovery) {
+				return
+			}
+			this.recoveryActivation = undefined
+			void this.activate(recovery)
+		})
 	}
 }
 

--- a/youtube-monitor/src/lib/living-scene-runtime.ts
+++ b/youtube-monitor/src/lib/living-scene-runtime.ts
@@ -1,8 +1,13 @@
+import type { LivingSceneInstance } from '../scenes/living-scene-profile'
+import { createLivingSceneForProfile } from '../scenes/living-scene-profile'
+import type { LivingSceneProfile } from '../types/room-scene'
+
 export type LivingSceneApplication = {
 	canvas: HTMLCanvasElement
 	start: () => void
 	stop: () => void
 	resize: (width: number, height: number) => void
+	setProfile: (profile: LivingSceneProfile) => boolean
 	destroy: () => void
 }
 
@@ -15,13 +20,14 @@ export type LivingSceneActivation = {
 	host: HTMLElement
 	width: number
 	height: number
+	profile: LivingSceneProfile
 }
 
 async function createPixiLivingSceneApplication(
 	width: number,
 	height: number,
 ): Promise<LivingSceneApplication> {
-	const { Application } = await import('pixi.js')
+	const { Application, Container, Graphics } = await import('pixi.js')
 	const app = new Application()
 
 	await app.init({
@@ -46,13 +52,61 @@ async function createPixiLivingSceneApplication(
 	canvas.style.height = '100%'
 	canvas.style.pointerEvents = 'none'
 
+	const sceneRoot = new Container()
+	app.stage.addChild(sceneRoot)
+
+	let currentProfile: LivingSceneProfile | undefined
+	let currentScene: LivingSceneInstance | undefined
+
+	const setProfile = (profile: LivingSceneProfile): boolean => {
+		if (currentProfile === profile && currentScene !== undefined) {
+			return true
+		}
+
+		currentScene?.destroy()
+		currentScene = undefined
+		currentProfile = undefined
+
+		try {
+			const scene = createLivingSceneForProfile(profile, {
+				root: sceneRoot,
+				ticker: app.ticker,
+				makeContainer: () => new Container(),
+				makeGraphics: () => new Graphics(),
+				getHost: () => canvas.parentElement,
+			})
+			if (scene === undefined) {
+				return false
+			}
+			currentScene = scene
+			currentProfile = profile
+			currentScene.resize(app.renderer.width, app.renderer.height)
+			return true
+		} catch (error) {
+			console.error(
+				`[living-scene] failed to configure profile: ${profile}`,
+				error,
+			)
+			return false
+		}
+	}
+
 	return {
 		canvas,
 		start: () => app.start(),
 		stop: () => app.stop(),
-		resize: (nextWidth, nextHeight) =>
-			app.renderer.resize(nextWidth, nextHeight),
-		destroy: () => app.destroy({ removeView: true }, true),
+		resize: (nextWidth, nextHeight) => {
+			app.renderer.resize(nextWidth, nextHeight)
+			currentScene?.resize(nextWidth, nextHeight)
+		},
+		setProfile,
+		destroy: () => {
+			currentScene?.destroy()
+			currentScene = undefined
+			currentProfile = undefined
+			sceneRoot.destroy({ children: true })
+			app.destroy({ removeView: true }, true)
+		},
 	}
 }
 
@@ -75,6 +129,7 @@ export class LivingSceneRuntimeManager {
 		host,
 		width,
 		height,
+		profile,
 	}: LivingSceneActivation): Promise<boolean> {
 		const revision = ++this.activationRevision
 		this.requestedHost = host
@@ -102,6 +157,14 @@ export class LivingSceneRuntimeManager {
 
 		if (this.activeHost !== undefined && this.activeHost !== host) {
 			application.stop()
+		}
+
+		if (!application.setProfile(profile)) {
+			application.stop()
+			application.canvas.hidden = true
+			this.requestedHost = undefined
+			this.activeHost = undefined
+			return false
 		}
 
 		application.resize(width, height)

--- a/youtube-monitor/src/lib/living-scene-runtime.ts
+++ b/youtube-monitor/src/lib/living-scene-runtime.ts
@@ -1,0 +1,189 @@
+export type LivingSceneApplication = {
+	canvas: HTMLCanvasElement
+	start: () => void
+	stop: () => void
+	resize: (width: number, height: number) => void
+	destroy: () => void
+}
+
+export type CreateLivingSceneApplication = (
+	width: number,
+	height: number,
+) => Promise<LivingSceneApplication>
+
+export type LivingSceneActivation = {
+	host: HTMLElement
+	width: number
+	height: number
+}
+
+async function createPixiLivingSceneApplication(
+	width: number,
+	height: number,
+): Promise<LivingSceneApplication> {
+	const { Application } = await import('pixi.js')
+	const app = new Application()
+
+	await app.init({
+		width,
+		height,
+		autoStart: false,
+		sharedTicker: false,
+		backgroundAlpha: 0,
+		antialias: false,
+		autoDensity: false,
+		resolution: 1,
+		preference: 'webgl',
+		preferWebGLVersion: 2,
+		powerPreference: 'high-performance',
+	})
+
+	const canvas = app.canvas as HTMLCanvasElement
+	canvas.setAttribute('aria-hidden', 'true')
+	canvas.style.position = 'absolute'
+	canvas.style.inset = '0'
+	canvas.style.width = '100%'
+	canvas.style.height = '100%'
+	canvas.style.pointerEvents = 'none'
+
+	return {
+		canvas,
+		start: () => app.start(),
+		stop: () => app.stop(),
+		resize: (nextWidth, nextHeight) =>
+			app.renderer.resize(nextWidth, nextHeight),
+		destroy: () => app.destroy({ removeView: true }, true),
+	}
+}
+
+export class LivingSceneRuntimeManager {
+	private application: LivingSceneApplication | undefined
+	private applicationPromise: Promise<LivingSceneApplication> | undefined
+	private requestedHost: HTMLElement | undefined
+	private activeHost: HTMLElement | undefined
+	private activationRevision = 0
+	private unavailable = false
+
+	constructor(
+		private readonly createApplication: CreateLivingSceneApplication = (
+			width,
+			height,
+		) => createPixiLivingSceneApplication(width, height),
+	) {}
+
+	async activate({
+		host,
+		width,
+		height,
+	}: LivingSceneActivation): Promise<boolean> {
+		const revision = ++this.activationRevision
+		this.requestedHost = host
+
+		if (this.unavailable) {
+			return false
+		}
+
+		let application: LivingSceneApplication
+		try {
+			application = await this.ensureApplication(width, height)
+		} catch (error) {
+			this.unavailable = true
+			console.error('[living-scene] failed to initialize PixiJS', error)
+			return false
+		}
+
+		if (
+			revision !== this.activationRevision ||
+			this.requestedHost !== host ||
+			this.unavailable
+		) {
+			return false
+		}
+
+		if (this.activeHost !== undefined && this.activeHost !== host) {
+			application.stop()
+		}
+
+		application.resize(width, height)
+		if (application.canvas.parentElement !== host) {
+			host.appendChild(application.canvas)
+		}
+		application.canvas.hidden = false
+		this.activeHost = host
+		application.start()
+		return true
+	}
+
+	deactivate(host: HTMLElement): void {
+		if (this.requestedHost === host) {
+			this.requestedHost = undefined
+			this.activationRevision++
+		}
+
+		if (this.activeHost !== host) {
+			return
+		}
+
+		this.application?.stop()
+		this.activeHost = undefined
+	}
+
+	destroy(): void {
+		this.activationRevision++
+		this.requestedHost = undefined
+		this.activeHost = undefined
+		this.unavailable = false
+
+		const application = this.application
+		this.application = undefined
+		this.applicationPromise = undefined
+		if (application === undefined) {
+			return
+		}
+
+		application.canvas.removeEventListener(
+			'webglcontextlost',
+			this.handleContextLost,
+		)
+		application.stop()
+		application.destroy()
+	}
+
+	private async ensureApplication(
+		width: number,
+		height: number,
+	): Promise<LivingSceneApplication> {
+		if (this.application !== undefined) {
+			return this.application
+		}
+
+		if (this.applicationPromise === undefined) {
+			this.applicationPromise = this.createApplication(width, height)
+		}
+
+		const application = await this.applicationPromise
+		if (this.application === undefined) {
+			this.application = application
+			application.canvas.addEventListener(
+				'webglcontextlost',
+				this.handleContextLost,
+			)
+		}
+		return this.application
+	}
+
+	private readonly handleContextLost = (event: Event): void => {
+		event.preventDefault()
+		this.activationRevision++
+		this.requestedHost = undefined
+		this.activeHost = undefined
+		this.unavailable = true
+
+		if (this.application !== undefined) {
+			this.application.stop()
+			this.application.canvas.hidden = true
+		}
+	}
+}
+
+export const livingSceneRuntime = new LivingSceneRuntimeManager()

--- a/youtube-monitor/src/lib/scene-clock.test.ts
+++ b/youtube-monitor/src/lib/scene-clock.test.ts
@@ -1,0 +1,95 @@
+import {
+	buildAmbientSceneFilter,
+	createSceneClockAnchor,
+	getJapanClockSeconds,
+	getSceneClockSecondsAt,
+	getSceneStateAtClockSeconds,
+	parseDebugSceneSpeed,
+	parseDebugSceneTime,
+	SCENE_DAY_SECONDS,
+} from './scene-clock'
+
+describe('Scene Clock', () => {
+	test('日本時間の壁時計秒へ変換する', () => {
+		expect(getJapanClockSeconds(new Date('2026-08-01T21:00:15Z'))).toBe(
+			6 * 60 * 60 + 15,
+		)
+	})
+
+	test('day keyframeは昼の明るさを返す', () => {
+		const state = getSceneStateAtClockSeconds((9 * 60 + 15) * 60)
+		expect(state.brightness).toBe(1)
+		expect(state.nightAmount).toBe(0)
+		expect(state.lampIntensity).toBe(0)
+	})
+
+	test('keyframe間を連続補間する', () => {
+		const left = getSceneStateAtClockSeconds((15 * 60 + 15) * 60)
+		const middle = getSceneStateAtClockSeconds((16 * 60 + 27.5) * 60)
+		const right = getSceneStateAtClockSeconds((17 * 60 + 40) * 60)
+
+		expect(middle.brightness).toBeLessThan(left.brightness)
+		expect(middle.brightness).toBeGreaterThan(right.brightness)
+		expect(middle.sunsetAmount).toBeGreaterThan(left.sunsetAmount)
+		expect(middle.sunsetAmount).toBeLessThan(right.sunsetAmount)
+	})
+
+	test('24時を越えて循環する', () => {
+		expect(getSceneStateAtClockSeconds(SCENE_DAY_SECONDS)).toEqual(
+			getSceneStateAtClockSeconds(0),
+		)
+		expect(getSceneStateAtClockSeconds(-1)).toEqual(
+			getSceneStateAtClockSeconds(SCENE_DAY_SECONDS - 1),
+		)
+	})
+})
+
+describe('Scene Clock debug query', () => {
+	test('sceneTime HH:mmを受け入れる', () => {
+		expect(parseDebugSceneTime('17:30', true)).toBe((17 * 60 + 30) * 60)
+	})
+
+	test.each(['24:00', '12:60', '7:30', 'unknown'])(
+		'不正なsceneTime %sを拒否する',
+		(value) => {
+			expect(parseDebugSceneTime(value, true)).toBeUndefined()
+		},
+	)
+
+	test('sceneSpeedは0〜1440倍を受け入れる', () => {
+		expect(parseDebugSceneSpeed('0', true)).toBe(0)
+		expect(parseDebugSceneSpeed('720', true)).toBe(720)
+		expect(parseDebugSceneSpeed('1440', true)).toBe(1440)
+	})
+
+	test('デバッグ無効時はqueryを無視する', () => {
+		expect(parseDebugSceneTime('17:30', false)).toBeUndefined()
+		expect(parseDebugSceneSpeed('720', false)).toBeUndefined()
+	})
+
+	test('sceneTimeだけなら固定し、sceneSpeed併用なら加速する', () => {
+		const now = new Date('2026-08-01T00:00:00Z')
+		const frozen = createSceneClockAnchor(now, '17:30', undefined, true)
+		const accelerated = createSceneClockAnchor(now, '17:30', '720', true)
+
+		expect(getSceneClockSecondsAt(frozen, now.getTime() + 60_000)).toBe(
+			(17 * 60 + 30) * 60,
+		)
+		expect(getSceneClockSecondsAt(accelerated, now.getTime() + 60_000)).toBe(
+			(5 * 60 + 30) * 60,
+		)
+	})
+})
+
+describe('Ambient filter', () => {
+	test('SceneStateをCSS filterへ変換する', () => {
+		const filter = buildAmbientSceneFilter(
+			getSceneStateAtClockSeconds((17 * 60 + 40) * 60),
+		)
+		expect(filter).toContain('brightness(')
+		expect(filter).toContain('saturate(')
+		expect(filter).toContain('sepia(')
+		expect(filter).toContain('hue-rotate(')
+		expect(filter).toContain('contrast(')
+	})
+})

--- a/youtube-monitor/src/lib/scene-clock.ts
+++ b/youtube-monitor/src/lib/scene-clock.ts
@@ -1,0 +1,230 @@
+import { getJapanTimeParts } from './time-theme'
+
+export const SCENE_DAY_SECONDS = 24 * 60 * 60
+export const MAX_DEBUG_SCENE_SPEED = 1440
+
+export type SceneState = {
+	brightness: number
+	saturation: number
+	warmth: number
+	sunsetAmount: number
+	nightAmount: number
+	lampIntensity: number
+	skyBrightness: number
+}
+
+type SceneKeyframe = SceneState & {
+	atSeconds: number
+}
+
+export type SceneClockAnchor = {
+	realStartedAtMs: number
+	sceneStartedAtSeconds: number
+	speed: number
+}
+
+const minutes = (hours: number, mins: number) => (hours * 60 + mins) * 60
+
+const SCENE_KEYFRAMES: readonly SceneKeyframe[] = [
+	{
+		atSeconds: 0,
+		brightness: 0.78,
+		saturation: 0.88,
+		warmth: 0.08,
+		sunsetAmount: 0,
+		nightAmount: 0.82,
+		lampIntensity: 0.95,
+		skyBrightness: 0.2,
+	},
+	{
+		atSeconds: minutes(0, 25),
+		brightness: 0.72,
+		saturation: 0.82,
+		warmth: 0.04,
+		sunsetAmount: 0,
+		nightAmount: 1,
+		lampIntensity: 1,
+		skyBrightness: 0.12,
+	},
+	{
+		atSeconds: minutes(4, 55),
+		brightness: 0.84,
+		saturation: 0.9,
+		warmth: 0.38,
+		sunsetAmount: 0.06,
+		nightAmount: 0.5,
+		lampIntensity: 0.72,
+		skyBrightness: 0.45,
+	},
+	{
+		atSeconds: minutes(9, 15),
+		brightness: 1,
+		saturation: 1,
+		warmth: 0.16,
+		sunsetAmount: 0,
+		nightAmount: 0,
+		lampIntensity: 0,
+		skyBrightness: 1,
+	},
+	{
+		atSeconds: minutes(15, 15),
+		brightness: 0.98,
+		saturation: 1.02,
+		warmth: 0.36,
+		sunsetAmount: 0.18,
+		nightAmount: 0,
+		lampIntensity: 0.04,
+		skyBrightness: 0.94,
+	},
+	{
+		atSeconds: minutes(17, 40),
+		brightness: 0.9,
+		saturation: 1.04,
+		warmth: 1,
+		sunsetAmount: 1,
+		nightAmount: 0.12,
+		lampIntensity: 0.28,
+		skyBrightness: 0.68,
+	},
+	{
+		atSeconds: minutes(18, 47),
+		brightness: 0.83,
+		saturation: 0.96,
+		warmth: 0.5,
+		sunsetAmount: 0.48,
+		nightAmount: 0.5,
+		lampIntensity: 0.7,
+		skyBrightness: 0.42,
+	},
+	{
+		atSeconds: minutes(19, 55),
+		brightness: 0.78,
+		saturation: 0.88,
+		warmth: 0.12,
+		sunsetAmount: 0.04,
+		nightAmount: 0.88,
+		lampIntensity: 1,
+		skyBrightness: 0.2,
+	},
+	{
+		atSeconds: SCENE_DAY_SECONDS,
+		brightness: 0.78,
+		saturation: 0.88,
+		warmth: 0.08,
+		sunsetAmount: 0,
+		nightAmount: 0.82,
+		lampIntensity: 0.95,
+		skyBrightness: 0.2,
+	},
+]
+
+const clamp01 = (value: number) => Math.min(1, Math.max(0, value))
+const lerp = (from: number, to: number, progress: number) =>
+	from + (to - from) * progress
+
+export function normalizeSceneClockSeconds(seconds: number): number {
+	return ((seconds % SCENE_DAY_SECONDS) + SCENE_DAY_SECONDS) % SCENE_DAY_SECONDS
+}
+
+export function getJapanClockSeconds(date: Date): number {
+	const { hours, minutes, seconds } = getJapanTimeParts(date)
+	return hours * 60 * 60 + minutes * 60 + seconds
+}
+
+export function getSceneStateAtClockSeconds(clockSeconds: number): SceneState {
+	const normalized = normalizeSceneClockSeconds(clockSeconds)
+	const nextIndex = SCENE_KEYFRAMES.findIndex(
+		(keyframe) => keyframe.atSeconds > normalized,
+	)
+	const right = SCENE_KEYFRAMES[nextIndex]
+	const left = SCENE_KEYFRAMES[Math.max(0, nextIndex - 1)]
+	const duration = right.atSeconds - left.atSeconds
+	const progress = duration === 0 ? 0 : (normalized - left.atSeconds) / duration
+
+	return {
+		brightness: lerp(left.brightness, right.brightness, progress),
+		saturation: lerp(left.saturation, right.saturation, progress),
+		warmth: lerp(left.warmth, right.warmth, progress),
+		sunsetAmount: lerp(left.sunsetAmount, right.sunsetAmount, progress),
+		nightAmount: lerp(left.nightAmount, right.nightAmount, progress),
+		lampIntensity: lerp(left.lampIntensity, right.lampIntensity, progress),
+		skyBrightness: lerp(left.skyBrightness, right.skyBrightness, progress),
+	}
+}
+
+export function parseDebugSceneTime(
+	value: string | string[] | undefined,
+	debugEnabled: boolean,
+): number | undefined {
+	if (!debugEnabled || typeof value !== 'string') {
+		return undefined
+	}
+	const match = /^(\d{2}):(\d{2})$/.exec(value)
+	if (!match) {
+		return undefined
+	}
+	const hours = Number(match[1])
+	const mins = Number(match[2])
+	if (hours < 0 || hours > 23 || mins < 0 || mins > 59) {
+		return undefined
+	}
+	return minutes(hours, mins)
+}
+
+export function parseDebugSceneSpeed(
+	value: string | string[] | undefined,
+	debugEnabled: boolean,
+): number | undefined {
+	if (!debugEnabled || typeof value !== 'string' || value.trim() === '') {
+		return undefined
+	}
+	const parsed = Number(value)
+	if (
+		!Number.isFinite(parsed) ||
+		parsed < 0 ||
+		parsed > MAX_DEBUG_SCENE_SPEED
+	) {
+		return undefined
+	}
+	return parsed
+}
+
+export function createSceneClockAnchor(
+	now: Date,
+	sceneTimeQuery: string | string[] | undefined,
+	sceneSpeedQuery: string | string[] | undefined,
+	debugEnabled: boolean,
+): SceneClockAnchor {
+	const debugTime = parseDebugSceneTime(sceneTimeQuery, debugEnabled)
+	const debugSpeed = parseDebugSceneSpeed(sceneSpeedQuery, debugEnabled)
+	return {
+		realStartedAtMs: now.getTime(),
+		sceneStartedAtSeconds: debugTime ?? getJapanClockSeconds(now),
+		speed: debugSpeed ?? (debugTime === undefined ? 1 : 0),
+	}
+}
+
+export function getSceneClockSecondsAt(
+	anchor: SceneClockAnchor,
+	realNowMs: number,
+): number {
+	const elapsedRealSeconds = (realNowMs - anchor.realStartedAtMs) / 1000
+	return normalizeSceneClockSeconds(
+		anchor.sceneStartedAtSeconds + elapsedRealSeconds * anchor.speed,
+	)
+}
+
+const compactNumber = (value: number) => Number(value.toFixed(4))
+
+export function buildAmbientSceneFilter(state: SceneState): string {
+	const sepia = clamp01(state.warmth * 0.14 + state.nightAmount * 0.025)
+	const hueRotateDeg = state.nightAmount * 8 - state.sunsetAmount * 5
+	const contrast = 1 - state.nightAmount * 0.04
+	return [
+		`brightness(${compactNumber(state.brightness)})`,
+		`saturate(${compactNumber(state.saturation)})`,
+		`sepia(${compactNumber(sepia)})`,
+		`hue-rotate(${compactNumber(hueRotateDeg)}deg)`,
+		`contrast(${compactNumber(contrast)})`,
+	].join(' ')
+}

--- a/youtube-monitor/src/pages/index.tsx
+++ b/youtube-monitor/src/pages/index.tsx
@@ -17,6 +17,7 @@ import Seats from '../components/MainContent'
 import MenuDisplay from '../components/MenuDisplay'
 import Timer from '../components/Timer'
 import Usage from '../components/Usage'
+import { useLiveRoomScenesEnabled } from '../hooks/use-live-room-scenes-enabled'
 import { useSceneClockCssVariables } from '../hooks/use-scene-clock-css-variables'
 import { useTimeTheme } from '../hooks/use-time-theme'
 import { firestoreMenuConverter, getFirebaseApp } from '../lib/firestore'
@@ -27,7 +28,8 @@ const Home: FC = () => {
 	const [menuItems, setMenuItems] = useState<Menu[]>([])
 	const sceneRootRef = useRef<HTMLDivElement>(null)
 	const { timeTheme, textTone, contrastBridge } = useTimeTheme()
-	useSceneClockCssVariables(sceneRootRef)
+	const liveRoomScenesEnabled = useLiveRoomScenesEnabled()
+	useSceneClockCssVariables(sceneRootRef, liveRoomScenesEnabled)
 
 	useEffect(() => {
 		const app = getFirebaseApp()
@@ -58,6 +60,7 @@ const Home: FC = () => {
 			data-time-theme={timeTheme}
 			data-text-tone={textTone}
 			data-contrast-bridge={contrastBridge ? 'true' : undefined}
+			data-live-room-scenes={liveRoomScenesEnabled ? 'on' : 'off'}
 			style={{
 				height: 1080,
 				width: 1920,

--- a/youtube-monitor/src/pages/index.tsx
+++ b/youtube-monitor/src/pages/index.tsx
@@ -7,7 +7,7 @@ import {
 } from 'firebase/firestore'
 import type { GetStaticProps } from 'next'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
-import { type FC, useEffect, useState } from 'react'
+import { type FC, useEffect, useRef, useState } from 'react'
 import AmbientFrame from '../components/AmbientFrame'
 import BackgroundImage from '../components/BackgroundImage'
 import BgmPlayer from '../components/BgmPlayer'
@@ -17,6 +17,7 @@ import Seats from '../components/MainContent'
 import MenuDisplay from '../components/MenuDisplay'
 import Timer from '../components/Timer'
 import Usage from '../components/Usage'
+import { useSceneClockCssVariables } from '../hooks/use-scene-clock-css-variables'
 import { useTimeTheme } from '../hooks/use-time-theme'
 import { firestoreMenuConverter, getFirebaseApp } from '../lib/firestore'
 import { themedRoot } from '../styles/AmbientFrame.styles'
@@ -24,7 +25,9 @@ import type { Menu } from '../types/api'
 
 const Home: FC = () => {
 	const [menuItems, setMenuItems] = useState<Menu[]>([])
+	const sceneRootRef = useRef<HTMLDivElement>(null)
 	const { timeTheme, textTone, contrastBridge } = useTimeTheme()
+	useSceneClockCssVariables(sceneRootRef)
 
 	useEffect(() => {
 		const app = getFirebaseApp()
@@ -50,6 +53,7 @@ const Home: FC = () => {
 
 	return (
 		<div
+			ref={sceneRootRef}
 			css={themedRoot}
 			data-time-theme={timeTheme}
 			data-text-tone={textTone}

--- a/youtube-monitor/src/rooms/layouts/cafe-rainy-room.ts
+++ b/youtube-monitor/src/rooms/layouts/cafe-rainy-room.ts
@@ -2,6 +2,7 @@ import type { RoomLayout } from '../../types/room-layout'
 
 export const CafeRainyRoom: RoomLayout = {
 	floor_image: '/images/rooms/cafe-rainy-room.png',
+	scene: { mode: 'living', profile: 'lume-rainy-poc' },
 	font_size_ratio: 0.015,
 	room_shape: {
 		width: 1520,

--- a/youtube-monitor/src/scenes/living-scene-profile.ts
+++ b/youtube-monitor/src/scenes/living-scene-profile.ts
@@ -1,0 +1,28 @@
+import type { Container, Graphics, Ticker } from 'pixi.js'
+import type { LivingSceneProfile } from '../types/room-scene'
+import { createLumeRainyScene } from './lume-rainy-poc'
+
+export type LivingSceneFactoryContext = {
+	root: Container
+	ticker: Ticker
+	makeContainer: () => Container
+	makeGraphics: () => Graphics
+	getHost: () => HTMLElement | null
+}
+
+export type LivingSceneInstance = {
+	resize: (width: number, height: number) => void
+	destroy: () => void
+}
+
+export function createLivingSceneForProfile(
+	profile: LivingSceneProfile,
+	context: LivingSceneFactoryContext,
+): LivingSceneInstance | undefined {
+	switch (profile) {
+		case 'lume-rainy-poc':
+			return createLumeRainyScene(context)
+		default:
+			return undefined
+	}
+}

--- a/youtube-monitor/src/scenes/lume-rainy-poc.test.ts
+++ b/youtube-monitor/src/scenes/lume-rainy-poc.test.ts
@@ -1,0 +1,26 @@
+import { createLumeRainDropSpecs } from './lume-rainy-poc'
+
+describe('Lume rainy Living Scene', () => {
+	test('uses a small deterministic rain field', () => {
+		const first = createLumeRainDropSpecs()
+		const second = createLumeRainDropSpecs()
+
+		expect(first).toEqual(second)
+		expect(first).toHaveLength(24)
+	})
+
+	test('keeps rain motion slow and visually sparse', () => {
+		for (const drop of createLumeRainDropSpecs()) {
+			expect(drop.x).toBeGreaterThanOrEqual(0)
+			expect(drop.x).toBeLessThanOrEqual(1520)
+			expect(drop.y).toBeGreaterThanOrEqual(0)
+			expect(drop.y).toBeLessThanOrEqual(1000)
+			expect(drop.length).toBeGreaterThanOrEqual(18)
+			expect(drop.length).toBeLessThanOrEqual(34)
+			expect(drop.speed).toBeGreaterThanOrEqual(26)
+			expect(drop.speed).toBeLessThanOrEqual(46)
+			expect(drop.alpha).toBeGreaterThanOrEqual(0.1)
+			expect(drop.alpha).toBeLessThanOrEqual(0.21)
+		}
+	})
+})

--- a/youtube-monitor/src/scenes/lume-rainy-poc.test.ts
+++ b/youtube-monitor/src/scenes/lume-rainy-poc.test.ts
@@ -9,7 +9,7 @@ describe('Lume rainy Living Scene', () => {
 		expect(first).toHaveLength(24)
 	})
 
-	test('keeps rain motion slow and visually sparse', () => {
+	test('keeps rain motion slow and visually sparse while remaining reviewable', () => {
 		for (const drop of createLumeRainDropSpecs()) {
 			expect(drop.x).toBeGreaterThanOrEqual(0)
 			expect(drop.x).toBeLessThanOrEqual(1520)
@@ -19,8 +19,10 @@ describe('Lume rainy Living Scene', () => {
 			expect(drop.length).toBeLessThanOrEqual(34)
 			expect(drop.speed).toBeGreaterThanOrEqual(26)
 			expect(drop.speed).toBeLessThanOrEqual(46)
-			expect(drop.alpha).toBeGreaterThanOrEqual(0.1)
-			expect(drop.alpha).toBeLessThanOrEqual(0.21)
+			expect(drop.alpha).toBeGreaterThanOrEqual(0.28)
+			expect(drop.alpha).toBeLessThanOrEqual(0.48)
+			expect(drop.width).toBeGreaterThanOrEqual(1.05)
+			expect(drop.width).toBeLessThanOrEqual(1.75)
 		}
 	})
 })

--- a/youtube-monitor/src/scenes/lume-rainy-poc.ts
+++ b/youtube-monitor/src/scenes/lume-rainy-poc.ts
@@ -1,0 +1,236 @@
+import type { Graphics } from 'pixi.js'
+import type {
+	LivingSceneFactoryContext,
+	LivingSceneInstance,
+} from './living-scene-profile'
+
+const DESIGN_WIDTH = 1520
+const DESIGN_HEIGHT = 1000
+const SCENE_STATE_REFRESH_MS = 1000
+
+type WindowPane = {
+	x: number
+	y: number
+	width: number
+	height: number
+}
+
+export type LumeRainDropSpec = {
+	x: number
+	y: number
+	minY: number
+	maxY: number
+	length: number
+	speed: number
+	alpha: number
+	width: number
+}
+
+type AnimatedRainDrop = LumeRainDropSpec & {
+	graphic: Graphics
+}
+
+const WINDOW_PANES: readonly WindowPane[] = [
+	{ x: 122, y: 100, width: 95, height: 420 },
+	{ x: 270, y: 75, width: 120, height: 400 },
+	{ x: 450, y: 50, width: 100, height: 350 },
+	{ x: 625, y: 30, width: 110, height: 320 },
+	{ x: 850, y: 25, width: 120, height: 330 },
+	{ x: 1015, y: 65, width: 85, height: 330 },
+	{ x: 1225, y: 105, width: 85, height: 350 },
+	{ x: 1350, y: 135, width: 48, height: 345 },
+]
+
+const LAMP_GLOWS = [
+	{ x: 82, y: 260, radius: 80 },
+	{ x: 235, y: 308, radius: 78 },
+	{ x: 422, y: 245, radius: 75 },
+	{ x: 585, y: 180, radius: 88 },
+	{ x: 779, y: 106, radius: 100 },
+	{ x: 1123, y: 215, radius: 82 },
+	{ x: 1195, y: 150, radius: 90 },
+	{ x: 1295, y: 298, radius: 78 },
+	{ x: 1455, y: 260, radius: 80 },
+	{ x: 170, y: 535, radius: 42 },
+	{ x: 540, y: 422, radius: 42 },
+	{ x: 1168, y: 454, radius: 42 },
+	{ x: 510, y: 803, radius: 38 },
+] as const
+
+function createDeterministicRandom(seed: number): () => number {
+	let state = seed >>> 0
+	return () => {
+		state = (Math.imul(state, 1664525) + 1013904223) >>> 0
+		return state / 4294967296
+	}
+}
+
+export function createLumeRainDropSpecs(seed = 0x4c554d45): LumeRainDropSpec[] {
+	const random = createDeterministicRandom(seed)
+	const drops: LumeRainDropSpec[] = []
+
+	for (const pane of WINDOW_PANES) {
+		for (let index = 0; index < 3; index++) {
+			const length = 18 + random() * 16
+			drops.push({
+				x: pane.x + 8 + random() * Math.max(1, pane.width - 16),
+				y: pane.y + random() * pane.height,
+				minY: pane.y - length,
+				maxY: pane.y + pane.height,
+				length,
+				speed: 26 + random() * 20,
+				alpha: 0.1 + random() * 0.11,
+				width: 0.8 + random() * 0.7,
+			})
+		}
+	}
+
+	return drops
+}
+
+function readSceneAmount(host: HTMLElement | null, property: string): number {
+	if (host === null) {
+		return 0
+	}
+	const value = Number.parseFloat(
+		window.getComputedStyle(host).getPropertyValue(property),
+	)
+	if (!Number.isFinite(value)) {
+		return 0
+	}
+	return Math.min(1, Math.max(0, value))
+}
+
+function approach(
+	current: number,
+	target: number,
+	deltaSeconds: number,
+): number {
+	const progress = 1 - Math.exp(-2.6 * deltaSeconds)
+	return current + (target - current) * progress
+}
+
+export function createLumeRainyScene(
+	context: LivingSceneFactoryContext,
+): LivingSceneInstance {
+	const scene = context.makeContainer()
+	const atmosphere = context.makeContainer()
+	const lampGlow = context.makeContainer()
+	const rain = context.makeContainer()
+	scene.addChild(atmosphere)
+	scene.addChild(lampGlow)
+	scene.addChild(rain)
+	context.root.addChild(scene)
+
+	const nightVeil = context
+		.makeGraphics()
+		.rect(0, 0, DESIGN_WIDTH, DESIGN_HEIGHT)
+		.fill({ color: 0x1c3e5f, alpha: 1 })
+	nightVeil.alpha = 0
+	atmosphere.addChild(nightVeil)
+
+	const windowTint = context.makeGraphics()
+	for (const pane of WINDOW_PANES) {
+		windowTint
+			.rect(pane.x, pane.y, pane.width, pane.height)
+			.fill({ color: 0x275c88, alpha: 1 })
+	}
+	windowTint.alpha = 0
+	atmosphere.addChild(windowTint)
+
+	const sunsetVeil = context
+		.makeGraphics()
+		.rect(0, 0, DESIGN_WIDTH, DESIGN_HEIGHT)
+		.fill({ color: 0xc77a45, alpha: 1 })
+	sunsetVeil.alpha = 0
+	atmosphere.addChild(sunsetVeil)
+
+	const glowGraphic = context.makeGraphics()
+	for (const lamp of LAMP_GLOWS) {
+		glowGraphic
+			.circle(lamp.x, lamp.y, lamp.radius * 1.55)
+			.fill({ color: 0xffba64, alpha: 0.012 })
+			.circle(lamp.x, lamp.y, lamp.radius * 1.15)
+			.fill({ color: 0xffbd68, alpha: 0.018 })
+			.circle(lamp.x, lamp.y, lamp.radius * 0.78)
+			.fill({ color: 0xffc371, alpha: 0.028 })
+			.circle(lamp.x, lamp.y, lamp.radius * 0.42)
+			.fill({ color: 0xffca7d, alpha: 0.042 })
+	}
+	lampGlow.alpha = 0
+	lampGlow.addChild(glowGraphic)
+
+	const rainDrops: AnimatedRainDrop[] = createLumeRainDropSpecs().map(
+		(spec) => {
+			const graphic = context
+				.makeGraphics()
+				.moveTo(0, 0)
+				.lineTo(-2.2, spec.length)
+				.stroke({
+					color: 0xdceff8,
+					width: spec.width,
+					alpha: spec.alpha,
+				})
+			graphic.x = spec.x
+			graphic.y = spec.y
+			rain.addChild(graphic)
+			return { ...spec, graphic }
+		},
+	)
+	rain.alpha = 0.28
+
+	let targetNight = 0
+	let targetSunset = 0
+	let targetLamp = 0
+	let currentNight = 0
+	let currentSunset = 0
+	let currentLamp = 0
+	let stateRefreshElapsedMs = SCENE_STATE_REFRESH_MS
+
+	const refreshSceneState = () => {
+		const host = context.getHost()
+		targetNight = readSceneAmount(host, '--scene-night-amount')
+		targetSunset = readSceneAmount(host, '--scene-sunset-amount')
+		targetLamp = readSceneAmount(host, '--scene-lamp-intensity')
+	}
+
+	const update = (ticker: { deltaMS: number }) => {
+		const deltaMs = Math.min(100, Math.max(0, ticker.deltaMS))
+		const deltaSeconds = deltaMs / 1000
+		stateRefreshElapsedMs += deltaMs
+		if (stateRefreshElapsedMs >= SCENE_STATE_REFRESH_MS) {
+			stateRefreshElapsedMs %= SCENE_STATE_REFRESH_MS
+			refreshSceneState()
+		}
+
+		currentNight = approach(currentNight, targetNight, deltaSeconds)
+		currentSunset = approach(currentSunset, targetSunset, deltaSeconds)
+		currentLamp = approach(currentLamp, targetLamp, deltaSeconds)
+
+		nightVeil.alpha = currentNight * 0.18
+		windowTint.alpha = currentNight * 0.075
+		sunsetVeil.alpha = currentSunset * 0.055
+		lampGlow.alpha = currentLamp * 0.9
+		rain.alpha = 0.27 + currentNight * 0.08
+
+		for (const drop of rainDrops) {
+			drop.graphic.y += drop.speed * deltaSeconds
+			if (drop.graphic.y > drop.maxY) {
+				drop.graphic.y = drop.minY
+			}
+		}
+	}
+
+	context.ticker.add(update)
+
+	return {
+		resize: (width, height) => {
+			scene.scale.set(width / DESIGN_WIDTH, height / DESIGN_HEIGHT)
+		},
+		destroy: () => {
+			context.ticker.remove(update)
+			context.root.removeChild(scene)
+			scene.destroy({ children: true })
+		},
+	}
+}

--- a/youtube-monitor/src/scenes/lume-rainy-poc.ts
+++ b/youtube-monitor/src/scenes/lume-rainy-poc.ts
@@ -79,8 +79,8 @@ export function createLumeRainDropSpecs(seed = 0x4c554d45): LumeRainDropSpec[] {
 				maxY: pane.y + pane.height,
 				length,
 				speed: 26 + random() * 20,
-				alpha: 0.1 + random() * 0.11,
-				width: 0.8 + random() * 0.7,
+				alpha: 0.28 + random() * 0.2,
+				width: 1.05 + random() * 0.7,
 			})
 		}
 	}
@@ -149,13 +149,13 @@ export function createLumeRainyScene(
 	for (const lamp of LAMP_GLOWS) {
 		glowGraphic
 			.circle(lamp.x, lamp.y, lamp.radius * 1.55)
-			.fill({ color: 0xffba64, alpha: 0.012 })
+			.fill({ color: 0xffba64, alpha: 0.022 })
 			.circle(lamp.x, lamp.y, lamp.radius * 1.15)
-			.fill({ color: 0xffbd68, alpha: 0.018 })
+			.fill({ color: 0xffbd68, alpha: 0.036 })
 			.circle(lamp.x, lamp.y, lamp.radius * 0.78)
-			.fill({ color: 0xffc371, alpha: 0.028 })
+			.fill({ color: 0xffc371, alpha: 0.06 })
 			.circle(lamp.x, lamp.y, lamp.radius * 0.42)
-			.fill({ color: 0xffca7d, alpha: 0.042 })
+			.fill({ color: 0xffca7d, alpha: 0.095 })
 	}
 	lampGlow.alpha = 0
 	lampGlow.addChild(glowGraphic)
@@ -177,7 +177,7 @@ export function createLumeRainyScene(
 			return { ...spec, graphic }
 		},
 	)
-	rain.alpha = 0.28
+	rain.alpha = 0.52
 
 	let targetNight = 0
 	let targetSunset = 0
@@ -207,11 +207,11 @@ export function createLumeRainyScene(
 		currentSunset = approach(currentSunset, targetSunset, deltaSeconds)
 		currentLamp = approach(currentLamp, targetLamp, deltaSeconds)
 
-		nightVeil.alpha = currentNight * 0.18
-		windowTint.alpha = currentNight * 0.075
-		sunsetVeil.alpha = currentSunset * 0.055
-		lampGlow.alpha = currentLamp * 0.9
-		rain.alpha = 0.27 + currentNight * 0.08
+		nightVeil.alpha = currentNight * 0.28
+		windowTint.alpha = currentNight * 0.14
+		sunsetVeil.alpha = currentSunset * 0.12
+		lampGlow.alpha = currentLamp
+		rain.alpha = 0.52 + currentNight * 0.08
 
 		for (const drop of rainDrops) {
 			drop.graphic.y += drop.speed * deltaSeconds

--- a/youtube-monitor/src/scenes/lume-rainy-poc.ts
+++ b/youtube-monitor/src/scenes/lume-rainy-poc.ts
@@ -207,9 +207,9 @@ export function createLumeRainyScene(
 		currentSunset = approach(currentSunset, targetSunset, deltaSeconds)
 		currentLamp = approach(currentLamp, targetLamp, deltaSeconds)
 
-		nightVeil.alpha = currentNight * 0.28
-		windowTint.alpha = currentNight * 0.14
-		sunsetVeil.alpha = currentSunset * 0.12
+		nightVeil.alpha = currentNight * 0.1
+		windowTint.alpha = currentNight * 0.08
+		sunsetVeil.alpha = currentSunset * 0.045
 		lampGlow.alpha = currentLamp
 		rain.alpha = 0.52 + currentNight * 0.08
 

--- a/youtube-monitor/src/styles/LivingSceneLayer.styles.ts
+++ b/youtube-monitor/src/styles/LivingSceneLayer.styles.ts
@@ -1,0 +1,11 @@
+import { css } from '@emotion/react'
+
+export const host = css`
+	position: absolute;
+	inset: 0;
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
+	pointer-events: none;
+	z-index: 0;
+`

--- a/youtube-monitor/src/styles/LivingSceneLayer.styles.ts
+++ b/youtube-monitor/src/styles/LivingSceneLayer.styles.ts
@@ -7,5 +7,5 @@ export const host = css`
 	height: 100%;
 	overflow: hidden;
 	pointer-events: none;
-	z-index: 0;
+	z-index: 1;
 `

--- a/youtube-monitor/src/styles/SeatBox.styles.ts
+++ b/youtube-monitor/src/styles/SeatBox.styles.ts
@@ -14,6 +14,7 @@ import {
 
 export const seat = css`
     position: absolute;
+    z-index: 2;
     display: flex;
     flex-direction: column;
     transform-origin: top left;

--- a/youtube-monitor/src/styles/SeatsPage.styles.ts
+++ b/youtube-monitor/src/styles/SeatsPage.styles.ts
@@ -3,6 +3,7 @@ import { Constants } from '../lib/constants'
 
 export const roomLayout = css`
     position: relative;
+    isolation: isolate;
     top: 0;
     left: 0;
     width: 100%;
@@ -14,5 +15,6 @@ export const roomLayout = css`
 
 export const partition = css`
 	position: absolute;
+	z-index: 2;
 	background-color: #2d2b41;
 `

--- a/youtube-monitor/src/types/room-layout.d.ts
+++ b/youtube-monitor/src/types/room-layout.d.ts
@@ -1,5 +1,8 @@
+import type { RoomSceneConfig } from './room-scene'
+
 export type RoomLayout = {
 	floor_image: string
+	scene?: RoomSceneConfig
 	font_size_ratio: number
 	room_shape: {
 		height: number

--- a/youtube-monitor/src/types/room-scene.ts
+++ b/youtube-monitor/src/types/room-scene.ts
@@ -1,0 +1,15 @@
+export const ROOM_SCENE_MODES = ['ambient', 'living'] as const
+
+export type RoomSceneMode = (typeof ROOM_SCENE_MODES)[number]
+
+/**
+ * Optional visual enhancement for a room.
+ *
+ * Omitting scene keeps the room fully static. The schema is intentionally
+ * minimal here; renderer/layer details are introduced only when their runtime
+ * contracts are implemented by later Live Room Scenes PRs.
+ */
+export type RoomSceneConfig = {
+	mode: RoomSceneMode
+	profile?: string
+}

--- a/youtube-monitor/src/types/room-scene.ts
+++ b/youtube-monitor/src/types/room-scene.ts
@@ -2,14 +2,23 @@ export const ROOM_SCENE_MODES = ['ambient', 'living'] as const
 
 export type RoomSceneMode = (typeof ROOM_SCENE_MODES)[number]
 
+export const LIVING_SCENE_PROFILES = ['lume-rainy-poc'] as const
+export type LivingSceneProfile = (typeof LIVING_SCENE_PROFILES)[number]
+
+export type AmbientRoomSceneConfig = {
+	mode: 'ambient'
+	profile?: string
+}
+
+export type LivingRoomSceneConfig = {
+	mode: 'living'
+	profile: LivingSceneProfile
+}
+
 /**
  * Optional visual enhancement for a room.
  *
- * Omitting scene keeps the room fully static. The schema is intentionally
- * minimal here; renderer/layer details are introduced only when their runtime
- * contracts are implemented by later Live Room Scenes PRs.
+ * Omitting scene keeps the room fully static. Living profiles are explicit so
+ * an unknown/missing profile cannot silently start an empty WebGL renderer.
  */
-export type RoomSceneConfig = {
-	mode: RoomSceneMode
-	profile?: string
-}
+export type RoomSceneConfig = AmbientRoomSceneConfig | LivingRoomSceneConfig


### PR DESCRIPTION
## Summary

静止画ベースのRoomを壊さず、必要なRoomだけ時間帯・光・天候Motionを持つ2D Living Sceneへ拡張する基盤を統合します。

Tracks #1069.

**重要:** このPRは `dev` 向け最終integration PRです。運用ルールにより、agentはこのPRをマージしません。

## Included PRs

- #1070 Static compatibility boundary / RoomSceneConfig
- #1071 continuous JST Scene Clock + Ambient mode
- #1073 PixiJS shared WebGL runtime + Static fallback
- #1075 Lume / Main Café Floor / Rainy Living PoC
- #1076 30fps cap + init retry + WebGL context recovery
- #1077 fail-closed rollout switch + OBS rollout/rollback runbook

## Architecture

Existing responsibilities stay separated:

- React / DOM: seats, user names, work labels, page state
- Static `floor_image`: authoritative room image and fallback
- Scene Clock: continuous JST environment parameters
- PixiJS: transparent environmental enhancement only

No seat count, seat order, page order, or max-seat algorithm change is introduced.

## First Living Room

Current `CafeRainyRoom` becomes the first opt-in Living profile:

```ts
scene: { mode: 'living', profile: 'lume-rainy-poc' }
```

The existing `cafe-rainy-room.png` stays unchanged and always remains underneath the Living canvas.

Enhancement:

- 24 slow deterministic rain streaks inside selected windows
- continuous sunset warmth
- night cool veil / window tint
- lamp glow driven by Scene Clock

No camera movement, furniture movement, or new raster scene assets.

## Time model

Scene state is synchronized to JST and continuously interpolated across the day.

Debug controls:

```text
?sceneTime=17:40
?sceneSpeed=720
```

With DEBUG enabled, a full 24h cycle can be reviewed in two minutes:

```text
?liveScenes=on&sceneTime=00:00&sceneSpeed=720
```

## Runtime safety

- one shared PixiJS Application
- hidden rooms stop animation work
- Living ticker capped at 30fps
- initialization failure leaves Static visible and can retry
- `webglcontextlost` falls back to Static
- attached active room can recover on `webglcontextrestored`
- hidden/detached rooms cannot restart after delayed recovery

## Production rollout is fail-closed

Merging this PR does **not** automatically enable moving rooms.

Normal Ambient/Living rendering requires:

```text
NEXT_PUBLIC_LIVE_ROOM_SCENES_ENABLED=true
```

Missing or other values keep the monitor Static.

Emergency runtime rollback in an enabled build:

```text
?liveScenes=off
```

This does not require a rebuild.

URL force-on is DEBUG-only.

## Verification completed

Every intermediate PR passed repository CI before being merged into the integration branch.

Latest PR6 preflight:

- Biome ✅
- Jest: 13 suites / 196 tests ✅
- TypeScript ✅
- Next production compilation ✅
- production build ✅

PR4 and PR5 also passed their full formal CI Gates.

## Operator runbook

See:

`docs/development/live-room-scenes-rollout.md`

It defines:

- Static baseline
- compressed 24h visual preview
- anchor-time review
- 1920x1080 / 30fps OBS smoke test
- runtime kill-switch check
- WebGL recovery checks
- two-hour soak
- first 24h production canary
- rollback levels

## After merge

1. Keep `NEXT_PUBLIC_LIVE_ROOM_SCENES_ENABLED` unset/false for the initial deploy.
2. Verify the Static baseline is unchanged.
3. Run the DEBUG compressed visual review outside production.
4. Run OBS smoke/recovery/soak checks.
5. Only then rebuild/deploy with `NEXT_PUBLIC_LIVE_ROOM_SCENES_ENABLED=true`.
6. Keep `?liveScenes=off` ready as the immediate rollback.

## Non-goals

- 3D
- real weather API
- camera-heavy transitions
- multiple Living rooms in the first rollout
- changing seat/max-seat behavior
- automatically enabling production


## Manual review follow-up

Initial local review on the target Lume page confirmed:

- `data-live-room-scenes="on"`
- the shared Living canvas is attached at 1520×1000 and visible
- the original PoC motion was technically running, but was too subtle to distinguish reliably from the rain/light already baked into the source image

Follow-up changes on this PR:

- fixed the `data-live-room-scenes` SSR/client hydration mismatch by keeping the first render fail-closed and resolving the runtime state after mount
- added a regression test for hydration-safe debug force-on and the runtime kill switch
- kept the rain field at 24 deterministic slow streaks and kept its speed range unchanged
- increased rain visibility, night/window tint, sunset warmth, and lamp glow so the compressed 24h preview is actually reviewable without turning the scene into high-frequency motion

The tuning follows the Motion Bible rule: prefer large/slow/smooth environmental change over adding more particles or faster movement.
