### PR TITLE
feat: prepare youtube-bot Fargate WIF runtime

### DIFF
--- a/aws-cdk/README.md
+++ b/aws-cdk/README.md
@@ -37,3 +37,34 @@ aws sts get-caller-identity --profile プロファイル名
     pnpm cdk:deploy --profile プロファイル名 --parameters AlarmEmail=notify@example.com
     ```
   - 初回のみ、指定したメールに AWS から届く **Confirm subscription** のリンクを開いて承認する。コンソールから行う場合は **SNS → Topics → `AlarmsTopic` に相当するトピック → Subscriptions** で Pending を Confirm する。
+
+
+## youtube-bot Fargate Service
+
+The stack defines a dedicated `youtube-bot` Fargate Service on the existing batch VPC/cluster.
+
+Safety defaults:
+
+- `YoutubeBotDesiredCount=0`: deploying the stack alone does not start a bot task.
+- `YoutubeBotEnvironment=disabled`: the WIF/headless container rejects startup until an explicit `development` or `production` target is deployed.
+- deployment uses minimum healthy percent 0 / maximum healthy percent 100, so desired count 1 replaces the old task before starting the new task instead of temporarily running two bot tasks.
+- unexpected task exits (`EssentialContainerExited` / `TaskFailedToStart`) are forwarded to `AlarmsTopic`.
+- the bot has a dedicated task role, log group, and security group. Public-IP HTTPS egress is used to avoid adding a NAT gateway.
+
+New outputs:
+
+- `YoutubeBotTaskDefinitionArn`
+- `YoutubeBotTaskRoleArn`
+- `YoutubeBotServiceName`
+- `YoutubeBotSecurityGroupId`
+
+The safe rollout order is:
+
+1. deploy the environment with `YoutubeBotDesiredCount=0` and the correct `YoutubeBotEnvironment`;
+2. take `YoutubeBotTaskRoleArn` from the stack output and add that role to the environment's Google WIF provider condition and Service Account `workloadIdentityUser` binding;
+3. run the task definition once with container command `preflight`;
+4. only after preflight succeeds, stop the streaming-PC bot;
+5. set `YoutubeBotDesiredCount=1`;
+6. verify live-chat command/moderation behavior.
+
+Do not set desired count 1 before the old streaming-PC bot is stopped.

--- a/aws-cdk/lib/aws-cdk-stack.ts
+++ b/aws-cdk/lib/aws-cdk-stack.ts
@@ -93,6 +93,29 @@ export class AwsCdkStack extends cdk.Stack {
 			GCP_WIF_SERVICE_ACCOUNT_EMAIL: gcpWifServiceAccountEmail.valueAsString,
 		}
 
+		const youtubeBotDesiredCount = new cdk.CfnParameter(
+			this,
+			'YoutubeBotDesiredCount',
+			{
+				type: 'Number',
+				default: 0,
+				allowedValues: ['0', '1'],
+				description:
+					'Youtube bot Fargate service desired count. Keep 0 until WIF trust and preflight are complete.',
+			},
+		)
+		const youtubeBotEnvironment = new cdk.CfnParameter(
+			this,
+			'YoutubeBotEnvironment',
+			{
+				type: 'String',
+				default: 'disabled',
+				allowedValues: ['disabled', 'development', 'production'],
+				description:
+					'Explicit youtube-bot target environment. The container rejects disabled or a project mismatch.',
+			},
+		)
+
 		// =========================
 		// Secrets Manager
 		// =========================
@@ -153,6 +176,36 @@ export class AwsCdkStack extends cdk.Stack {
 			'ECS task metadata/credentials',
 		)
 
+		const youtubeBotSecurityGroup = new ec2.SecurityGroup(
+			this,
+			'YoutubeBotSecurityGroup',
+			{
+				vpc,
+				allowAllOutbound: false,
+				description: 'Minimal egress for youtube-bot Fargate service',
+			},
+		)
+		youtubeBotSecurityGroup.addEgressRule(
+			ec2.Peer.anyIpv4(),
+			ec2.Port.tcp(443),
+			'HTTPS to YouTube, Google APIs, and Discord',
+		)
+		youtubeBotSecurityGroup.addEgressRule(
+			ec2.Peer.ipv4('169.254.169.253/32'),
+			ec2.Port.tcp(53),
+			'DNS TCP to VPC resolver',
+		)
+		youtubeBotSecurityGroup.addEgressRule(
+			ec2.Peer.ipv4('169.254.169.253/32'),
+			ec2.Port.udp(53),
+			'DNS UDP to VPC resolver',
+		)
+		youtubeBotSecurityGroup.addEgressRule(
+			ec2.Peer.ipv4('169.254.170.2/32'),
+			ec2.Port.tcp(80),
+			'ECS task metadata/credentials',
+		)
+
 		const cluster = new ecs.Cluster(this, 'BatchCluster', { vpc })
 
 		const batchLogGroup = new logs.LogGroup(this, 'BatchLogGroup', {
@@ -195,9 +248,82 @@ export class AwsCdkStack extends cdk.Stack {
 			},
 		})
 
+		const youtubeBotLogGroup = new logs.LogGroup(this, 'YoutubeBotLogGroup', {
+			retention: logs.RetentionDays.INFINITE,
+		})
+		const youtubeBotImageAsset = new ecr_assets.DockerImageAsset(
+			this,
+			'YoutubeBotImage',
+			{
+				directory: systemDir,
+				file: DOCKERFILE_FARGATE,
+				platform: Platform.LINUX_ARM64,
+				buildArgs: {
+					BUILD_TARGET: './cmd/youtube-bot',
+				},
+			},
+		)
+		const youtubeBotTaskDefinition = new ecs.FargateTaskDefinition(
+			this,
+			'YoutubeBotTaskDefinition',
+			{
+				cpu: 256,
+				memoryLimitMiB: 512,
+				runtimePlatform: {
+					cpuArchitecture: ecs.CpuArchitecture.ARM64,
+					operatingSystemFamily: ecs.OperatingSystemFamily.LINUX,
+				},
+			},
+		)
+		youtubeBotTaskDefinition.addContainer('youtube-bot', {
+			image: ecs.ContainerImage.fromDockerImageAsset(youtubeBotImageAsset),
+			logging: ecs.LogDrivers.awsLogs({
+				logGroup: youtubeBotLogGroup,
+				streamPrefix: 'youtube-bot',
+			}),
+			environment: {
+				...googleAuthEnvironment,
+				YOUTUBE_BOT_AUTH_MODE: 'wif',
+				YOUTUBE_BOT_ENVIRONMENT: youtubeBotEnvironment.valueAsString,
+				AWS_REGION: cdk.Stack.of(this).region,
+				AWS_DEFAULT_REGION: cdk.Stack.of(this).region,
+			},
+		})
+
 		// SNS topic for CloudWatch alarms and subscription to Discord notify Lambda
 		const alarmsTopic = new sns.Topic(this, 'AlarmsTopic', {
 			displayName: 'youtube-study-space-alarms',
+		})
+
+		const youtubeBotService = new ecs.FargateService(
+			this,
+			'YoutubeBotService',
+			{
+				cluster,
+				taskDefinition: youtubeBotTaskDefinition,
+				serviceName: 'youtube-bot',
+				desiredCount: youtubeBotDesiredCount.valueAsNumber,
+				assignPublicIp: true,
+				vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
+				securityGroups: [youtubeBotSecurityGroup],
+				platformVersion: ecs.FargatePlatformVersion.LATEST,
+				minHealthyPercent: 0,
+				maxHealthyPercent: 100,
+				circuitBreaker: { rollback: true },
+			},
+		)
+		new events.Rule(this, 'YoutubeBotUnexpectedStopRule', {
+			eventPattern: {
+				source: ['aws.ecs'],
+				detailType: ['ECS Task State Change'],
+				detail: {
+					clusterArn: [cluster.clusterArn],
+					group: ['service:youtube-bot'],
+					lastStatus: ['STOPPED'],
+					stopCode: ['EssentialContainerExited', 'TaskFailedToStart'],
+				},
+			},
+			targets: [new targets.SnsTopic(alarmsTopic)],
 		})
 		// Unified SNS consumer Lambda for all infra/app alerts
 		const snsNotifyDiscordFunction = new lambda.DockerImageFunction(
@@ -276,6 +402,22 @@ export class AwsCdkStack extends cdk.Stack {
 		new cdk.CfnOutput(this, 'BatchVpcId', {
 			value: vpc.vpcId,
 			exportName: 'BatchVpcId',
+		})
+		new cdk.CfnOutput(this, 'YoutubeBotTaskDefinitionArn', {
+			value: youtubeBotTaskDefinition.taskDefinitionArn,
+			exportName: 'YoutubeBotTaskDefinitionArn',
+		})
+		new cdk.CfnOutput(this, 'YoutubeBotTaskRoleArn', {
+			value: youtubeBotTaskDefinition.taskRole.roleArn,
+			exportName: 'YoutubeBotTaskRoleArn',
+		})
+		new cdk.CfnOutput(this, 'YoutubeBotServiceName', {
+			value: youtubeBotService.serviceName,
+			exportName: 'YoutubeBotServiceName',
+		})
+		new cdk.CfnOutput(this, 'YoutubeBotSecurityGroupId', {
+			value: youtubeBotSecurityGroup.securityGroupId,
+			exportName: 'YoutubeBotSecurityGroupId',
 		})
 
 		// =========================

--- a/aws-cdk/test/aws-cdk.test.ts
+++ b/aws-cdk/test/aws-cdk.test.ts
@@ -100,6 +100,74 @@ describe('AwsCdkStack', () => {
 		})
 	})
 
+	test('defines youtube-bot as a dormant stop-before-start Fargate service', () => {
+		template.hasParameter('YoutubeBotDesiredCount', {
+			Type: 'Number',
+			Default: 0,
+		})
+		template.hasParameter('YoutubeBotEnvironment', {
+			Type: 'String',
+			Default: 'disabled',
+		})
+
+		template.hasResourceProperties(
+			'AWS::ECS::Service',
+			Match.objectLike({
+				ServiceName: 'youtube-bot',
+				DesiredCount: { Ref: 'YoutubeBotDesiredCount' },
+				DeploymentConfiguration: Match.objectLike({
+					MaximumPercent: 100,
+					MinimumHealthyPercent: 0,
+					DeploymentCircuitBreaker: {
+						Enable: true,
+						Rollback: true,
+					},
+				}),
+				NetworkConfiguration: Match.objectLike({
+					AwsvpcConfiguration: Match.objectLike({
+						AssignPublicIp: 'ENABLED',
+					}),
+				}),
+			}),
+		)
+
+		template.hasResourceProperties('AWS::ECS::TaskDefinition', {
+			ContainerDefinitions: Match.arrayWith([
+				Match.objectLike({
+					Name: 'youtube-bot',
+					Environment: Match.arrayWith([
+						{ Name: 'YOUTUBE_BOT_AUTH_MODE', Value: 'wif' },
+						{
+							Name: 'YOUTUBE_BOT_ENVIRONMENT',
+							Value: { Ref: 'YoutubeBotEnvironment' },
+						},
+						{
+							Name: 'GOOGLE_CLOUD_PROJECT',
+							Value: { Ref: 'GoogleCloudProject' },
+						},
+					]),
+				}),
+			]),
+		})
+	})
+
+	test('notifies on unexpected youtube-bot task stops', () => {
+		template.hasResourceProperties(
+			'AWS::Events::Rule',
+			Match.objectLike({
+				EventPattern: Match.objectLike({
+					source: ['aws.ecs'],
+					'detail-type': ['ECS Task State Change'],
+					detail: Match.objectLike({
+						group: ['service:youtube-bot'],
+						lastStatus: ['STOPPED'],
+						stopCode: ['EssentialContainerExited', 'TaskFailedToStart'],
+					}),
+				}),
+			}),
+		)
+	})
+
 	test('exposes the required batch outputs', () => {
 		template.hasOutput('BatchClusterArn', {})
 		template.hasOutput('DailyBatchTaskDefinitionArn', {})

--- a/system/README.md
+++ b/system/README.md
@@ -133,7 +133,7 @@ Fargate向けにはside-effect-freeなpreflightを用意している。
 /app/batch preflight
 ```
 
-Fargate imageは既存の `Dockerfile.fargate` を `BUILD_TARGET=./cmd/youtube-bot` でビルドするため、container内の実行ファイル名は移行中も `/app/batch` のまま。preflightはFirestoreのcredentials設定、system constants、menu docsとNGワード用Google Sheetsをread-onlyで確認し、YouTube/Discordへの投稿やFirestore更新は行わない。
+Fargate imageは既存の `Dockerfile.fargate` を `BUILD_TARGET=./cmd/youtube-bot` でビルドするため、container内の実行ファイル名は移行中も `/app/batch` のまま。preflightはFirestoreのcredentials設定、system constants、menu docsとNGワード用Google Sheetsをread-onlyで確認し、YouTube/Discordへの投稿やFirestore更新は行わない。既存の対話起動が警告対象にしているzero-value constantsもJSONへ列挙するが、`false` / `0` が正当な設定もあるため一律エラーにはしない。
 
 ECS Serviceは初期状態でdesired count 0とし、Task RoleのGoogle WIF trustとpreflightが完了するまで常駐起動しない。実切替では配信PCの旧Botを停止してからServiceを1へ上げ、同じライブチャットを2つのBotが同時処理しないことを優先する。
 

--- a/system/README.md
+++ b/system/README.md
@@ -120,6 +120,23 @@ go generate ./...
 ```
 
 
+## youtube-bot のFargate移行
+
+`cmd/youtube-bot` は移行期間中、2つのGoogle Cloud認証経路を持つ。
+
+- 既定値 / `YOUTUBE_BOT_AUTH_MODE=service-account`: 現在の配信PC互換経路。 `.env` と `CREDENTIAL_FILE_LOCATION` を読み、従来どおりproject IDの対話確認を行う。
+- `YOUTUBE_BOT_AUTH_MODE=wif`: ECS/Fargate用。 `.env` やService Account JSONを読まず、Task RoleからGoogle WIFを利用する。`YOUTUBE_BOT_ENVIRONMENT` と `GOOGLE_CLOUD_PROJECT` の組み合わせが既知のdevelopment/production対象と一致しない場合はAWS credential取得前に停止する。
+
+Fargate向けにはside-effect-freeなpreflightを用意している。
+
+```bash
+/app/batch preflight
+```
+
+Fargate imageは既存の `Dockerfile.fargate` を `BUILD_TARGET=./cmd/youtube-bot` でビルドするため、container内の実行ファイル名は移行中も `/app/batch` のまま。preflightはFirestoreのcredentials設定、system constants、menu docsとNGワード用Google Sheetsをread-onlyで確認し、YouTube/Discordへの投稿やFirestore更新は行わない。
+
+ECS Serviceは初期状態でdesired count 0とし、Task RoleのGoogle WIF trustとpreflightが完了するまで常駐起動しない。実切替では配信PCの旧Botを停止してからServiceを1へ上げ、同じライブチャットを2つのBotが同時処理しないことを優先する。
+
 ## 日次バッチ（ECS Fargate）と通知（SNS→Lambda→Discord）
 
 - 実行基盤: AWS ECS Fargate (arm64) 上の単一バッチコンテナ

--- a/system/cmd/youtube-bot/auth.go
+++ b/system/cmd/youtube-bot/auth.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"app.modules/core/utils"
+	"app.modules/internal/awsruntime"
+
+	"google.golang.org/api/option"
+	"google.golang.org/api/transport"
+)
+
+const (
+	youtubeBotAuthModeEnv     = "YOUTUBE_BOT_AUTH_MODE"
+	youtubeBotEnvironmentEnv  = "YOUTUBE_BOT_ENVIRONMENT"
+	youtubeBotAuthModeLegacy  = "service-account"
+	youtubeBotAuthModeWIF     = "wif"
+	googleCloudProjectEnvName = "GOOGLE_CLOUD_PROJECT"
+
+	youtubeBotDevelopmentProjectID = "test-youtube-study-space"
+	youtubeBotProductionProjectID  = "youtube-study-space"
+)
+
+func initGoogleClient(ctx context.Context) (option.ClientOption, bool, error) {
+	mode := strings.TrimSpace(os.Getenv(youtubeBotAuthModeEnv))
+	switch mode {
+	case "", youtubeBotAuthModeLegacy:
+		clientOption, err := initLegacyGoogleClient(ctx)
+		if err != nil {
+			return nil, false, err
+		}
+		return clientOption, true, nil
+	case youtubeBotAuthModeWIF:
+		clientOption, err := initWIFGoogleClient(ctx)
+		if err != nil {
+			return nil, false, err
+		}
+		return clientOption, false, nil
+	default:
+		return nil, false, fmt.Errorf(
+			"%s must be %q or %q, got %q",
+			youtubeBotAuthModeEnv,
+			youtubeBotAuthModeLegacy,
+			youtubeBotAuthModeWIF,
+			mode,
+		)
+	}
+}
+
+func initLegacyGoogleClient(ctx context.Context) (option.ClientOption, error) {
+	utils.LoadEnv(".env")
+	credentialFilePath := strings.TrimSpace(os.Getenv("CREDENTIAL_FILE_LOCATION"))
+	if credentialFilePath == "" {
+		return nil, errors.New("CREDENTIAL_FILE_LOCATION is required")
+	}
+
+	//nolint:staticcheck // Temporary streaming-PC path until the Fargate WIF cutover is validated.
+	clientOption := option.WithCredentialsFile(credentialFilePath)
+	creds, err := transport.Creds(ctx, clientOption)
+	if err != nil {
+		return nil, fmt.Errorf("load Google credentials: %w", err)
+	}
+
+	fmt.Printf("Project ID: %s\n", creds.ProjectID)
+	fmt.Println("Is this the correct project ID? (yes/no)")
+	var confirmation string
+	if _, err := fmt.Scanln(&confirmation); err != nil {
+		return nil, fmt.Errorf("failed to read project confirmation: %w", err)
+	}
+	if confirmation != "yes" {
+		return nil, errors.New("aborted")
+	}
+	return clientOption, nil
+}
+
+func initWIFGoogleClient(ctx context.Context) (option.ClientOption, error) {
+	environment := strings.TrimSpace(os.Getenv(youtubeBotEnvironmentEnv))
+	projectID := strings.TrimSpace(os.Getenv(googleCloudProjectEnvName))
+	if err := validateYoutubeBotTarget(environment, projectID); err != nil {
+		return nil, err
+	}
+
+	clientOption, err := awsruntime.GoogleClientOption(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("initialize youtube-bot Google WIF credentials: %w", err)
+	}
+	return clientOption, nil
+}
+
+func validateYoutubeBotTarget(environment, projectID string) error {
+	var expectedProjectID string
+	switch environment {
+	case "development":
+		expectedProjectID = youtubeBotDevelopmentProjectID
+	case "production":
+		expectedProjectID = youtubeBotProductionProjectID
+	default:
+		return fmt.Errorf(
+			"%s must be development or production, got %q",
+			youtubeBotEnvironmentEnv,
+			environment,
+		)
+	}
+	if projectID == "" {
+		return fmt.Errorf("%s is required", googleCloudProjectEnvName)
+	}
+	if projectID != expectedProjectID {
+		return fmt.Errorf(
+			"youtube-bot environment/project mismatch: environment=%q requires project=%q, configured=%q",
+			environment,
+			expectedProjectID,
+			projectID,
+		)
+	}
+	return nil
+}

--- a/system/cmd/youtube-bot/auth.go
+++ b/system/cmd/youtube-bot/auth.go
@@ -9,6 +9,7 @@ import (
 
 	"app.modules/core/utils"
 	"app.modules/internal/awsruntime"
+	"app.modules/internal/googleauth"
 
 	"google.golang.org/api/option"
 	"google.golang.org/api/transport"
@@ -20,9 +21,6 @@ const (
 	youtubeBotAuthModeLegacy  = "service-account"
 	youtubeBotAuthModeWIF     = "wif"
 	googleCloudProjectEnvName = "GOOGLE_CLOUD_PROJECT"
-
-	youtubeBotDevelopmentProjectID = "test-youtube-study-space"
-	youtubeBotProductionProjectID  = "youtube-study-space"
 )
 
 func initGoogleClient(ctx context.Context) (option.ClientOption, bool, error) {
@@ -92,18 +90,9 @@ func initWIFGoogleClient(ctx context.Context) (option.ClientOption, error) {
 }
 
 func validateYoutubeBotTarget(environment, projectID string) error {
-	var expectedProjectID string
-	switch environment {
-	case "development":
-		expectedProjectID = youtubeBotDevelopmentProjectID
-	case "production":
-		expectedProjectID = youtubeBotProductionProjectID
-	default:
-		return fmt.Errorf(
-			"%s must be development or production, got %q",
-			youtubeBotEnvironmentEnv,
-			environment,
-		)
+	expectedProjectID, err := googleauth.ProjectIDForEnvironment(environment)
+	if err != nil {
+		return fmt.Errorf("%s: %w", youtubeBotEnvironmentEnv, err)
 	}
 	if projectID == "" {
 		return fmt.Errorf("%s is required", googleCloudProjectEnvName)

--- a/system/cmd/youtube-bot/auth_test.go
+++ b/system/cmd/youtube-bot/auth_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"strings"
 	"testing"
+
+	"app.modules/internal/googleauth"
 )
 
 func TestValidateYoutubeBotTarget(t *testing.T) {
@@ -14,12 +16,12 @@ func TestValidateYoutubeBotTarget(t *testing.T) {
 		{
 			name:        "development",
 			environment: "development",
-			projectID:   youtubeBotDevelopmentProjectID,
+			projectID:   googleauth.DevelopmentProjectID,
 		},
 		{
 			name:        "production",
 			environment: "production",
-			projectID:   youtubeBotProductionProjectID,
+			projectID:   googleauth.ProductionProjectID,
 		},
 	}
 	for _, tt := range tests {
@@ -32,14 +34,14 @@ func TestValidateYoutubeBotTarget(t *testing.T) {
 }
 
 func TestValidateYoutubeBotTargetRejectsUnknownEnvironment(t *testing.T) {
-	err := validateYoutubeBotTarget("disabled", youtubeBotDevelopmentProjectID)
+	err := validateYoutubeBotTarget("disabled", googleauth.DevelopmentProjectID)
 	if err == nil || !strings.Contains(err.Error(), youtubeBotEnvironmentEnv) {
 		t.Fatalf("expected environment error, got %v", err)
 	}
 }
 
 func TestValidateYoutubeBotTargetRejectsProjectMismatch(t *testing.T) {
-	err := validateYoutubeBotTarget("development", youtubeBotProductionProjectID)
+	err := validateYoutubeBotTarget("development", googleauth.ProductionProjectID)
 	if err == nil || !strings.Contains(err.Error(), "environment/project mismatch") {
 		t.Fatalf("expected project mismatch, got %v", err)
 	}
@@ -64,7 +66,7 @@ func TestInitGoogleClientRejectsUnknownModeBeforeCredentialAccess(t *testing.T) 
 func TestInitGoogleClientWIFRejectsTargetBeforeAWSCredentialAccess(t *testing.T) {
 	t.Setenv(youtubeBotAuthModeEnv, youtubeBotAuthModeWIF)
 	t.Setenv(youtubeBotEnvironmentEnv, "development")
-	t.Setenv(googleCloudProjectEnvName, youtubeBotProductionProjectID)
+	t.Setenv(googleCloudProjectEnvName, googleauth.ProductionProjectID)
 	t.Setenv("GCP_WIF_AUDIENCE", "")
 	t.Setenv("GCP_WIF_SERVICE_ACCOUNT_EMAIL", "")
 

--- a/system/cmd/youtube-bot/auth_test.go
+++ b/system/cmd/youtube-bot/auth_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateYoutubeBotTarget(t *testing.T) {
+	tests := []struct {
+		name        string
+		environment string
+		projectID   string
+	}{
+		{
+			name:        "development",
+			environment: "development",
+			projectID:   youtubeBotDevelopmentProjectID,
+		},
+		{
+			name:        "production",
+			environment: "production",
+			projectID:   youtubeBotProductionProjectID,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := validateYoutubeBotTarget(tt.environment, tt.projectID); err != nil {
+				t.Fatalf("validateYoutubeBotTarget returned error: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateYoutubeBotTargetRejectsUnknownEnvironment(t *testing.T) {
+	err := validateYoutubeBotTarget("disabled", youtubeBotDevelopmentProjectID)
+	if err == nil || !strings.Contains(err.Error(), youtubeBotEnvironmentEnv) {
+		t.Fatalf("expected environment error, got %v", err)
+	}
+}
+
+func TestValidateYoutubeBotTargetRejectsProjectMismatch(t *testing.T) {
+	err := validateYoutubeBotTarget("development", youtubeBotProductionProjectID)
+	if err == nil || !strings.Contains(err.Error(), "environment/project mismatch") {
+		t.Fatalf("expected project mismatch, got %v", err)
+	}
+}
+
+func TestValidateYoutubeBotTargetRequiresProjectID(t *testing.T) {
+	err := validateYoutubeBotTarget("development", "")
+	if err == nil || !strings.Contains(err.Error(), googleCloudProjectEnvName) {
+		t.Fatalf("expected missing project ID error, got %v", err)
+	}
+}
+
+func TestInitGoogleClientRejectsUnknownModeBeforeCredentialAccess(t *testing.T) {
+	t.Setenv(youtubeBotAuthModeEnv, "unknown")
+
+	_, _, err := initGoogleClient(t.Context())
+	if err == nil || !strings.Contains(err.Error(), youtubeBotAuthModeEnv) {
+		t.Fatalf("expected auth mode error, got %v", err)
+	}
+}
+
+func TestInitGoogleClientWIFRejectsTargetBeforeAWSCredentialAccess(t *testing.T) {
+	t.Setenv(youtubeBotAuthModeEnv, youtubeBotAuthModeWIF)
+	t.Setenv(youtubeBotEnvironmentEnv, "development")
+	t.Setenv(googleCloudProjectEnvName, youtubeBotProductionProjectID)
+	t.Setenv("GCP_WIF_AUDIENCE", "")
+	t.Setenv("GCP_WIF_SERVICE_ACCOUNT_EMAIL", "")
+
+	_, _, err := initGoogleClient(t.Context())
+	if err == nil || !strings.Contains(err.Error(), "environment/project mismatch") {
+		t.Fatalf("expected target mismatch before WIF config access, got %v", err)
+	}
+}

--- a/system/cmd/youtube-bot/main.go
+++ b/system/cmd/youtube-bot/main.go
@@ -50,18 +50,17 @@ func CalculateRetryIntervalSec(base float64, numContinuousFailed int) float64 {
 	return math.Min(MaxRetryIntervalSeconds, math.Pow(base, float64(numContinuousFailed)))
 }
 
-func Bot(ctx context.Context, clientOption option.ClientOption, interactive bool) {
+func Bot(ctx context.Context, clientOption option.ClientOption, interactive bool) error {
 	app, err := workspaceapp.NewWorkspaceApp(ctx, interactive, clientOption)
 	if err != nil {
-		slog.ErrorContext(ctx, "failed core.NewWorkspaceApp()", "error", err)
-		return
+		return fmt.Errorf("initialize workspace app: %w", err)
 	}
 	defer app.CloseFirestoreClient()
 
 	ngWordConfig, err := loadNGWordConfig(ctx, clientOption, app.Configs.Constants.BotConfigSpreadsheetID)
 	if err != nil {
 		app.MessageToOwnerWithError(ctx, "failed loadNGWordConfig()", err)
-		return
+		return fmt.Errorf("load NG word config: %w", err)
 	}
 
 	app.MessageToOwner(ctx, fmt.Sprintf("Botが起動しました。\n全規制ワード数: %d", ngWordConfig.Count()))
@@ -228,5 +227,7 @@ func main() {
 		panic("usage: youtube-bot [preflight]")
 	}
 
-	Bot(ctx, clientOption, interactive)
+	if err := Bot(ctx, clientOption, interactive); err != nil {
+		panic(err)
+	}
 }

--- a/system/cmd/youtube-bot/main.go
+++ b/system/cmd/youtube-bot/main.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"app.modules/core/workspaceapp"
@@ -57,16 +56,6 @@ func Bot(ctx context.Context, clientOption option.ClientOption, interactive bool
 		return fmt.Errorf("initialize workspace app: %w", err)
 	}
 	defer app.CloseFirestoreClient()
-
-	if !interactive {
-		uninitializedFields := workspaceapp.UninitializedConstantsFields(app.Configs.Constants)
-		if len(uninitializedFields) > 0 {
-			return fmt.Errorf(
-				"system constants contain zero values in headless mode: %s",
-				strings.Join(uninitializedFields, ", "),
-			)
-		}
-	}
 
 	ngWordConfig, err := loadNGWordConfig(ctx, clientOption, app.Configs.Constants.BotConfigSpreadsheetID)
 	if err != nil {

--- a/system/cmd/youtube-bot/main.go
+++ b/system/cmd/youtube-bot/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"math"
@@ -18,10 +17,7 @@ import (
 	"app.modules/core/youtubebot"
 
 	"google.golang.org/api/option"
-	"google.golang.org/api/transport"
-
 	"app.modules/core/timeutil"
-	"app.modules/core/utils"
 )
 
 const (
@@ -29,29 +25,13 @@ const (
 	RetryIntervalCalculationBase = 1.2
 )
 
-func Init() (option.ClientOption, context.Context, error) {
-	utils.LoadEnv(".env")
-	credentialFilePath := os.Getenv("CREDENTIAL_FILE_LOCATION")
-
+func Init() (option.ClientOption, context.Context, bool, error) {
 	ctx := context.Background()
-	//nolint:staticcheck // Credential file path is repo/operator-controlled and restricted to the service account JSON used for this app.
-	clientOption := option.WithCredentialsFile(credentialFilePath)
-
-	creds, err := transport.Creds(ctx, clientOption)
+	clientOption, interactive, err := initGoogleClient(ctx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("load Google credentials: %w", err)
+		return nil, nil, false, err
 	}
-	fmt.Printf("Project ID: %s\n", creds.ProjectID)
-	fmt.Println("Is this the correct project ID? (yes/no)")
-	var s string
-	if _, err := fmt.Scanln(&s); err != nil {
-		return nil, nil, fmt.Errorf("failed to read project confirmation: %w", err)
-	}
-	if s != "yes" {
-		return nil, nil, errors.New("aborted")
-	}
-
-	return clientOption, ctx, nil
+	return clientOption, ctx, interactive, nil
 }
 
 func CheckLongTimeSitting(ctx context.Context, clientOption option.ClientOption) {
@@ -70,8 +50,8 @@ func CalculateRetryIntervalSec(base float64, numContinuousFailed int) float64 {
 	return math.Min(MaxRetryIntervalSeconds, math.Pow(base, float64(numContinuousFailed)))
 }
 
-func Bot(ctx context.Context, clientOption option.ClientOption) {
-	app, err := workspaceapp.NewWorkspaceApp(ctx, true, clientOption)
+func Bot(ctx context.Context, clientOption option.ClientOption, interactive bool) {
+	app, err := workspaceapp.NewWorkspaceApp(ctx, interactive, clientOption)
 	if err != nil {
 		slog.ErrorContext(ctx, "failed core.NewWorkspaceApp()", "error", err)
 		return
@@ -230,10 +210,23 @@ func loadNGWordConfig(
 }
 
 func main() {
-	clientOption, ctx, err := Init()
+	clientOption, ctx, interactive, err := Init()
 	if err != nil {
 		panic(err)
 	}
 
-	Bot(ctx, clientOption)
+	if len(os.Args) == 2 && os.Args[1] == "preflight" {
+		if interactive {
+			panic("youtube-bot preflight requires WIF/headless mode")
+		}
+		if err := Preflight(ctx, clientOption, os.Stdout); err != nil {
+			panic(err)
+		}
+		return
+	}
+	if len(os.Args) != 1 {
+		panic("usage: youtube-bot [preflight]")
+	}
+
+	Bot(ctx, clientOption, interactive)
 }

--- a/system/cmd/youtube-bot/main.go
+++ b/system/cmd/youtube-bot/main.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"app.modules/core/workspaceapp"
@@ -56,6 +57,16 @@ func Bot(ctx context.Context, clientOption option.ClientOption, interactive bool
 		return fmt.Errorf("initialize workspace app: %w", err)
 	}
 	defer app.CloseFirestoreClient()
+
+	if !interactive {
+		uninitializedFields := workspaceapp.UninitializedConstantsFields(app.Configs.Constants)
+		if len(uninitializedFields) > 0 {
+			return fmt.Errorf(
+				"system constants contain zero values in headless mode: %s",
+				strings.Join(uninitializedFields, ", "),
+			)
+		}
+	}
 
 	ngWordConfig, err := loadNGWordConfig(ctx, clientOption, app.Configs.Constants.BotConfigSpreadsheetID)
 	if err != nil {

--- a/system/cmd/youtube-bot/preflight.go
+++ b/system/cmd/youtube-bot/preflight.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"app.modules/core/repository"
+	"app.modules/core/workspaceapp"
 
 	"google.golang.org/api/option"
 )
@@ -45,6 +46,13 @@ func Preflight(ctx context.Context, clientOption option.ClientOption, stdout io.
 	constants, err := repo.ReadSystemConstantsConfig(ctx, nil)
 	if err != nil {
 		return fmt.Errorf("read system constants: %w", err)
+	}
+	uninitializedFields := workspaceapp.UninitializedConstantsFields(constants)
+	if len(uninitializedFields) > 0 {
+		return fmt.Errorf(
+			"system constants contain zero values: %s",
+			strings.Join(uninitializedFields, ", "),
+		)
 	}
 	menuDocs, err := repo.ReadAllMenuDocsOrderByCode(ctx)
 	if err != nil {

--- a/system/cmd/youtube-bot/preflight.go
+++ b/system/cmd/youtube-bot/preflight.go
@@ -20,7 +20,8 @@ type youtubeBotPreflightOutput struct {
 	CredentialsRead   bool   `json:"credentials_read"`
 	SystemConstants   bool   `json:"system_constants_read"`
 	MenuDocuments     int    `json:"menu_documents"`
-	NGWordConfigCount int    `json:"ng_word_config_count"`
+	NGWordConfigCount       int      `json:"ng_word_config_count"`
+	ZeroValueConstantFields []string `json:"zero_value_constant_fields,omitempty"`
 }
 
 func Preflight(ctx context.Context, clientOption option.ClientOption, stdout io.Writer) error {
@@ -48,12 +49,6 @@ func Preflight(ctx context.Context, clientOption option.ClientOption, stdout io.
 		return fmt.Errorf("read system constants: %w", err)
 	}
 	uninitializedFields := workspaceapp.UninitializedConstantsFields(constants)
-	if len(uninitializedFields) > 0 {
-		return fmt.Errorf(
-			"system constants contain zero values: %s",
-			strings.Join(uninitializedFields, ", "),
-		)
-	}
 	menuDocs, err := repo.ReadAllMenuDocsOrderByCode(ctx)
 	if err != nil {
 		return fmt.Errorf("read menu docs: %w", err)
@@ -71,7 +66,8 @@ func Preflight(ctx context.Context, clientOption option.ClientOption, stdout io.
 		CredentialsRead:   true,
 		SystemConstants:   true,
 		MenuDocuments:     len(menuDocs),
-		NGWordConfigCount: ngWordConfig.Count(),
+		NGWordConfigCount:       ngWordConfig.Count(),
+		ZeroValueConstantFields: uninitializedFields,
 	}); err != nil {
 		return fmt.Errorf("encode youtube-bot preflight output: %w", err)
 	}

--- a/system/cmd/youtube-bot/preflight.go
+++ b/system/cmd/youtube-bot/preflight.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"app.modules/core/repository"
+
+	"google.golang.org/api/option"
+)
+
+type youtubeBotPreflightOutput struct {
+	Environment       string `json:"environment"`
+	ProjectID         string `json:"project_id"`
+	CredentialsRead   bool   `json:"credentials_read"`
+	SystemConstants   bool   `json:"system_constants_read"`
+	MenuDocuments     int    `json:"menu_documents"`
+	NGWordConfigCount int    `json:"ng_word_config_count"`
+}
+
+func Preflight(ctx context.Context, clientOption option.ClientOption, stdout io.Writer) error {
+	environment := strings.TrimSpace(os.Getenv(youtubeBotEnvironmentEnv))
+	projectID := strings.TrimSpace(os.Getenv(googleCloudProjectEnvName))
+	if err := validateYoutubeBotTarget(environment, projectID); err != nil {
+		return fmt.Errorf("validate youtube-bot target: %w", err)
+	}
+
+	repo, err := repository.NewFirestoreController(ctx, clientOption)
+	if err != nil {
+		return fmt.Errorf("initialize Firestore: %w", err)
+	}
+	defer func() {
+		if err := repo.FirestoreClient().Close(); err != nil {
+			fmt.Fprintln(os.Stderr, "youtube-bot preflight: close Firestore:", err)
+		}
+	}()
+
+	if _, err := repo.ReadCredentialsConfig(ctx, nil); err != nil {
+		return fmt.Errorf("read credentials config: %w", err)
+	}
+	constants, err := repo.ReadSystemConstantsConfig(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("read system constants: %w", err)
+	}
+	menuDocs, err := repo.ReadAllMenuDocsOrderByCode(ctx)
+	if err != nil {
+		return fmt.Errorf("read menu docs: %w", err)
+	}
+	ngWordConfig, err := loadNGWordConfig(ctx, clientOption, constants.BotConfigSpreadsheetID)
+	if err != nil {
+		return fmt.Errorf("read NG word config: %w", err)
+	}
+
+	encoder := json.NewEncoder(stdout)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(youtubeBotPreflightOutput{
+		Environment:       environment,
+		ProjectID:         projectID,
+		CredentialsRead:   true,
+		SystemConstants:   true,
+		MenuDocuments:     len(menuDocs),
+		NGWordConfigCount: ngWordConfig.Count(),
+	}); err != nil {
+		return fmt.Errorf("encode youtube-bot preflight output: %w", err)
+	}
+	return nil
+}

--- a/system/core/workspaceapp/workspace_app.go
+++ b/system/core/workspaceapp/workspace_app.go
@@ -46,6 +46,21 @@ type Configs struct {
 	LiveChatBotChannelID string
 }
 
+// UninitializedConstantsFields returns zero-valued system constant fields using
+// the same check as the interactive workspace startup guard.
+func UninitializedConstantsFields(constants repository.ConstantsConfigDoc) []string {
+	v := reflect.ValueOf(constants)
+	var uninitializedFields []string
+	for i := 0; i < v.NumField(); i++ {
+		if v.Field(i).IsZero() {
+			fieldName := v.Type().Field(i).Name
+			fieldValue := fmt.Sprintf("%v", v.Field(i))
+			uninitializedFields = append(uninitializedFields, fieldName+" = "+fieldValue)
+		}
+	}
+	return uninitializedFields
+}
+
 func NewWorkspaceApp(ctx context.Context, interactive bool, clientOption option.ClientOption) (*WorkspaceApp, error) {
 	if err := i18n.LoadLocaleFolderFS(); err != nil {
 		return nil, fmt.Errorf("in LoadLocaleFolderFS(): %w", err)
@@ -100,15 +115,7 @@ func NewWorkspaceApp(ctx context.Context, interactive bool, clientOption option.
 	}
 
 	// 全ての項目が初期化できているか確認
-	v := reflect.ValueOf(configs.Constants)
-	var uninitializedFields []string
-	for i := 0; i < v.NumField(); i++ {
-		if v.Field(i).IsZero() {
-			fieldName := v.Type().Field(i).Name
-			fieldValue := fmt.Sprintf("%v", v.Field(i))
-			uninitializedFields = append(uninitializedFields, fieldName+" = "+fieldValue)
-		}
-	}
+	uninitializedFields := UninitializedConstantsFields(configs.Constants)
 
 	if interactive && len(uninitializedFields) > 0 {
 		fmt.Println("The following fields may not be initialized:")

--- a/system/internal/googleauth/target.go
+++ b/system/internal/googleauth/target.go
@@ -1,0 +1,19 @@
+package googleauth
+
+import "fmt"
+
+const (
+	DevelopmentProjectID = "test-youtube-study-space"
+	ProductionProjectID  = "youtube-study-space"
+)
+
+func ProjectIDForEnvironment(environment string) (string, error) {
+	switch environment {
+	case "development":
+		return DevelopmentProjectID, nil
+	case "production":
+		return ProductionProjectID, nil
+	default:
+		return "", fmt.Errorf("environment must be development or production: %q", environment)
+	}
+}

--- a/system/internal/googleauth/target_test.go
+++ b/system/internal/googleauth/target_test.go
@@ -1,0 +1,34 @@
+package googleauth
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestProjectIDForEnvironment(t *testing.T) {
+	tests := []struct {
+		environment string
+		want        string
+	}{
+		{environment: "development", want: DevelopmentProjectID},
+		{environment: "production", want: ProductionProjectID},
+	}
+	for _, tt := range tests {
+		t.Run(tt.environment, func(t *testing.T) {
+			got, err := ProjectIDForEnvironment(tt.environment)
+			if err != nil {
+				t.Fatalf("ProjectIDForEnvironment returned error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("project ID = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProjectIDForEnvironmentRejectsUnknownEnvironment(t *testing.T) {
+	_, err := ProjectIDForEnvironment("staging")
+	if err == nil || !strings.Contains(err.Error(), "development or production") {
+		t.Fatalf("expected environment error, got %v", err)
+	}
+}

--- a/system/internal/operatorauth/google.go
+++ b/system/internal/operatorauth/google.go
@@ -10,15 +10,13 @@ import (
 	"google.golang.org/api/option"
 
 	"app.modules/internal/awsruntime"
+	"app.modules/internal/googleauth"
 )
 
 const (
 	awsAccessKeyIDEnv     = "AWS_ACCESS_KEY_ID"
 	awsSecretAccessKeyEnv = "AWS_SECRET_ACCESS_KEY"
 	awsSessionTokenEnv    = "AWS_SESSION_TOKEN"
-
-	developmentProjectID = "test-youtube-study-space"
-	productionProjectID  = "youtube-study-space"
 
 	developmentAWSProfile = "soraride-google-operator-dev"
 	productionAWSProfile  = "soraride-google-operator-prod"
@@ -33,7 +31,11 @@ type GoogleConfig struct {
 
 func GoogleConfigFromEnv(environment, expectedProjectID string) (GoogleConfig, error) {
 	environment = strings.TrimSpace(environment)
-	environmentProjectID, awsProfile, err := targetForEnvironment(environment)
+	environmentProjectID, err := googleauth.ProjectIDForEnvironment(environment)
+	if err != nil {
+		return GoogleConfig{}, fmt.Errorf("resolve Google project target: %w", err)
+	}
+	awsProfile, err := operatorProfileForEnvironment(environment)
 	if err != nil {
 		return GoogleConfig{}, err
 	}
@@ -89,14 +91,14 @@ func (c GoogleConfig) ClientOption(ctx context.Context) (option.ClientOption, er
 	return clientOption, nil
 }
 
-func targetForEnvironment(environment string) (string, string, error) {
+func operatorProfileForEnvironment(environment string) (string, error) {
 	switch environment {
 	case "development":
-		return developmentProjectID, developmentAWSProfile, nil
+		return developmentAWSProfile, nil
 	case "production":
-		return productionProjectID, productionAWSProfile, nil
+		return productionAWSProfile, nil
 	default:
-		return "", "", fmt.Errorf("environment must be development or production: %q", environment)
+		return "", fmt.Errorf("operator profile is not configured for environment %q", environment)
 	}
 }
 

--- a/system/internal/operatorauth/google_test.go
+++ b/system/internal/operatorauth/google_test.go
@@ -3,6 +3,8 @@ package operatorauth
 import (
 	"strings"
 	"testing"
+
+	"app.modules/internal/googleauth"
 )
 
 func clearStaticAWSEnv(t *testing.T) {
@@ -15,18 +17,18 @@ func clearStaticAWSEnv(t *testing.T) {
 func TestGoogleConfigFromEnv(t *testing.T) {
 	clearStaticAWSEnv(t)
 	t.Setenv("AWS_PROFILE", "broad-profile-that-must-be-ignored")
-	t.Setenv("GOOGLE_CLOUD_PROJECT", developmentProjectID)
+	t.Setenv("GOOGLE_CLOUD_PROJECT", googleauth.DevelopmentProjectID)
 	t.Setenv("GCP_WIF_AUDIENCE", "//iam.googleapis.com/projects/123/locations/global/workloadIdentityPools/operator/providers/aws")
 	t.Setenv("GCP_WIF_SERVICE_ACCOUNT_EMAIL", "operator@test-youtube-study-space.iam.gserviceaccount.com")
 
-	got, err := GoogleConfigFromEnv("development", developmentProjectID)
+	got, err := GoogleConfigFromEnv("development", googleauth.DevelopmentProjectID)
 	if err != nil {
 		t.Fatalf("GoogleConfigFromEnv returned error: %v", err)
 	}
 	if got.Environment != "development" {
 		t.Fatalf("environment = %q", got.Environment)
 	}
-	if got.ProjectID != developmentProjectID {
+	if got.ProjectID != googleauth.DevelopmentProjectID {
 		t.Fatalf("project ID = %q", got.ProjectID)
 	}
 	if got.AWSProfile != developmentAWSProfile {
@@ -36,11 +38,11 @@ func TestGoogleConfigFromEnv(t *testing.T) {
 
 func TestGoogleConfigFromEnvBindsProductionProfile(t *testing.T) {
 	clearStaticAWSEnv(t)
-	t.Setenv("GOOGLE_CLOUD_PROJECT", productionProjectID)
+	t.Setenv("GOOGLE_CLOUD_PROJECT", googleauth.ProductionProjectID)
 	t.Setenv("GCP_WIF_AUDIENCE", "audience")
 	t.Setenv("GCP_WIF_SERVICE_ACCOUNT_EMAIL", "operator@example.iam.gserviceaccount.com")
 
-	got, err := GoogleConfigFromEnv("production", productionProjectID)
+	got, err := GoogleConfigFromEnv("production", googleauth.ProductionProjectID)
 	if err != nil {
 		t.Fatalf("GoogleConfigFromEnv returned error: %v", err)
 	}
@@ -50,7 +52,7 @@ func TestGoogleConfigFromEnvBindsProductionProfile(t *testing.T) {
 }
 
 func TestGoogleConfigFromEnvRejectsEnvironmentProjectMismatch(t *testing.T) {
-	_, err := GoogleConfigFromEnv("development", productionProjectID)
+	_, err := GoogleConfigFromEnv("development", googleauth.ProductionProjectID)
 	if err == nil || !strings.Contains(err.Error(), "environment/project mismatch") {
 		t.Fatalf("expected environment/project mismatch, got %v", err)
 	}
@@ -58,11 +60,11 @@ func TestGoogleConfigFromEnvRejectsEnvironmentProjectMismatch(t *testing.T) {
 
 func TestGoogleConfigFromEnvRejectsConfiguredProjectMismatch(t *testing.T) {
 	clearStaticAWSEnv(t)
-	t.Setenv("GOOGLE_CLOUD_PROJECT", developmentProjectID)
+	t.Setenv("GOOGLE_CLOUD_PROJECT", googleauth.DevelopmentProjectID)
 	t.Setenv("GCP_WIF_AUDIENCE", "audience")
 	t.Setenv("GCP_WIF_SERVICE_ACCOUNT_EMAIL", "operator@example.iam.gserviceaccount.com")
 
-	_, err := GoogleConfigFromEnv("production", productionProjectID)
+	_, err := GoogleConfigFromEnv("production", googleauth.ProductionProjectID)
 	if err == nil || !strings.Contains(err.Error(), "GCP project mismatch") {
 		t.Fatalf("expected project mismatch, got %v", err)
 	}
@@ -72,11 +74,11 @@ func TestGoogleConfigFromEnvRejectsStaticAWSCredentials(t *testing.T) {
 	t.Setenv("AWS_ACCESS_KEY_ID", "AKIAEXAMPLE")
 	t.Setenv("AWS_SECRET_ACCESS_KEY", "secret")
 	t.Setenv("AWS_SESSION_TOKEN", "session")
-	t.Setenv("GOOGLE_CLOUD_PROJECT", developmentProjectID)
+	t.Setenv("GOOGLE_CLOUD_PROJECT", googleauth.DevelopmentProjectID)
 	t.Setenv("GCP_WIF_AUDIENCE", "audience")
 	t.Setenv("GCP_WIF_SERVICE_ACCOUNT_EMAIL", "operator@example.iam.gserviceaccount.com")
 
-	_, err := GoogleConfigFromEnv("development", developmentProjectID)
+	_, err := GoogleConfigFromEnv("development", googleauth.DevelopmentProjectID)
 	if err == nil || !strings.Contains(err.Error(), "must be unset") {
 		t.Fatalf("expected static AWS credential rejection, got %v", err)
 	}


### PR DESCRIPTION
> [!NOTE]
> 2026-09-19: This PR is intentionally abandoned. We decided to keep `youtube-bot` on the streaming PC instead of moving it to a 24/7 ECS Fargate Service because the recurring cloud cost is not justified by the operational/security benefit for this workload. The future security improvement is limited to creating a dedicated, least-privilege Google Service Account for `youtube-bot`; that work will be handled separately.

## Goal

Prepare `youtube-bot` to run headlessly on ECS Fargate with Task Role -> Google WIF authentication, while keeping the current streaming-PC service-account path unchanged until cutover.

## Stack

1. #1084 operator WIF preflight, merged to the integration branch
2. **This PR**: youtube-bot headless/WIF mode + side-effect-free preflight + dormant Fargate Service
3. Planned: migrate/remove remaining local service-account credential consumers

Integration branch: `infra/google-auth-key-retirement`.

## Key invariants

- Current streaming-PC startup remains the default: `.env` + `CREDENTIAL_FILE_LOCATION` + interactive project confirmation.
- Fargate explicitly sets `YOUTUBE_BOT_AUTH_MODE=wif`; that path does not load `.env` or a Google JSON key.
- WIF startup binds `development` / `production` to the known Google project before AWS credential access.
- `preflight` only reads Firestore credentials config, system constants, menu docs, and the NG-word Google Sheet. It does not post to YouTube/Discord or mutate Firestore.
- The ECS Service defaults to `YoutubeBotDesiredCount=0`, so merging/deploying the stack without an explicit cutover cannot start a second bot.
- At desired count 1, deployment is stop-before-start via min healthy 0 / max healthy 100.
- Unexpected task exits are sent to the existing alarm SNS topic.
- Startup initialization failures now propagate as a non-zero process exit for ECS.

## Non-goals

- No AWS/GCP deployment in this PR.
- No Google WIF provider/Service Account trust mutation.
- No production bot cutover.
- No Service Account key disable/delete.
- No migration of the remaining admin/audit commands.

## Verification

GitHub Actions is the deterministic verification gate. This PR changes both `system/` and `aws-cdk/`, so Go tests/lint/generated checks/Firestore Emulator and AWS CDK tests must all pass.

No real `youtube-bot` is executed during CI.