### PR TITLE
feat(youtube-monitor): make SeatBox a translucent UI surface

### DIFF
--- a/youtube-monitor/src/components/SeatBox.test.tsx
+++ b/youtube-monitor/src/components/SeatBox.test.tsx
@@ -347,3 +347,51 @@ describe('SeatBox general seat font fitting', () => {
 		})
 	})
 })
+
+describe('SeatBox translucent surface', () => {
+	test('keeps the existing appearance colors on a separate surface layer', () => {
+		const SeatBox = loadSeatBox()
+		const { container, rerender } = render(
+			<SeatBox
+				{...createBaseProps({
+					processingSeat: {
+						...createBaseProps().processingSeat,
+						appearance: {
+							color_code1: '#5BD27D',
+							color_code2: '#008CFF',
+							num_stars: 0,
+							color_gradient_enabled: true,
+						},
+					},
+				})}
+			/>,
+		)
+
+		const seat = container.firstElementChild
+		const usedSurface = container.querySelector('[data-seat-surface="used"]')
+
+		expect(seat).not.toBeNull()
+		expect(seat?.style.backgroundColor).toBe('')
+		expect(usedSurface).not.toBeNull()
+		expect(usedSurface?.getAttribute('aria-hidden')).toBe('true')
+		expect(usedSurface?.getAttribute('style')).toContain(
+			'--seat-surface-start: #5BD27D',
+		)
+		expect(usedSurface?.getAttribute('style')).toContain(
+			'--seat-surface-end: #008CFF',
+		)
+
+		rerender(<SeatBox {...createBaseProps({ isUsed: false })} />)
+		const vacantSurface = container.querySelector(
+			'[data-seat-surface="vacant"]',
+		)
+
+		expect(vacantSurface).not.toBeNull()
+		expect(vacantSurface?.getAttribute('style')).toContain(
+			'--seat-surface-start: #ded5c6ff',
+		)
+		expect(vacantSurface?.getAttribute('style')).toContain(
+			'--seat-surface-end: #ded5c6ff',
+		)
+	})
+})

--- a/youtube-monitor/src/components/SeatBox.test.tsx
+++ b/youtube-monitor/src/components/SeatBox.test.tsx
@@ -349,7 +349,7 @@ describe('SeatBox general seat font fitting', () => {
 })
 
 describe('SeatBox translucent surface', () => {
-	test('keeps the existing appearance colors on a separate surface layer', () => {
+	test('keeps the neutral surface separate from appearance colors', () => {
 		const SeatBox = loadSeatBox()
 		const { container, rerender } = render(
 			<SeatBox
@@ -375,10 +375,10 @@ describe('SeatBox translucent surface', () => {
 		expect(usedSurface).not.toBeNull()
 		expect(usedSurface?.getAttribute('aria-hidden')).toBe('true')
 		expect(usedSurface?.getAttribute('style')).toContain(
-			'--seat-surface-start: #5BD27D',
+			'--seat-surface-start: #F4EFE7',
 		)
 		expect(usedSurface?.getAttribute('style')).toContain(
-			'--seat-surface-end: #008CFF',
+			'--seat-surface-end: #F4EFE7',
 		)
 
 		rerender(<SeatBox {...createBaseProps({ isUsed: false })} />)

--- a/youtube-monitor/src/components/SeatBox.tsx
+++ b/youtube-monitor/src/components/SeatBox.tsx
@@ -309,16 +309,12 @@ const SeatBox: FC<SeatProps> = (props) => {
 			? props.seatFontSizePx * 0.63
 			: generalDisplayNameAutoFontSizePx
 		: 0
-	const seatSurfaceStartColor = props.isUsed
-		? props.processingSeat.appearance.color_code1
+	const seatSurfaceColor = props.isUsed
+		? Constants.seatBackgroundColor
 		: Constants.vacantSeatBackgroundColor
-	const seatSurfaceEndColor =
-		props.isUsed && props.processingSeat.appearance.color_gradient_enabled
-			? props.processingSeat.appearance.color_code2
-			: seatSurfaceStartColor
 	const seatSurfaceStyle = {
-		'--seat-surface-start': seatSurfaceStartColor,
-		'--seat-surface-end': seatSurfaceEndColor,
+		'--seat-surface-start': seatSurfaceColor,
+		'--seat-surface-end': seatSurfaceColor,
 	} as CSSProperties
 
 	return (

--- a/youtube-monitor/src/components/SeatBox.tsx
+++ b/youtube-monitor/src/components/SeatBox.tsx
@@ -1,7 +1,13 @@
 /** @jsxImportSource @emotion/react */
 import { css, keyframes } from '@emotion/react'
 import Image from 'next/image'
-import { type FC, type SyntheticEvent, useEffect, useState } from 'react'
+import {
+	type CSSProperties,
+	type FC,
+	type SyntheticEvent,
+	useEffect,
+	useState,
+} from 'react'
 import { fontFamily, validateString } from '../lib/common'
 import { Constants } from '../lib/constants'
 import * as styles from '../styles/SeatBox.styles'
@@ -303,6 +309,17 @@ const SeatBox: FC<SeatProps> = (props) => {
 			? props.seatFontSizePx * 0.63
 			: generalDisplayNameAutoFontSizePx
 		: 0
+	const seatSurfaceStartColor = props.isUsed
+		? props.processingSeat.appearance.color_code1
+		: Constants.vacantSeatBackgroundColor
+	const seatSurfaceEndColor =
+		props.isUsed && props.processingSeat.appearance.color_gradient_enabled
+			? props.processingSeat.appearance.color_code2
+			: seatSurfaceStartColor
+	const seatSurfaceStyle = {
+		'--seat-surface-start': seatSurfaceStartColor,
+		'--seat-surface-end': seatSurfaceEndColor,
+	} as CSSProperties
 
 	return (
 		<div
@@ -315,11 +332,15 @@ const SeatBox: FC<SeatProps> = (props) => {
 				width: `${props.seatShape.widthPx}px`,
 				height: `${props.seatShape.heightPx}px`,
 				fontSize: `${props.seatFontSizePx}px`,
-				backgroundColor: props.isUsed
-					? Constants.seatBackgroundColor
-					: Constants.vacantSeatBackgroundColor,
 			}}
 		>
+			<div
+				aria-hidden="true"
+				data-seat-surface={props.isUsed ? 'used' : 'vacant'}
+				css={styles.seatSurface}
+				style={seatSurfaceStyle}
+			/>
+
 			{/* Accent Bar */}
 			{props.isUsed && (
 				<div

--- a/youtube-monitor/src/lib/constants.ts
+++ b/youtube-monitor/src/lib/constants.ts
@@ -39,7 +39,6 @@ export const Constants = {
 	colorBarHeight: 100,
 	menuHeight: 310,
 	timerHeight: 260,
-	seatBackgroundColor: '#F4EFE7',
 	vacantSeatBackgroundColor: '#ded5c6ff',
 	breakBadgeZIndex: 10,
 	bgmVolume: DEBUG ? 0.1 : 0.3,

--- a/youtube-monitor/src/lib/constants.ts
+++ b/youtube-monitor/src/lib/constants.ts
@@ -39,6 +39,7 @@ export const Constants = {
 	colorBarHeight: 100,
 	menuHeight: 310,
 	timerHeight: 260,
+	seatBackgroundColor: '#F4EFE7',
 	vacantSeatBackgroundColor: '#ded5c6ff',
 	breakBadgeZIndex: 10,
 	bgmVolume: DEBUG ? 0.1 : 0.3,

--- a/youtube-monitor/src/styles/SeatBox.styles.ts
+++ b/youtube-monitor/src/styles/SeatBox.styles.ts
@@ -34,7 +34,7 @@ export const seatSurface = css`
 	background:
 		linear-gradient(rgba(255, 255, 255, 0.42), rgba(255, 255, 255, 0.42)),
 		linear-gradient(135deg, var(--seat-surface-start), var(--seat-surface-end));
-	opacity: 0.68;
+	opacity: 0.6;
 	backdrop-filter: blur(1.5px) saturate(1.08);
 	-webkit-backdrop-filter: blur(1.5px) saturate(1.08);
 `

--- a/youtube-monitor/src/styles/SeatBox.styles.ts
+++ b/youtube-monitor/src/styles/SeatBox.styles.ts
@@ -19,9 +19,24 @@ export const seat = css`
     transform-origin: top left;
     box-sizing: border-box;
     overflow: hidden;
-    border: ${seatBorderWidthPx}px solid rgba(84, 75, 62, 0.12);
-    box-shadow: 0 0.2rem 0.55rem rgba(70, 58, 43, 0.08);
+    border: ${seatBorderWidthPx}px solid rgba(255, 255, 255, 0.66);
+    box-shadow:
+        0 0.2rem 0.55rem rgba(30, 38, 45, 0.2),
+        inset 0 0 0 ${seatBorderWidthPx}px rgba(39, 47, 54, 0.16);
     font-family: ${fontFamily};
+`
+
+export const seatSurface = css`
+	position: absolute;
+	inset: 0;
+	z-index: 0;
+	pointer-events: none;
+	background:
+		linear-gradient(rgba(255, 255, 255, 0.42), rgba(255, 255, 255, 0.42)),
+		linear-gradient(135deg, var(--seat-surface-start), var(--seat-surface-end));
+	opacity: 0.68;
+	backdrop-filter: blur(1.5px) saturate(1.08);
+	-webkit-backdrop-filter: blur(1.5px) saturate(1.08);
 `
 
 export const accentBar = css`
@@ -34,6 +49,7 @@ export const accentBar = css`
 	width: 100%;
 	box-sizing: border-box;
 	pointer-events: none;
+	z-index: 2;
 `
 
 export const seatBody = css`
@@ -43,6 +59,10 @@ export const seatBody = css`
     flex-direction: column;
     min-height: 0;
     padding: 0.35em ${seatBodyHorizontalPaddingEm}em 0.34em;
+    z-index: 1;
+    text-shadow:
+        0 1px 1px rgba(255, 255, 255, 0.75),
+        0 0 2px rgba(255, 255, 255, 0.3);
 `
 
 export const headerRow = css`


### PR DESCRIPTION
## Summary

Issue #1091対応。SeatBoxを家具を避けて置く不透明カードから、対応する椅子・作業面へ直接重ねられる半透明UIサーフェスへ変更しました。

- 使用中SeatBox本体は既存の `Constants.seatBackgroundColor`（`#F4EFE7`）をsurfaceへ使用
- 空席は既存の `vacantSeatBackgroundColor` を維持
- `appearance.color_code1/2`、gradient、rank、Favorite Color等の既存色意味はAccent Bar側で維持
- 背景サーフェスだけへ白いハイライト、透明度、軽いbackdrop blurを適用
- 文字・アイコンは独立レイヤーのまま、境界線・影・文字ハイライトで可読性を維持
- SeatBoxサイズ、座標、validator、ページ送り、Runtime Room画像契約は変更なし

## Visual QA

PR #1090のDevelopment/Runtime Room Previewブランチへ本変更を一時適用して確認しました（#1090のコードとQA用画像はこのPRへ取り込んでいません）。

- 明るい背景: 白〜青系の作業ホール
- 暗い背景: 雨天カフェ
- 情報量の多い背景: 家具・窓・植物のある港湾カフェ
- general 140×100 / member 230×150
- 空席、一般利用中、長い作業名、メンバー、休憩中、プロフィール画像あり
- 既存の正常系はPASS、Calo回帰fixtureは既知のFAIL内容を維持
- Accent Barの座席固有色はSeatBox全面へ広がらず、SeatBox越しに認識可能

比較した透明度案は0.54 / 0.68 / 0.60。0.54は暗背景でSeatBoxが溶けやすく、0.68は物理席の見え方が弱くなったため、0.60を採用しました。

## Verification

- `pnpm exec jest --runInBand`: 7 suites / 159 tests passed
- `pnpm check`: passed
- `git diff --check`: passed
- `NEXT_PUBLIC_DEBUG=true NEXT_PUBLIC_CHANNEL_GL=false NEXT_PUBLIC_ROOM_CONFIG=DEV pnpm build`: passed
- PR #1090 Previewの`pnpm build-storybook`: passed
- GitHub Actions / CodeQL / CI Gate: passed

Relates #1091

マージは行っていません。Notion正本への反映や、実運用Room画像での最終的な席アンカー・景観保護境界の判断は人間レビューに残ります。
