### PR TITLE
chore: remove legacy DynamoDB gateway endpoint

### DIFF
--- a/aws-cdk/lib/aws-cdk-stack.ts
+++ b/aws-cdk/lib/aws-cdk-stack.ts
@@ -119,15 +119,6 @@ export class AwsCdkStack extends cdk.Stack {
 			],
 		})
 
-		// DynamoDB Gateway VPC Endpoint for secure, cost-effective access
-		// Note: This VPC uses only Public Subnets (no NAT). Gateway endpoint attaches to route tables
-		// in these public subnets and enables private DynamoDB access without NAT egress.
-		vpc.addGatewayEndpoint('DynamoDbEndpoint', {
-			service: ec2.GatewayVpcEndpointAwsService.DYNAMODB,
-			// public subnets are fine; gateway endpoints are attached to the route tables
-			// associatedRoutes can be left default to all route tables in the VPC
-		})
-
 		// 最小限のegressのみ許可するSG
 		const batchSecurityGroup = new ec2.SecurityGroup(
 			this,

--- a/aws-cdk/test/aws-cdk.test.ts
+++ b/aws-cdk/test/aws-cdk.test.ts
@@ -203,7 +203,7 @@ describe('AwsCdkStack', () => {
 		})
 	})
 
-	test('removes legacy DynamoDB credential reads while retaining the DynamoDB gateway endpoint', () => {
+	test('removes legacy DynamoDB credential reads and gateway endpoint', () => {
 		const json = createTemplate().toJSON() as {
 			Resources?: Record<
 				string,
@@ -226,7 +226,7 @@ describe('AwsCdkStack', () => {
 				resource.Type === 'AWS::EC2::VPCEndpoint' &&
 				JSON.stringify(resource.Properties?.ServiceName).includes('dynamodb'),
 		)
-		expect(dynamodbGatewayEndpoints).toHaveLength(1)
+		expect(dynamodbGatewayEndpoints).toHaveLength(0)
 	})
 
 	test('subscribes AlarmsTopic to email and Lambda notifier', () => {


### PR DESCRIPTION
## Summary

Removes the DynamoDB gateway VPC endpoint that was retained during the WIF migration rollback window.

### What changes

- remove the DynamoDB gateway endpoint from the batch VPC
- update the CDK test to assert that no DynamoDB gateway endpoint remains
- keep the WIF runtime configuration and ECS credential endpoint egress unchanged

### Why

The legacy DynamoDB-backed Google credential implementation and runtime auth switch have been removed, and development/production WIF-only validation has passed. The batch workload no longer has a runtime dependency on the DynamoDB secrets table.

### Validation

CI is green. AWS CDK tests, CDK synth, and the final CI gate pass.

Runtime rollout validation is also complete:

- development change-set contained only the DynamoDB gateway endpoint deletion
- development deploy completed successfully
- development endpoint lookup returns no DynamoDB gateway endpoint
- development daily batch completed with all three ECS tasks succeeding and no task failure events
- production change-set contained only the DynamoDB gateway endpoint deletion
- production deploy completed successfully
- production endpoint lookup returns no DynamoDB gateway endpoint
- post-deploy scheduled Lambda invocations continue successfully with no new error logs
- production Fargate validation reaches Firestore-backed configuration reads through WIF after endpoint removal; the validation job intentionally uses an unknown JOB value so none of the three business batch operations run

Operational identifiers remain in the private runbook.