### PR TITLE
feat(youtube-monitor): Runtime Room実寸プレビューとvalidatorを追加

### DIFF
--- a/youtube-monitor/README.md
+++ b/youtube-monitor/README.md
@@ -54,6 +54,39 @@ pnpm build
 
 These values are **build-only placeholders**. They do not prove connectivity or behavior against a deployed environment.
 
+## Runtime Roomの実寸プレビュー
+
+Runtime Room画像は、最終配信フレーム（1920 × 1080）の左上1520 × 1000へ表示します。右400pxはサイドバー、下80pxはメッセージ領域です。新規Runtime RoomのClean Imageは当面1520 × 1000を正とし、16:9画像を暗黙に引き伸ばしません。
+
+Storybookの `Development/Runtime Room Preview` では、本番と同じ `SeatsPage` / `SeatBox` / CSS / 左上原点の座標変換を使い、全体フレーム上で実寸相当の配置を確認できます。Firestoreや実環境APIへは接続しません。
+
+```sh
+cd youtube-monitor
+NEXT_PUBLIC_DEBUG=false \
+NEXT_PUBLIC_CHANNEL_GL=false \
+NEXT_PUBLIC_ROOM_CONFIG=DEV \
+NEXT_PUBLIC_API_ENDPOINT=http://localhost:3000 \
+NEXT_PUBLIC_API_KEY=preview-dummy-api-key \
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=preview-dummy-project \
+NEXT_PUBLIC_FIREBASE_API_KEY=preview-dummy-firebase-api-key \
+pnpm storybook
+```
+
+プレビュー上部のボタンで `general`（140 × 100）と `member`（230 × 150）を切り替えます。同じ画像・同じSeat Anchorを維持したまま、メンバー席でのstress testができます。チェックボックスでSeat Zone、Protected Visual Zone、main circulation、Seat Anchor、回転後外接矩形、validation結果を個別に表示できます。赤い外接矩形と `FAIL` は、SeatBox同士の正の面積を持つ重なり、Room外へのはみ出し、保護領域・主動線への侵入、指定Seat Zone外のいずれかを表します。境界へ接しているだけの場合は衝突にしません。
+
+fixtureは [`src/dev/runtime-room-preview/fixtures.ts`](./src/dev/runtime-room-preview/fixtures.ts) に追加します。`RuntimeRoomOverlayMap` は `RoomLayout`そのものへ開発専用metadataを隣接させた型です。`room_shape`、`seat_shape`、`seats[].x/y/rotate` を一度だけ定義し、その同じオブジェクトをDOMプレビュー、validator、最終 `RoomLayout` として使ってください。Clean Imageを `public/` 以下へ置き、`floor_image`へ絶対パスを設定します。座標は0〜1へ正規化せず、Room左上を原点とする1520 × 1000論理座標で記述します。
+
+Runtime Room追加時は、次を両profileで確認します。
+
+- 全席の椅子・作業面とSeatBoxの対応が読める
+- 一般席で合格し、同じ画像を共用する場合はメンバー席でも合格する
+- 空席、利用中、長い作業名、休憩、メンバー、プロフィール画像ありの表示が背景と競合しない
+- 回転後外接矩形が相互に重ならず、1520 × 1000内に収まる
+- Protected Visual Zoneとmain circulationを覆わず、各席が指定Seat Zone内に収まる
+- 失敗時はSeatBoxを縮小せず、Seat Plan、カメラ、家具間隔、動線の順で再構図する
+
+`Calo current相当 — 既知UI互換性問題` は成功例ではなく、10席の短いベイでの衝突、港景、横動線との競合をvalidatorが検出し続けるための回帰fixtureです。
+
 ## Real-environment verification
 
 Use real environment values only when the task explicitly requires an authorized environment smoke test. Confirm the target environment before opening the monitor because it subscribes to Firestore and can send desired-seat-count requests.

--- a/youtube-monitor/README.md
+++ b/youtube-monitor/README.md
@@ -56,7 +56,7 @@ These values are **build-only placeholders**. They do not prove connectivity or 
 
 ## Runtime Roomの実寸プレビュー
 
-Runtime Room画像は、最終配信フレーム（1920 × 1080）の左上1520 × 1000へ表示します。右400pxはサイドバー、下80pxはメッセージ領域です。新規Runtime RoomのClean Imageは当面1520 × 1000を正とし、16:9画像を暗黙に引き伸ばしません。
+Runtime Room画像は、最終配信フレーム（1920 × 1080）の左上1520 × 1000へ表示します。右400pxはSidebar、左1520pxの下80pxはMessage（920 × 80）とTicker（600 × 80）です。新規Runtime RoomのClean Imageは当面1520 × 1000を正とし、16:9画像を暗黙に引き伸ばしません。
 
 Storybookの `Development/Runtime Room Preview` では、本番と同じ `SeatsPage` / `SeatBox` / CSS / 左上原点の座標変換を使い、全体フレーム上で実寸相当の配置を確認できます。Firestoreや実環境APIへは接続しません。
 

--- a/youtube-monitor/src/dev/runtime-room-preview/RuntimeRoomPreview.styles.ts
+++ b/youtube-monitor/src/dev/runtime-room-preview/RuntimeRoomPreview.styles.ts
@@ -1,0 +1,164 @@
+import { css } from '@emotion/react'
+
+export const preview = css`
+	display: flex;
+	flex-direction: column;
+	gap: 1rem;
+	padding: 1rem;
+	min-width: min-content;
+	background: #eef1f4;
+	color: #18202a;
+	font-family: ui-sans-serif, system-ui, sans-serif;
+`
+
+export const controls = css`
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.75rem 1rem;
+	max-width: 1200px;
+	padding: 0.8rem 1rem;
+	border: 1px solid #c7ced6;
+	border-radius: 0.5rem;
+	background: white;
+`
+
+export const field = css`
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	font-size: 0.85rem;
+`
+
+export const profileButtons = css`
+	display: flex;
+	overflow: hidden;
+	border: 1px solid #83909d;
+	border-radius: 0.35rem;
+`
+
+export const profileButton = css`
+	padding: 0.42rem 0.7rem;
+	border: 0;
+	border-right: 1px solid #83909d;
+	background: #f8fafc;
+	cursor: pointer;
+
+	&:last-of-type {
+		border-right: 0;
+	}
+`
+
+export const selectedProfileButton = css`
+	background: #244d73;
+	color: white;
+`
+
+export const fixtureDescription = css`
+	flex-basis: 100%;
+	margin: 0;
+	color: #4b5866;
+	font-size: 0.8rem;
+`
+
+export const scaledFrame = css`
+	position: relative;
+	overflow: hidden;
+	border: 1px solid #8d99a5;
+	background: #202731;
+`
+
+export const fullFrame = css`
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 1920px;
+	height: 1080px;
+	transform-origin: top left;
+	background: #17202a;
+`
+
+export const roomRegion = css`
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 1520px;
+	height: 1000px;
+	overflow: hidden;
+	background: linear-gradient(145deg, #dbe5e5 0%, #cadad3 48%, #b9c9d0 100%);
+`
+
+export const cleanImagePlaceholder = css`
+	position: absolute;
+	inset: 0;
+	background-image:
+		linear-gradient(rgba(255, 255, 255, 0.18) 1px, transparent 1px),
+		linear-gradient(90deg, rgba(255, 255, 255, 0.18) 1px, transparent 1px);
+	background-size: 100px 100px;
+`
+
+export const frameRegion = css`
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	box-sizing: border-box;
+	border: 3px dashed rgba(255, 255, 255, 0.42);
+	background: #26333e;
+	color: rgba(255, 255, 255, 0.82);
+	font-size: 32px;
+	font-weight: 700;
+	letter-spacing: 0.04em;
+`
+
+export const sidebarRegion = css`
+	position: absolute;
+	top: 0;
+	right: 0;
+	width: 400px;
+	height: 1080px;
+`
+
+export const messageRegion = css`
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	width: 1520px;
+	height: 80px;
+`
+
+export const overlay = css`
+	position: absolute;
+	inset: 0;
+	z-index: 100;
+	pointer-events: none;
+`
+
+export const statusPanel = css`
+	display: grid;
+	grid-template-columns: repeat(5, minmax(135px, auto));
+	gap: 0.45rem;
+	max-width: 1200px;
+	padding: 0.8rem 1rem;
+	border: 1px solid #c7ced6;
+	border-radius: 0.5rem;
+	background: white;
+	font-size: 0.78rem;
+`
+
+export const statusSummary = css`
+	grid-column: 1 / -1;
+	margin: 0;
+	font-weight: 700;
+`
+
+export const valid = css`
+	color: #116636;
+`
+
+export const invalid = css`
+	color: #a11a1a;
+`
+
+export const statusItem = css`
+	margin: 0;
+`

--- a/youtube-monitor/src/dev/runtime-room-preview/RuntimeRoomPreview.styles.ts
+++ b/youtube-monitor/src/dev/runtime-room-preview/RuntimeRoomPreview.styles.ts
@@ -72,8 +72,6 @@ export const fullFrame = css`
 	position: absolute;
 	top: 0;
 	left: 0;
-	width: 1920px;
-	height: 1080px;
 	transform-origin: top left;
 	background: #17202a;
 `
@@ -82,8 +80,6 @@ export const roomRegion = css`
 	position: absolute;
 	top: 0;
 	left: 0;
-	width: 1520px;
-	height: 1000px;
 	overflow: hidden;
 	background: linear-gradient(145deg, #dbe5e5 0%, #cadad3 48%, #b9c9d0 100%);
 `
@@ -114,16 +110,11 @@ export const sidebarRegion = css`
 	position: absolute;
 	top: 0;
 	right: 0;
-	width: 400px;
-	height: 1080px;
 `
 
-export const messageRegion = css`
+export const bottomRegion = css`
 	position: absolute;
 	bottom: 0;
-	left: 0;
-	width: 1520px;
-	height: 80px;
 `
 
 export const overlay = css`

--- a/youtube-monitor/src/dev/runtime-room-preview/RuntimeRoomPreview.tsx
+++ b/youtube-monitor/src/dev/runtime-room-preview/RuntimeRoomPreview.tsx
@@ -1,0 +1,312 @@
+import { type FC, useMemo, useState } from 'react'
+import SeatsPage from '../../components/SeatsPage'
+import { Constants } from '../../lib/constants'
+import type { RuntimeRoomPreviewFixture } from './fixtures'
+import { runtimeRoomPreviewFixtures } from './fixtures'
+import type { OverlayZone, RuntimeProfile } from './overlay-map'
+import { roomLayoutForProfile, runtimeProfiles } from './overlay-map'
+import * as styles from './RuntimeRoomPreview.styles'
+import { validateRuntimeRoom } from './validator'
+
+type OverlayVisibility = {
+	seatZones: boolean
+	protectedVisualZones: boolean
+	mainCirculation: boolean
+	seatAnchors: boolean
+	boundingBoxes: boolean
+	validationState: boolean
+}
+
+const initialVisibility: OverlayVisibility = {
+	seatZones: true,
+	protectedVisualZones: true,
+	mainCirculation: true,
+	seatAnchors: true,
+	boundingBoxes: true,
+	validationState: true,
+}
+
+type Props = {
+	fixtures?: RuntimeRoomPreviewFixture[]
+	initialFixtureId?: string
+}
+
+function zonePoints(zone: OverlayZone): string {
+	if (zone.shape.type === 'polygon') {
+		return zone.shape.points.map((point) => `${point.x},${point.y}`).join(' ')
+	}
+	const { x, y, width, height } = zone.shape
+	return [
+		`${x},${y}`,
+		`${x + width},${y}`,
+		`${x + width},${y + height}`,
+		`${x},${y + height}`,
+	].join(' ')
+}
+
+const RuntimeRoomPreview: FC<Props> = ({
+	fixtures = runtimeRoomPreviewFixtures,
+	initialFixtureId,
+}) => {
+	const availableFixtures =
+		fixtures.length > 0 ? fixtures : runtimeRoomPreviewFixtures
+	const firstFixture =
+		availableFixtures.find(
+			(candidate) =>
+				candidate.overlayMap.runtime_preview.id === initialFixtureId,
+		) ?? availableFixtures[0]
+	const [fixtureId, setFixtureId] = useState(
+		firstFixture.overlayMap.runtime_preview.id,
+	)
+	const [profile, setProfile] = useState<RuntimeProfile>('general')
+	const [scale, setScale] = useState(0.45)
+	const [visibility, setVisibility] =
+		useState<OverlayVisibility>(initialVisibility)
+	const fixture =
+		availableFixtures.find(
+			(candidate) => candidate.overlayMap.runtime_preview.id === fixtureId,
+		) ?? firstFixture
+	const { overlayMap, usedSeats } = fixture
+	const roomLayout = useMemo(
+		() => roomLayoutForProfile(overlayMap, profile),
+		[overlayMap, profile],
+	)
+	const validation = useMemo(
+		() => validateRuntimeRoom(overlayMap, profile),
+		[overlayMap, profile],
+	)
+	const invalidSeatIds = useMemo(() => {
+		const ids = new Set<number>(validation.overflows)
+		for (const collision of validation.seatCollisions) {
+			ids.add(collision.seatIds[0])
+			ids.add(collision.seatIds[1])
+		}
+		for (const intrusion of [
+			...validation.protectedVisualZoneIntrusions,
+			...validation.mainCirculationIntrusions,
+			...validation.seatZoneMisses,
+		]) {
+			ids.add(intrusion.seatId)
+		}
+		return ids
+	}, [validation])
+
+	const updateVisibility = (key: keyof OverlayVisibility) => {
+		setVisibility((current) => ({ ...current, [key]: !current[key] }))
+	}
+	const statusText = (seatIds: number[]) =>
+		seatIds.length === 0 ? 'なし' : seatIds.join(', ')
+	const intrusionText = (items: { seatId: number; zoneId: string }[]) =>
+		items.length === 0
+			? 'なし'
+			: items.map((item) => `${item.seatId}→${item.zoneId}`).join(', ')
+
+	return (
+		<div css={styles.preview}>
+			<div css={styles.controls}>
+				<label css={styles.field}>
+					Fixture
+					<select
+						value={fixtureId}
+						onChange={(event) => setFixtureId(event.target.value)}
+					>
+						{availableFixtures.map((candidate) => (
+							<option
+								key={candidate.overlayMap.runtime_preview.id}
+								value={candidate.overlayMap.runtime_preview.id}
+							>
+								{candidate.overlayMap.runtime_preview.name}
+							</option>
+						))}
+					</select>
+				</label>
+				<div css={styles.profileButtons}>
+					{(['general', 'member'] as const).map((candidate) => (
+						<button
+							type="button"
+							key={candidate}
+							css={[
+								styles.profileButton,
+								candidate === profile && styles.selectedProfileButton,
+							]}
+							onClick={() => setProfile(candidate)}
+						>
+							{runtimeProfiles[candidate].label}
+						</button>
+					))}
+				</div>
+				<label css={styles.field}>
+					表示倍率
+					<input
+						type="range"
+						min="0.25"
+						max="0.75"
+						step="0.05"
+						value={scale}
+						onChange={(event) => setScale(Number(event.target.value))}
+					/>
+					{Math.round(scale * 100)}%
+				</label>
+				{(
+					[
+						['seatZones', 'Seat Zone'],
+						['protectedVisualZones', 'Protected Visual Zone'],
+						['mainCirculation', 'main circulation'],
+						['seatAnchors', 'Seat Anchor'],
+						['boundingBoxes', 'SeatBox外接矩形'],
+						['validationState', 'collision / overflow状態'],
+					] as const
+				).map(([key, label]) => (
+					<label css={styles.field} key={key}>
+						<input
+							type="checkbox"
+							checked={visibility[key]}
+							onChange={() => updateVisibility(key)}
+						/>
+						{label}
+					</label>
+				))}
+				<p css={styles.fixtureDescription}>
+					{overlayMap.runtime_preview.description} Camera:{' '}
+					{overlayMap.runtime_preview.camera_profile}
+				</p>
+			</div>
+
+			<div
+				css={styles.scaledFrame}
+				style={{
+					width: Constants.screenWidth * scale,
+					height: Constants.screenHeight * scale,
+				}}
+			>
+				<div css={styles.fullFrame} style={{ transform: `scale(${scale})` }}>
+					<div css={styles.roomRegion}>
+						{!roomLayout.floor_image && (
+							<div css={styles.cleanImagePlaceholder} />
+						)}
+						<SeatsPage
+							roomLayout={roomLayout}
+							usedSeats={usedSeats}
+							firstSeatId={1}
+							display={true}
+							memberOnly={runtimeProfiles[profile].memberOnly}
+							menuImageMap={new Map<string, string>()}
+						/>
+						<svg
+							css={styles.overlay}
+							viewBox={`0 0 ${roomLayout.room_shape.width} ${roomLayout.room_shape.height}`}
+							aria-label="Runtime Room development overlay"
+						>
+							{visibility.seatZones &&
+								overlayMap.runtime_preview.seat_zones.map((zone) => (
+									<polygon
+										key={zone.id}
+										points={zonePoints(zone)}
+										fill="rgba(43, 135, 255, 0.13)"
+										stroke="#1870d5"
+										strokeWidth="3"
+										strokeDasharray="12 8"
+									/>
+								))}
+							{visibility.protectedVisualZones &&
+								overlayMap.runtime_preview.protected_visual_zones.map(
+									(zone) => (
+										<polygon
+											key={zone.id}
+											points={zonePoints(zone)}
+											fill="rgba(255, 54, 109, 0.16)"
+											stroke="#d91f55"
+											strokeWidth="4"
+										/>
+									),
+								)}
+							{visibility.mainCirculation &&
+								overlayMap.runtime_preview.main_circulation.map((zone) => (
+									<polygon
+										key={zone.id}
+										points={zonePoints(zone)}
+										fill="rgba(255, 182, 33, 0.18)"
+										stroke="#c27400"
+										strokeWidth="4"
+										strokeDasharray="18 10"
+									/>
+								))}
+							{visibility.boundingBoxes &&
+								validation.seatBounds.map((bounds) => (
+									<rect
+										key={bounds.seatId}
+										x={bounds.left}
+										y={bounds.top}
+										width={bounds.right - bounds.left}
+										height={bounds.bottom - bounds.top}
+										fill="none"
+										stroke={
+											visibility.validationState &&
+											invalidSeatIds.has(bounds.seatId)
+												? '#e00000'
+												: '#145c2e'
+										}
+										strokeWidth="5"
+									/>
+								))}
+							{visibility.seatAnchors &&
+								overlayMap.seats.map((seat) => (
+									<g key={seat.id}>
+										<circle cx={seat.x} cy={seat.y} r="10" fill="#24105f" />
+										<path
+											d={`M ${seat.x - 18} ${seat.y} H ${seat.x + 18} M ${seat.x} ${seat.y - 18} V ${seat.y + 18}`}
+											stroke="white"
+											strokeWidth="4"
+										/>
+									</g>
+								))}
+						</svg>
+					</div>
+					<div css={[styles.frameRegion, styles.sidebarRegion]}>
+						右サイドバー 400 × 1080
+					</div>
+					<div css={[styles.frameRegion, styles.messageRegion]}>
+						下メッセージ領域 1520 × 80
+					</div>
+				</div>
+			</div>
+
+			{visibility.validationState && (
+				<div css={styles.statusPanel}>
+					<p
+						css={[
+							styles.statusSummary,
+							validation.isValid ? styles.valid : styles.invalid,
+						]}
+					>
+						{validation.isValid ? 'PASS' : 'FAIL'} —{' '}
+						{runtimeProfiles[profile].label}
+					</p>
+					<p css={styles.statusItem}>
+						衝突:{' '}
+						{validation.seatCollisions.length === 0
+							? 'なし'
+							: validation.seatCollisions
+									.map((item) => item.seatIds.join('↔'))
+									.join(', ')}
+					</p>
+					<p css={styles.statusItem}>
+						Room外: {statusText(validation.overflows)}
+					</p>
+					<p css={styles.statusItem}>
+						Protected侵入:{' '}
+						{intrusionText(validation.protectedVisualZoneIntrusions)}
+					</p>
+					<p css={styles.statusItem}>
+						主動線侵入: {intrusionText(validation.mainCirculationIntrusions)}
+					</p>
+					<p css={styles.statusItem}>
+						Seat Zone外: {intrusionText(validation.seatZoneMisses)}
+					</p>
+				</div>
+			)}
+		</div>
+	)
+}
+
+export default RuntimeRoomPreview

--- a/youtube-monitor/src/dev/runtime-room-preview/RuntimeRoomPreview.tsx
+++ b/youtube-monitor/src/dev/runtime-room-preview/RuntimeRoomPreview.tsx
@@ -26,6 +26,10 @@ const initialVisibility: OverlayVisibility = {
 	validationState: true,
 }
 
+const roomWidth = Constants.screenWidth - Constants.sideBarWidth
+const roomHeight = Constants.screenHeight - Constants.messageBarHeight
+const messageWidth = roomWidth - Constants.tickerWidth
+
 type Props = {
 	fixtures?: RuntimeRoomPreviewFixture[]
 	initialFixtureId?: string
@@ -179,8 +183,18 @@ const RuntimeRoomPreview: FC<Props> = ({
 					height: Constants.screenHeight * scale,
 				}}
 			>
-				<div css={styles.fullFrame} style={{ transform: `scale(${scale})` }}>
-					<div css={styles.roomRegion}>
+				<div
+					css={styles.fullFrame}
+					style={{
+						width: Constants.screenWidth,
+						height: Constants.screenHeight,
+						transform: `scale(${scale})`,
+					}}
+				>
+					<div
+						css={styles.roomRegion}
+						style={{ width: roomWidth, height: roomHeight }}
+					>
 						{!roomLayout.floor_image && (
 							<div css={styles.cleanImagePlaceholder} />
 						)}
@@ -262,11 +276,34 @@ const RuntimeRoomPreview: FC<Props> = ({
 								))}
 						</svg>
 					</div>
-					<div css={[styles.frameRegion, styles.sidebarRegion]}>
-						右サイドバー 400 × 1080
+					<div
+						css={[styles.frameRegion, styles.sidebarRegion]}
+						style={{
+							width: Constants.sideBarWidth,
+							height: Constants.screenHeight,
+						}}
+					>
+						Sidebar {Constants.sideBarWidth} × {Constants.screenHeight}
 					</div>
-					<div css={[styles.frameRegion, styles.messageRegion]}>
-						下メッセージ領域 1520 × 80
+					<div
+						css={[styles.frameRegion, styles.bottomRegion]}
+						style={{
+							left: 0,
+							width: messageWidth,
+							height: Constants.messageBarHeight,
+						}}
+					>
+						Message {messageWidth} × {Constants.messageBarHeight}
+					</div>
+					<div
+						css={[styles.frameRegion, styles.bottomRegion]}
+						style={{
+							left: messageWidth,
+							width: Constants.tickerWidth,
+							height: Constants.messageBarHeight,
+						}}
+					>
+						Ticker {Constants.tickerWidth} × {Constants.messageBarHeight}
 					</div>
 				</div>
 			</div>

--- a/youtube-monitor/src/dev/runtime-room-preview/fixtures.ts
+++ b/youtube-monitor/src/dev/runtime-room-preview/fixtures.ts
@@ -1,0 +1,215 @@
+import { Timestamp } from 'firebase/firestore'
+import type { Seat } from '../../types/api'
+import type { RuntimeRoomOverlayMap } from './overlay-map'
+
+export type RuntimeRoomPreviewFixture = {
+	overlayMap: RuntimeRoomOverlayMap
+	usedSeats: Seat[]
+}
+
+const now = Date.now()
+
+function createSeat(seatId: number, overrides: Partial<Seat> = {}): Seat {
+	return {
+		seat_id: seatId,
+		user_id: `preview-user-${seatId.toString()}`,
+		user_display_name: `プレビュー利用者${seatId.toString()}`,
+		work_name: '実装とレビュー',
+		break_work_name: '',
+		entered_at: Timestamp.fromMillis(now - 45 * 60 * 1000),
+		until: Timestamp.fromMillis(now + 45 * 60 * 1000),
+		appearance: {
+			color_code1: '#5BD27D',
+			color_code2: '#008CFF',
+			num_stars: seatId === 5 ? 5 : 0,
+			color_gradient_enabled: seatId === 5,
+		},
+		menu_code: '',
+		state: 'work',
+		current_state_started_at: Timestamp.fromMillis(now - 45 * 60 * 1000),
+		current_state_until: Timestamp.fromMillis(now + 45 * 60 * 1000),
+		cumulative_work_sec: 45 * 60,
+		daily_cumulative_work_sec: 45 * 60,
+		user_profile_image_url: '',
+		...overrides,
+	}
+}
+
+const previewSeatStates: Seat[] = [
+	createSeat(2, { user_display_name: '一般利用中', work_name: '設計レビュー' }),
+	createSeat(3, {
+		user_display_name: '長い作業名の確認者',
+		work_name:
+			'Runtime Room画像と実寸SeatBoxの互換性を細部まで確認する長い作業名',
+	}),
+	createSeat(4, {
+		user_display_name: '休憩中の利用者',
+		work_name: '実装作業',
+		break_work_name: 'コーヒー休憩',
+		state: 'break',
+	}),
+	createSeat(5, {
+		user_display_name: 'プロフィール画像あり',
+		work_name: 'メンバー表示確認',
+		user_profile_image_url: '/images/sample_profile.svg',
+	}),
+]
+
+export const passingOverlayMap: RuntimeRoomOverlayMap = {
+	floor_image: '',
+	font_size_ratio: 0.015,
+	room_shape: { width: 1520, height: 1000 },
+	seat_shape: { width: 140, height: 100 },
+	partition_shapes: [],
+	partitions: [],
+	seats: [
+		{ id: 1, x: 70, y: 100, rotate: 0 },
+		{ id: 2, x: 360, y: 100, rotate: 0 },
+		{ id: 3, x: 650, y: 100, rotate: 0 },
+		{ id: 4, x: 940, y: 100, rotate: 0 },
+		{ id: 5, x: 110, y: 630, rotate: 0 },
+		{ id: 6, x: 400, y: 630, rotate: 0 },
+		{ id: 7, x: 690, y: 630, rotate: 0 },
+		{ id: 8, x: 980, y: 630, rotate: 0 },
+	],
+	runtime_preview: {
+		id: 'passing-split-islands',
+		name: '正常系 — Split Islands 8席',
+		description:
+			'一般席・メンバー席ともに、全SeatBoxがRoom内・Seat Zone内へ収まり、保護領域と主動線を避ける正常系。',
+		runtime_profile: 'both',
+		camera_profile: 'medium slightly elevated 3/4',
+		protected_visual_zones: [
+			{
+				id: 'PVZ-hero-view',
+				label: 'ヒーロー景観',
+				shape: { type: 'rect', x: 1260, y: 60, width: 220, height: 790 },
+			},
+		],
+		seat_zones: [
+			{
+				id: 'SZ-upper',
+				label: '上段ワークステーション群',
+				shape: { type: 'rect', x: 40, y: 60, width: 1190, height: 230 },
+			},
+			{
+				id: 'SZ-lower',
+				label: '下段ワークステーション群',
+				shape: { type: 'rect', x: 40, y: 590, width: 1190, height: 230 },
+			},
+		],
+		main_circulation: [
+			{
+				id: 'MC-center',
+				label: '中央主動線',
+				shape: { type: 'rect', x: 40, y: 350, width: 1440, height: 150 },
+			},
+		],
+		seat_zone_by_seat_id: {
+			1: 'SZ-upper',
+			2: 'SZ-upper',
+			3: 'SZ-upper',
+			4: 'SZ-upper',
+			5: 'SZ-lower',
+			6: 'SZ-lower',
+			7: 'SZ-lower',
+			8: 'SZ-lower',
+		},
+	},
+}
+
+/**
+ * Calo current相当の既知失敗を固定する回帰fixture。
+ * SeatBoxを画像へ合わせて縮小・再配置せず、短いベイ、港景、横動線との
+ * 既知の競合をvalidatorが検出できる状態で保持する。
+ */
+export const caloRegressionOverlayMap: RuntimeRoomOverlayMap = {
+	floor_image: '',
+	font_size_ratio: 0.015,
+	room_shape: { width: 1520, height: 1000 },
+	seat_shape: { width: 140, height: 100 },
+	partition_shapes: [],
+	partitions: [],
+	seats: [
+		{ id: 1, x: 70, y: 160, rotate: 0 },
+		{ id: 2, x: 245, y: 150, rotate: 3 },
+		{ id: 3, x: 420, y: 155, rotate: -3 },
+		{ id: 4, x: 680, y: 220, rotate: 0 },
+		{ id: 5, x: 805, y: 225, rotate: 2 },
+		{ id: 6, x: 980, y: 220, rotate: -2 },
+		{ id: 7, x: 1150, y: 230, rotate: 0 },
+		{ id: 8, x: 160, y: 570, rotate: 0 },
+		{ id: 9, x: 330, y: 600, rotate: -4 },
+		{ id: 10, x: 560, y: 620, rotate: 3 },
+	],
+	runtime_preview: {
+		id: 'calo-current-regression',
+		name: 'Calo current相当 — 既知UI互換性問題',
+		description:
+			'10席と港湾Hubの骨格は維持し、短いベイのSeatBox衝突、港景の侵入、横動線の侵入を意図的に再現する回帰fixture。成功例ではない。',
+		runtime_profile: 'both',
+		camera_profile: 'Offset Spine / medium-high slightly elevated',
+		protected_visual_zones: [
+			{
+				id: 'PVZ-harbor-view',
+				label: '港景・水平線',
+				shape: {
+					type: 'polygon',
+					points: [
+						{ x: 1180, y: 40 },
+						{ x: 1500, y: 40 },
+						{ x: 1500, y: 420 },
+						{ x: 1240, y: 390 },
+					],
+				},
+			},
+		],
+		seat_zones: [
+			{
+				id: 'SZ-west-bay',
+				label: '西側短ベイ',
+				shape: { type: 'rect', x: 40, y: 110, width: 540, height: 230 },
+			},
+			{
+				id: 'SZ-east-bay',
+				label: '東側短ベイ',
+				shape: { type: 'rect', x: 650, y: 180, width: 640, height: 230 },
+			},
+			{
+				id: 'SZ-south-bay',
+				label: '南側短ベイ',
+				shape: { type: 'rect', x: 120, y: 550, width: 650, height: 230 },
+			},
+		],
+		main_circulation: [
+			{
+				id: 'MC-harbor-spine',
+				label: '港湾横動線',
+				shape: { type: 'rect', x: 40, y: 440, width: 1440, height: 160 },
+			},
+		],
+		seat_zone_by_seat_id: {
+			1: 'SZ-west-bay',
+			2: 'SZ-west-bay',
+			3: 'SZ-west-bay',
+			4: 'SZ-east-bay',
+			5: 'SZ-east-bay',
+			6: 'SZ-east-bay',
+			7: 'SZ-east-bay',
+			8: 'SZ-south-bay',
+			9: 'SZ-south-bay',
+			10: 'SZ-south-bay',
+		},
+	},
+}
+
+export const runtimeRoomPreviewFixtures: RuntimeRoomPreviewFixture[] = [
+	{
+		overlayMap: passingOverlayMap,
+		usedSeats: previewSeatStates,
+	},
+	{
+		overlayMap: caloRegressionOverlayMap,
+		usedSeats: previewSeatStates,
+	},
+]

--- a/youtube-monitor/src/dev/runtime-room-preview/overlay-map.ts
+++ b/youtube-monitor/src/dev/runtime-room-preview/overlay-map.ts
@@ -1,0 +1,81 @@
+import type { RoomLayout } from '../../types/room-layout'
+
+export type RuntimeProfile = 'general' | 'member'
+
+export type RuntimeProfileIntent = RuntimeProfile | 'both'
+
+export type Point = {
+	x: number
+	y: number
+}
+
+export type OverlayZone = {
+	id: string
+	label: string
+	shape:
+		| {
+				type: 'rect'
+				x: number
+				y: number
+				width: number
+				height: number
+		  }
+		| {
+				type: 'polygon'
+				points: Point[]
+		  }
+}
+
+/**
+ * RoomLayout itself is the implementation-ready Seat Overlay Map. Review-only
+ * metadata is attached to that same object so seat coordinates are never copied
+ * between preview, validation, and production layout definitions.
+ */
+export type RuntimeRoomOverlayMap = RoomLayout & {
+	runtime_preview: {
+		id: string
+		name: string
+		description: string
+		runtime_profile: RuntimeProfileIntent
+		camera_profile: string
+		protected_visual_zones: OverlayZone[]
+		seat_zones: OverlayZone[]
+		main_circulation: OverlayZone[]
+		seat_zone_by_seat_id?: Record<number, string>
+	}
+}
+
+export const runtimeProfiles = {
+	general: {
+		label: '一般席 140 × 100',
+		seatShape: { width: 140, height: 100 },
+		fontSizeRatio: 0.015,
+		memberOnly: false,
+	},
+	member: {
+		label: 'メンバー席 230 × 150',
+		seatShape: { width: 230, height: 150 },
+		fontSizeRatio: 0.017,
+		memberOnly: true,
+	},
+} as const satisfies Record<
+	RuntimeProfile,
+	{
+		label: string
+		seatShape: RoomLayout['seat_shape']
+		fontSizeRatio: number
+		memberOnly: boolean
+	}
+>
+
+export function roomLayoutForProfile(
+	overlayMap: RuntimeRoomOverlayMap,
+	profile: RuntimeProfile,
+): RoomLayout {
+	const runtimeProfile = runtimeProfiles[profile]
+	return {
+		...overlayMap,
+		seat_shape: runtimeProfile.seatShape,
+		font_size_ratio: runtimeProfile.fontSizeRatio,
+	}
+}

--- a/youtube-monitor/src/dev/runtime-room-preview/validator.test.ts
+++ b/youtube-monitor/src/dev/runtime-room-preview/validator.test.ts
@@ -111,6 +111,83 @@ function overlayMapWithSeats(
 	}
 }
 
+function validateSeatZone(
+	zone: OverlayZone,
+	seat: RuntimeRoomOverlayMap['seats'][number],
+) {
+	const overlayMap = overlayMapWithSeats([seat])
+	overlayMap.runtime_preview.seat_zones = [zone]
+	overlayMap.runtime_preview.seat_zone_by_seat_id = { [seat.id]: zone.id }
+	return validateRuntimeRoom(overlayMap, 'general').seatZoneMisses
+}
+
+test('a SeatBox fully contained by a rectangular Seat Zone is allowed', () => {
+	const zone: OverlayZone = {
+		id: 'seat-zone',
+		label: 'seat-zone',
+		shape: { type: 'rect', x: 0, y: 0, width: 200, height: 150 },
+	}
+	expect(validateSeatZone(zone, { id: 1, x: 20, y: 20, rotate: 0 })).toEqual([])
+})
+
+test('a SeatBox touching a polygon Seat Zone boundary is allowed', () => {
+	const zone: OverlayZone = {
+		id: 'seat-zone',
+		label: 'seat-zone',
+		shape: {
+			type: 'polygon',
+			points: [
+				{ x: 0, y: 0 },
+				{ x: 140, y: 0 },
+				{ x: 140, y: 100 },
+				{ x: 0, y: 100 },
+			],
+		},
+	}
+	expect(validateSeatZone(zone, { id: 1, x: 0, y: 0, rotate: 0 })).toEqual([])
+})
+
+test('a SeatBox extending outside a convex polygon Seat Zone is a miss', () => {
+	const zone: OverlayZone = {
+		id: 'seat-zone',
+		label: 'seat-zone',
+		shape: {
+			type: 'polygon',
+			points: [
+				{ x: 0, y: 0 },
+				{ x: 200, y: 0 },
+				{ x: 0, y: 200 },
+			],
+		},
+	}
+	expect(validateSeatZone(zone, { id: 1, x: 20, y: 20, rotate: 0 })).toEqual([
+		{ seatId: 1, zoneId: 'seat-zone' },
+	])
+})
+
+test('a SeatBox crossing a concave polygon notch is a miss even when all corners are inside', () => {
+	const zone: OverlayZone = {
+		id: 'seat-zone',
+		label: 'seat-zone',
+		shape: {
+			type: 'polygon',
+			points: [
+				{ x: -20, y: -20 },
+				{ x: 60, y: -20 },
+				{ x: 60, y: 50 },
+				{ x: 80, y: 50 },
+				{ x: 80, y: -20 },
+				{ x: 160, y: -20 },
+				{ x: 160, y: 120 },
+				{ x: -20, y: 120 },
+			],
+		},
+	}
+	expect(validateSeatZone(zone, { id: 1, x: 0, y: 0, rotate: 0 })).toEqual([
+		{ seatId: 1, zoneId: 'seat-zone' },
+	])
+})
+
 test('a seat may touch the room edge but one-pixel overflow is detected', () => {
 	const exactEdge = validateRuntimeRoom(
 		overlayMapWithSeats([{ id: 1, x: 1380, y: 900, rotate: 0 }]),

--- a/youtube-monitor/src/dev/runtime-room-preview/validator.test.ts
+++ b/youtube-monitor/src/dev/runtime-room-preview/validator.test.ts
@@ -1,0 +1,168 @@
+import { caloRegressionOverlayMap, passingOverlayMap } from './fixtures'
+import type { OverlayZone, RuntimeRoomOverlayMap } from './overlay-map'
+import {
+	boundsOverlap,
+	boundsOverlapZone,
+	rotatedRectBounds,
+	validateRuntimeRoom,
+} from './validator'
+
+const expectBoundsCloseTo = (
+	actual: ReturnType<typeof rotatedRectBounds>,
+	expected: ReturnType<typeof rotatedRectBounds>,
+) => {
+	expect(actual.left).toBeCloseTo(expected.left)
+	expect(actual.top).toBeCloseTo(expected.top)
+	expect(actual.right).toBeCloseTo(expected.right)
+	expect(actual.bottom).toBeCloseTo(expected.bottom)
+}
+
+test('rotate 0 keeps the original rectangle bounds', () => {
+	expectBoundsCloseTo(
+		rotatedRectBounds({ x: 10, y: 20, width: 140, height: 100, rotate: 0 }),
+		{ left: 10, top: 20, right: 150, bottom: 120 },
+	)
+})
+
+test('positive and negative rotation use the top-left transform origin', () => {
+	expectBoundsCloseTo(
+		rotatedRectBounds({ x: 10, y: 20, width: 140, height: 100, rotate: 90 }),
+		{ left: -90, top: 20, right: 10, bottom: 160 },
+	)
+	expectBoundsCloseTo(
+		rotatedRectBounds({ x: 10, y: 20, width: 140, height: 100, rotate: -90 }),
+		{ left: 10, top: -120, right: 110, bottom: 20 },
+	)
+})
+
+test('touching bounds are allowed while a one-pixel overlap is detected', () => {
+	const first = { left: 0, top: 0, right: 140, bottom: 100 }
+	expect(
+		boundsOverlap(first, { left: 140, top: 0, right: 280, bottom: 100 }),
+	).toBe(false)
+	expect(
+		boundsOverlap(first, { left: 139, top: 0, right: 279, bottom: 100 }),
+	).toBe(true)
+})
+
+test('touching a rectangular protected zone is allowed', () => {
+	const zone: OverlayZone = {
+		id: 'zone',
+		label: 'zone',
+		shape: { type: 'rect', x: 140, y: 0, width: 100, height: 100 },
+	}
+	expect(
+		boundsOverlapZone({ left: 0, top: 0, right: 140, bottom: 100 }, zone),
+	).toBe(false)
+	expect(
+		boundsOverlapZone({ left: 0, top: 0, right: 141, bottom: 100 }, zone),
+	).toBe(true)
+})
+
+test('polygon zones distinguish border contact from positive-area overlap', () => {
+	const polygonPoints = [
+		{ x: 140, y: 0 },
+		{ x: 240, y: 0 },
+		{ x: 240, y: 100 },
+		{ x: 140, y: 100 },
+	]
+	const touchingZone: OverlayZone = {
+		id: 'polygon-zone',
+		label: 'polygon-zone',
+		shape: { type: 'polygon', points: polygonPoints },
+	}
+	const bounds = { left: 0, top: 0, right: 140, bottom: 100 }
+	expect(boundsOverlapZone(bounds, touchingZone)).toBe(false)
+
+	const overlappingZone: OverlayZone = {
+		...touchingZone,
+		shape: {
+			type: 'polygon',
+			points: polygonPoints.map((point) => ({
+				...point,
+				x: point.x - 1,
+			})),
+		},
+	}
+	expect(boundsOverlapZone(bounds, overlappingZone)).toBe(true)
+})
+
+function overlayMapWithSeats(
+	seats: RuntimeRoomOverlayMap['seats'],
+): RuntimeRoomOverlayMap {
+	return {
+		floor_image: '',
+		font_size_ratio: 0.015,
+		room_shape: { width: 1520, height: 1000 },
+		seat_shape: { width: 140, height: 100 },
+		partition_shapes: [],
+		partitions: [],
+		seats,
+		runtime_preview: {
+			id: 'test',
+			name: 'test',
+			description: 'test',
+			runtime_profile: 'general',
+			camera_profile: 'test',
+			protected_visual_zones: [],
+			seat_zones: [],
+			main_circulation: [],
+		},
+	}
+}
+
+test('a seat may touch the room edge but one-pixel overflow is detected', () => {
+	const exactEdge = validateRuntimeRoom(
+		overlayMapWithSeats([{ id: 1, x: 1380, y: 900, rotate: 0 }]),
+		'general',
+	)
+	expect(exactEdge.overflows).toEqual([])
+
+	const overflow = validateRuntimeRoom(
+		overlayMapWithSeats([{ id: 1, x: 1381, y: 900, rotate: 0 }]),
+		'general',
+	)
+	expect(overflow.overflows).toEqual([1])
+})
+
+test('all colliding pairs are reported for multiple SeatBoxes', () => {
+	const result = validateRuntimeRoom(
+		overlayMapWithSeats([
+			{ id: 1, x: 0, y: 0, rotate: 0 },
+			{ id: 2, x: 139, y: 0, rotate: 0 },
+			{ id: 3, x: 278, y: 0, rotate: 0 },
+		]),
+		'general',
+	)
+	expect(result.seatCollisions).toEqual([
+		{ seatIds: [1, 2] },
+		{ seatIds: [2, 3] },
+	])
+})
+
+test('the passing fixture passes both representative runtime profiles', () => {
+	expect(validateRuntimeRoom(passingOverlayMap, 'general').isValid).toBe(true)
+	expect(validateRuntimeRoom(passingOverlayMap, 'member').isValid).toBe(true)
+})
+
+test('the Calo regression fixture preserves known UI incompatibilities', () => {
+	const general = validateRuntimeRoom(caloRegressionOverlayMap, 'general')
+	expect(general.seatCollisions).toContainEqual({ seatIds: [4, 5] })
+	expect(general.protectedVisualZoneIntrusions).toContainEqual({
+		seatId: 7,
+		zoneId: 'PVZ-harbor-view',
+	})
+	expect(general.mainCirculationIntrusions).toEqual(
+		expect.arrayContaining([
+			{ seatId: 8, zoneId: 'MC-harbor-spine' },
+			{ seatId: 9, zoneId: 'MC-harbor-spine' },
+		]),
+	)
+	expect(general.isValid).toBe(false)
+
+	const member = validateRuntimeRoom(caloRegressionOverlayMap, 'member')
+	expect(member.seatCollisions.length).toBeGreaterThan(
+		general.seatCollisions.length,
+	)
+	expect(member.isValid).toBe(false)
+})

--- a/youtube-monitor/src/dev/runtime-room-preview/validator.ts
+++ b/youtube-monitor/src/dev/runtime-room-preview/validator.ts
@@ -146,6 +146,23 @@ function segmentsProperlyIntersect(
 	)
 }
 
+function polygonsProperlyIntersect(first: Point[], second: Point[]): boolean {
+	for (let firstIndex = 0; firstIndex < first.length; firstIndex++) {
+		const firstStart = first[firstIndex]
+		const firstEnd = first[(firstIndex + 1) % first.length]
+		for (let secondIndex = 0; secondIndex < second.length; secondIndex++) {
+			const secondStart = second[secondIndex]
+			const secondEnd = second[(secondIndex + 1) % second.length]
+			if (
+				segmentsProperlyIntersect(firstStart, firstEnd, secondStart, secondEnd)
+			) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 function pointInsidePolygonStrict(point: Point, polygon: Point[]): boolean {
 	let inside = false
 	for (
@@ -204,29 +221,7 @@ export function boundsOverlapZone(bounds: Bounds, zone: OverlayZone): boolean {
 	) {
 		return true
 	}
-	for (
-		let rectangleIndex = 0;
-		rectangleIndex < rectangle.length;
-		rectangleIndex++
-	) {
-		const rectangleStart = rectangle[rectangleIndex]
-		const rectangleEnd = rectangle[(rectangleIndex + 1) % rectangle.length]
-		for (let polygonIndex = 0; polygonIndex < polygon.length; polygonIndex++) {
-			const polygonStart = polygon[polygonIndex]
-			const polygonEnd = polygon[(polygonIndex + 1) % polygon.length]
-			if (
-				segmentsProperlyIntersect(
-					rectangleStart,
-					rectangleEnd,
-					polygonStart,
-					polygonEnd,
-				)
-			) {
-				return true
-			}
-		}
-	}
-	return false
+	return polygonsProperlyIntersect(rectangle, polygon)
 }
 
 function pointInsidePolygonInclusive(point: Point, polygon: Point[]): boolean {
@@ -248,9 +243,27 @@ function pointInsidePolygonInclusive(point: Point, polygon: Point[]): boolean {
 }
 
 function boundsInsideZone(bounds: Bounds, zone: OverlayZone): boolean {
+	if (zone.shape.type === 'rect') {
+		return (
+			bounds.left >= zone.shape.x - EPSILON &&
+			bounds.top >= zone.shape.y - EPSILON &&
+			bounds.right <= zone.shape.x + zone.shape.width + EPSILON &&
+			bounds.bottom <= zone.shape.y + zone.shape.height + EPSILON
+		)
+	}
 	const polygon = zonePoints(zone)
-	return boundsPoints(bounds).every((point) =>
-		pointInsidePolygonInclusive(point, polygon),
+	const rectangle = boundsPoints(bounds)
+	if (
+		!rectangle.every((point) => pointInsidePolygonInclusive(point, polygon))
+	) {
+		return false
+	}
+
+	// Four contained corners are insufficient for a concave polygon: an inward
+	// notch can cross a rectangle edge or place polygon boundary inside it.
+	return (
+		!polygon.some((point) => pointInsidePolygonStrict(point, rectangle)) &&
+		!polygonsProperlyIntersect(rectangle, polygon)
 	)
 }
 

--- a/youtube-monitor/src/dev/runtime-room-preview/validator.ts
+++ b/youtube-monitor/src/dev/runtime-room-preview/validator.ts
@@ -1,0 +1,333 @@
+import type {
+	OverlayZone,
+	Point,
+	RuntimeProfile,
+	RuntimeRoomOverlayMap,
+} from './overlay-map'
+import { roomLayoutForProfile } from './overlay-map'
+
+const EPSILON = 1e-9
+
+export type Bounds = {
+	left: number
+	top: number
+	right: number
+	bottom: number
+}
+
+export type SeatBounds = Bounds & {
+	seatId: number
+}
+
+export type SeatCollision = {
+	seatIds: [number, number]
+}
+
+export type ZoneIntrusion = {
+	seatId: number
+	zoneId: string
+}
+
+export type RuntimeRoomValidation = {
+	profile: RuntimeProfile
+	seatBounds: SeatBounds[]
+	seatCollisions: SeatCollision[]
+	overflows: number[]
+	protectedVisualZoneIntrusions: ZoneIntrusion[]
+	mainCirculationIntrusions: ZoneIntrusion[]
+	seatZoneMisses: ZoneIntrusion[]
+	isValid: boolean
+}
+
+export function rotatedRectBounds({
+	x,
+	y,
+	width,
+	height,
+	rotate,
+}: {
+	x: number
+	y: number
+	width: number
+	height: number
+	rotate: number
+}): Bounds {
+	const radians = (rotate * Math.PI) / 180
+	const cosine = Math.cos(radians)
+	const sine = Math.sin(radians)
+	const corners = [
+		{ x: 0, y: 0 },
+		{ x: width, y: 0 },
+		{ x: 0, y: height },
+		{ x: width, y: height },
+	].map((corner) => ({
+		x: x + corner.x * cosine - corner.y * sine,
+		y: y + corner.x * sine + corner.y * cosine,
+	}))
+
+	return {
+		left: Math.min(...corners.map((corner) => corner.x)),
+		top: Math.min(...corners.map((corner) => corner.y)),
+		right: Math.max(...corners.map((corner) => corner.x)),
+		bottom: Math.max(...corners.map((corner) => corner.y)),
+	}
+}
+
+/** Border contact is allowed; positive-area overlap is not. */
+export function boundsOverlap(first: Bounds, second: Bounds): boolean {
+	return (
+		first.left < second.right - EPSILON &&
+		first.right > second.left + EPSILON &&
+		first.top < second.bottom - EPSILON &&
+		first.bottom > second.top + EPSILON
+	)
+}
+
+function zonePoints(zone: OverlayZone): Point[] {
+	if (zone.shape.type === 'polygon') {
+		return zone.shape.points
+	}
+	const { x, y, width, height } = zone.shape
+	return [
+		{ x, y },
+		{ x: x + width, y },
+		{ x: x + width, y: y + height },
+		{ x, y: y + height },
+	]
+}
+
+function boundsPoints(bounds: Bounds): Point[] {
+	return [
+		{ x: bounds.left, y: bounds.top },
+		{ x: bounds.right, y: bounds.top },
+		{ x: bounds.right, y: bounds.bottom },
+		{ x: bounds.left, y: bounds.bottom },
+	]
+}
+
+function polygonSamples(polygon: Point[]): Point[] {
+	const edgeMidpoints = polygon.map((point, index) => {
+		const nextPoint = polygon[(index + 1) % polygon.length]
+		return {
+			x: (point.x + nextPoint.x) / 2,
+			y: (point.y + nextPoint.y) / 2,
+		}
+	})
+	const center = polygon.reduce(
+		(accumulator, point) => ({
+			x: accumulator.x + point.x / polygon.length,
+			y: accumulator.y + point.y / polygon.length,
+		}),
+		{ x: 0, y: 0 },
+	)
+	return [...polygon, ...edgeMidpoints, center]
+}
+
+function crossProduct(first: Point, second: Point, third: Point): number {
+	return (
+		(second.x - first.x) * (third.y - first.y) -
+		(second.y - first.y) * (third.x - first.x)
+	)
+}
+
+function segmentsProperlyIntersect(
+	firstStart: Point,
+	firstEnd: Point,
+	secondStart: Point,
+	secondEnd: Point,
+): boolean {
+	const firstSideStart = crossProduct(firstStart, firstEnd, secondStart)
+	const firstSideEnd = crossProduct(firstStart, firstEnd, secondEnd)
+	const secondSideStart = crossProduct(secondStart, secondEnd, firstStart)
+	const secondSideEnd = crossProduct(secondStart, secondEnd, firstEnd)
+	return (
+		firstSideStart * firstSideEnd < -EPSILON &&
+		secondSideStart * secondSideEnd < -EPSILON
+	)
+}
+
+function pointInsidePolygonStrict(point: Point, polygon: Point[]): boolean {
+	let inside = false
+	for (
+		let current = 0, previous = polygon.length - 1;
+		current < polygon.length;
+		previous = current++
+	) {
+		const currentPoint = polygon[current]
+		const previousPoint = polygon[previous]
+		if (Math.abs(crossProduct(previousPoint, currentPoint, point)) <= EPSILON) {
+			const withinX =
+				point.x >= Math.min(previousPoint.x, currentPoint.x) - EPSILON &&
+				point.x <= Math.max(previousPoint.x, currentPoint.x) + EPSILON
+			const withinY =
+				point.y >= Math.min(previousPoint.y, currentPoint.y) - EPSILON &&
+				point.y <= Math.max(previousPoint.y, currentPoint.y) + EPSILON
+			if (withinX && withinY) {
+				return false
+			}
+		}
+		const crossesRay =
+			currentPoint.y > point.y !== previousPoint.y > point.y &&
+			point.x <
+				((previousPoint.x - currentPoint.x) * (point.y - currentPoint.y)) /
+					(previousPoint.y - currentPoint.y) +
+					currentPoint.x
+		if (crossesRay) {
+			inside = !inside
+		}
+	}
+	return inside
+}
+
+export function boundsOverlapZone(bounds: Bounds, zone: OverlayZone): boolean {
+	if (zone.shape.type === 'rect') {
+		return boundsOverlap(bounds, {
+			left: zone.shape.x,
+			top: zone.shape.y,
+			right: zone.shape.x + zone.shape.width,
+			bottom: zone.shape.y + zone.shape.height,
+		})
+	}
+	const polygon = zonePoints(zone)
+	const rectangle = boundsPoints(bounds)
+	if (
+		polygonSamples(rectangle).some((point) =>
+			pointInsidePolygonStrict(point, polygon),
+		)
+	) {
+		return true
+	}
+	if (
+		polygonSamples(polygon).some((point) =>
+			pointInsidePolygonStrict(point, rectangle),
+		)
+	) {
+		return true
+	}
+	for (
+		let rectangleIndex = 0;
+		rectangleIndex < rectangle.length;
+		rectangleIndex++
+	) {
+		const rectangleStart = rectangle[rectangleIndex]
+		const rectangleEnd = rectangle[(rectangleIndex + 1) % rectangle.length]
+		for (let polygonIndex = 0; polygonIndex < polygon.length; polygonIndex++) {
+			const polygonStart = polygon[polygonIndex]
+			const polygonEnd = polygon[(polygonIndex + 1) % polygon.length]
+			if (
+				segmentsProperlyIntersect(
+					rectangleStart,
+					rectangleEnd,
+					polygonStart,
+					polygonEnd,
+				)
+			) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+function pointInsidePolygonInclusive(point: Point, polygon: Point[]): boolean {
+	if (pointInsidePolygonStrict(point, polygon)) {
+		return true
+	}
+	return polygon.some((currentPoint, index) => {
+		const nextPoint = polygon[(index + 1) % polygon.length]
+		if (Math.abs(crossProduct(currentPoint, nextPoint, point)) > EPSILON) {
+			return false
+		}
+		return (
+			point.x >= Math.min(currentPoint.x, nextPoint.x) - EPSILON &&
+			point.x <= Math.max(currentPoint.x, nextPoint.x) + EPSILON &&
+			point.y >= Math.min(currentPoint.y, nextPoint.y) - EPSILON &&
+			point.y <= Math.max(currentPoint.y, nextPoint.y) + EPSILON
+		)
+	})
+}
+
+function boundsInsideZone(bounds: Bounds, zone: OverlayZone): boolean {
+	const polygon = zonePoints(zone)
+	return boundsPoints(bounds).every((point) =>
+		pointInsidePolygonInclusive(point, polygon),
+	)
+}
+
+export function validateRuntimeRoom(
+	overlayMap: RuntimeRoomOverlayMap,
+	profile: RuntimeProfile,
+): RuntimeRoomValidation {
+	const layout = roomLayoutForProfile(overlayMap, profile)
+	const seatBounds = layout.seats.map((seat) => ({
+		seatId: seat.id,
+		...rotatedRectBounds({
+			x: seat.x,
+			y: seat.y,
+			width: layout.seat_shape.width,
+			height: layout.seat_shape.height,
+			rotate: seat.rotate,
+		}),
+	}))
+	const seatCollisions: SeatCollision[] = []
+	for (let first = 0; first < seatBounds.length; first++) {
+		for (let second = first + 1; second < seatBounds.length; second++) {
+			if (boundsOverlap(seatBounds[first], seatBounds[second])) {
+				seatCollisions.push({
+					seatIds: [seatBounds[first].seatId, seatBounds[second].seatId],
+				})
+			}
+		}
+	}
+
+	const overflows = seatBounds
+		.filter(
+			(bounds) =>
+				bounds.left < -EPSILON ||
+				bounds.top < -EPSILON ||
+				bounds.right > layout.room_shape.width + EPSILON ||
+				bounds.bottom > layout.room_shape.height + EPSILON,
+		)
+		.map((bounds) => bounds.seatId)
+	const intrusions = (zones: OverlayZone[]): ZoneIntrusion[] =>
+		seatBounds.flatMap((bounds) =>
+			zones
+				.filter((zone) => boundsOverlapZone(bounds, zone))
+				.map((zone) => ({ seatId: bounds.seatId, zoneId: zone.id })),
+		)
+	const protectedVisualZoneIntrusions = intrusions(
+		overlayMap.runtime_preview.protected_visual_zones,
+	)
+	const mainCirculationIntrusions = intrusions(
+		overlayMap.runtime_preview.main_circulation,
+	)
+	const seatZoneMisses = Object.entries(
+		overlayMap.runtime_preview.seat_zone_by_seat_id ?? {},
+	).flatMap(([seatIdText, zoneId]) => {
+		const seatId = Number(seatIdText)
+		const bounds = seatBounds.find((candidate) => candidate.seatId === seatId)
+		const zone = overlayMap.runtime_preview.seat_zones.find(
+			(candidate) => candidate.id === zoneId,
+		)
+		return bounds && zone && !boundsInsideZone(bounds, zone)
+			? [{ seatId, zoneId }]
+			: []
+	})
+	const isValid =
+		seatCollisions.length === 0 &&
+		overflows.length === 0 &&
+		protectedVisualZoneIntrusions.length === 0 &&
+		mainCirculationIntrusions.length === 0 &&
+		seatZoneMisses.length === 0
+
+	return {
+		profile,
+		seatBounds,
+		seatCollisions,
+		overflows,
+		protectedVisualZoneIntrusions,
+		mainCirculationIntrusions,
+		seatZoneMisses,
+		isValid,
+	}
+}

--- a/youtube-monitor/src/stories/RuntimeRoomPreview.stories.tsx
+++ b/youtube-monitor/src/stories/RuntimeRoomPreview.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import RuntimeRoomPreview from '../dev/runtime-room-preview/RuntimeRoomPreview'
+
+const meta = {
+	title: 'Development/Runtime Room Preview',
+	component: RuntimeRoomPreview,
+	parameters: {
+		layout: 'fullscreen',
+		docs: { disable: true },
+	},
+} satisfies Meta<typeof RuntimeRoomPreview>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Normal: Story = {
+	name: '正常系 8席',
+	args: { initialFixtureId: 'passing-split-islands' },
+}
+
+export const CaloRegression: Story = {
+	name: 'Calo current相当 既知問題',
+	args: { initialFixtureId: 'calo-current-regression' },
+}


### PR DESCRIPTION
## 概要

Issue #1089 のRuntime Room制作後検証を、既存Storybook上で再現可能にします。

- 本番の `SeatsPage` / `SeatBox` / CSS / 座標変換をそのまま使う1920 × 1080プレビュー
- general（140 × 100）/ member（230 × 150）の即時切替
- 空席、利用中、長い作業名、休憩、メンバー表示、プロフィール画像の固定状態fixture
- Seat Zone / Protected Visual Zone / main circulation / Seat Anchor / 回転後AABB / validation状態の開発用Overlay
- 回転後AABBによるSeatBox衝突・Room外・保護領域・主動線・Seat Zone逸脱の純粋関数validator
- 正常系8席fixtureと、既知問題を意図的に残したCalo current相当10席回帰fixture

## 追加レビュー反映

- 1920 × 1080フレーム下部を現行Constantsから導出し、Message 920 × 80 / Ticker 600 × 80 / Sidebar 400 × 1080として表示
- Seat Zoneのpolygon内包判定で、凹部を横切る矩形辺と矩形内部に入るpolygon境界を検出
- rect内包、polygon境界接触、凸polygon逸脱、四隅が内側の凹polygon横断をunit testで固定
- Notion「ルーム構図ライブラリ」の占有領域説明も同じ寸法へ最小修正

## 設計上の不変条件

- `RuntimeRoomOverlayMap` は `RoomLayout` 自体にdev-only metadataを隣接させ、座標を二重管理しない
- preview実装はStoryからのみimportし、本番表示・席数制御・ページ送りへ接続しない
- SeatBoxのサイズ・デザイン、既存Room、Approved画像は変更しない
- 16:9は最終配信フレーム、Runtime Room Clean Imageは1520 × 1000と明文化

## 確認

- [x] `Biome 2.5.6 check youtube-monitor`（ローカル）
- [x] `git diff --check`（ローカル）
- [x] YouTube Monitor Test / Jest（GitHub Actions）
- [x] YouTube Monitor Build / Next build（GitHub Actions）
- [x] Documentation References / CI Gate（GitHub Actions）

Relates #1089

> baseは `dev` です。人間レビュー後も、このPRはエージェント側ではマージしません。