### PR TITLE
fix: reject unpinned base image changes

### DIFF
--- a/.github/scripts/base-image-pin-check.mjs
+++ b/.github/scripts/base-image-pin-check.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+import { pathToFileURL } from "node:url";
+
+import { parseFromImages, parsePinnedImage } from "./base-image-update-report.mjs";
+
+export function detectDigestUnpins(baseContent, headContent) {
+  const before = parseFromImages(baseContent);
+  const after = parseFromImages(headContent);
+  const violations = [];
+  const count = Math.max(before.length, after.length);
+
+  for (let index = 0; index < count; index += 1) {
+    const oldStage = before[index];
+    const newStage = after[index];
+    if (!oldStage || !newStage || oldStage.image === newStage.image) continue;
+
+    const oldImage = parsePinnedImage(oldStage.image);
+    if (!oldImage) continue;
+
+    const newImage = parsePinnedImage(newStage.image);
+    if (newImage) continue;
+
+    violations.push({
+      stage: newStage.stage,
+      line: newStage.line,
+      oldRef: oldStage.image,
+      newRef: newStage.image,
+    });
+  }
+
+  return violations;
+}
+
+function requireEnv(name) {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+async function githubRequest(path) {
+  const apiUrl = process.env.GITHUB_API_URL || "https://api.github.com";
+  const token = requireEnv("GITHUB_TOKEN");
+  const response = await fetch(`${apiUrl}${path}`, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`GitHub API GET ${path} failed: ${response.status} ${body}`);
+  }
+
+  return response.json();
+}
+
+async function paginatedGithubRequest(path) {
+  const items = [];
+  for (let page = 1; ; page += 1) {
+    const separator = path.includes("?") ? "&" : "?";
+    const pageItems = await githubRequest(`${path}${separator}per_page=100&page=${page}`);
+    items.push(...pageItems);
+    if (pageItems.length < 100) return items;
+  }
+}
+
+function encodeRepositoryPath(path) {
+  return path.split("/").map(encodeURIComponent).join("/");
+}
+
+async function getFileContent(repository, path, ref) {
+  const response = await githubRequest(
+    `/repos/${repository}/contents/${encodeRepositoryPath(path)}?ref=${encodeURIComponent(ref)}`,
+  );
+  if (response.type !== "file" || response.encoding !== "base64") {
+    throw new Error(`Unexpected GitHub contents response for ${path}@${ref}`);
+  }
+  return Buffer.from(response.content.replaceAll("\n", ""), "base64").toString("utf8");
+}
+
+async function main() {
+  const repository = requireEnv("GITHUB_REPOSITORY");
+  const pullNumber = Number(requireEnv("PR_NUMBER"));
+  const baseSha = requireEnv("BASE_SHA");
+  const headSha = requireEnv("HEAD_SHA");
+
+  if (!Number.isInteger(pullNumber) || pullNumber <= 0) {
+    throw new Error(`Invalid PR_NUMBER: ${process.env.PR_NUMBER}`);
+  }
+
+  const changedFiles = await paginatedGithubRequest(`/repos/${repository}/pulls/${pullNumber}/files`);
+  const dockerfiles = changedFiles.filter(
+    (file) => /^system\/Dockerfile[^/]*$/.test(file.filename) && file.status !== "added" && file.status !== "removed",
+  );
+
+  const violations = [];
+  for (const file of dockerfiles) {
+    const basePath = file.status === "renamed" && file.previous_filename ? file.previous_filename : file.filename;
+    const [baseContent, headContent] = await Promise.all([
+      getFileContent(repository, basePath, baseSha),
+      getFileContent(repository, file.filename, headSha),
+    ]);
+
+    for (const violation of detectDigestUnpins(baseContent, headContent)) {
+      violations.push({ file: file.filename, ...violation });
+    }
+  }
+
+  if (violations.length === 0) {
+    console.log("No base image digest pins were removed.");
+    return;
+  }
+
+  for (const violation of violations) {
+    console.error(
+      `::error file=${violation.file},line=${violation.line}::Base image digest pin removed in stage ${violation.stage}: ${violation.oldRef} -> ${violation.newRef}`,
+    );
+  }
+
+  throw new Error(
+    `${violations.length} base image reference(s) removed required sha256 digest pinning`,
+  );
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.stack : error);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/base-image-pin-check.mjs
+++ b/.github/scripts/base-image-pin-check.mjs
@@ -2,31 +2,53 @@
 
 import { pathToFileURL } from "node:url";
 
-import { parseFromImages, parsePinnedImage } from "./base-image-update-report.mjs";
+import { parsePinnedImage } from "./base-image-update-report.mjs";
 
-export function detectDigestUnpins(baseContent, headContent) {
-  const before = parseFromImages(baseContent);
-  const after = parseFromImages(headContent);
-  const violations = [];
-  const count = Math.max(before.length, after.length);
+export function parseFromStages(content) {
+  const stages = [];
+  for (const [index, line] of content.split(/\r?\n/).entries()) {
+    const trimmed = line.trim();
+    if (!/^FROM\s+/i.test(trimmed)) continue;
 
-  for (let index = 0; index < count; index += 1) {
-    const oldStage = before[index];
-    const newStage = after[index];
-    if (!oldStage || !newStage || oldStage.image === newStage.image) continue;
+    const parts = trimmed.split(/\s+/);
+    let imageIndex = 1;
+    while (parts[imageIndex]?.startsWith("--")) imageIndex += 1;
+    if (!parts[imageIndex]) continue;
 
-    const oldImage = parsePinnedImage(oldStage.image);
-    if (!oldImage) continue;
+    const alias = /^AS$/i.test(parts[imageIndex + 1] || "")
+      ? parts[imageIndex + 2] || null
+      : null;
 
-    const newImage = parsePinnedImage(newStage.image);
-    if (newImage) continue;
-
-    violations.push({
-      stage: newStage.stage,
-      line: newStage.line,
-      oldRef: oldStage.image,
-      newRef: newStage.image,
+    stages.push({
+      stage: stages.length + 1,
+      line: index + 1,
+      image: parts[imageIndex],
+      alias,
     });
+  }
+  return stages;
+}
+
+export function detectUnpinnedExternalBaseImages(headContent) {
+  const declaredAliases = new Set();
+  const violations = [];
+
+  for (const stage of parseFromStages(headContent)) {
+    const normalizedRef = stage.image.toLowerCase();
+    const isInternalStage = declaredAliases.has(normalizedRef);
+    const isScratch = normalizedRef === "scratch";
+
+    if (!isInternalStage && !isScratch && !parsePinnedImage(stage.image)) {
+      violations.push({
+        stage: stage.stage,
+        line: stage.line,
+        ref: stage.image,
+      });
+    }
+
+    if (stage.alias) {
+      declaredAliases.add(stage.alias.toLowerCase());
+    }
   }
 
   return violations;
@@ -84,7 +106,6 @@ async function getFileContent(repository, path, ref) {
 async function main() {
   const repository = requireEnv("GITHUB_REPOSITORY");
   const pullNumber = Number(requireEnv("PR_NUMBER"));
-  const baseSha = requireEnv("BASE_SHA");
   const headSha = requireEnv("HEAD_SHA");
 
   if (!Number.isInteger(pullNumber) || pullNumber <= 0) {
@@ -93,35 +114,30 @@ async function main() {
 
   const changedFiles = await paginatedGithubRequest(`/repos/${repository}/pulls/${pullNumber}/files`);
   const dockerfiles = changedFiles.filter(
-    (file) => /^system\/Dockerfile[^/]*$/.test(file.filename) && file.status !== "added" && file.status !== "removed",
+    (file) => /^system\/Dockerfile[^/]*$/.test(file.filename) && file.status !== "removed",
   );
 
   const violations = [];
   for (const file of dockerfiles) {
-    const basePath = file.status === "renamed" && file.previous_filename ? file.previous_filename : file.filename;
-    const [baseContent, headContent] = await Promise.all([
-      getFileContent(repository, basePath, baseSha),
-      getFileContent(repository, file.filename, headSha),
-    ]);
-
-    for (const violation of detectDigestUnpins(baseContent, headContent)) {
+    const headContent = await getFileContent(repository, file.filename, headSha);
+    for (const violation of detectUnpinnedExternalBaseImages(headContent)) {
       violations.push({ file: file.filename, ...violation });
     }
   }
 
   if (violations.length === 0) {
-    console.log("No base image digest pins were removed.");
+    console.log("All external base images in changed system Dockerfiles are digest pinned.");
     return;
   }
 
   for (const violation of violations) {
     console.error(
-      `::error file=${violation.file},line=${violation.line}::Base image digest pin removed in stage ${violation.stage}: ${violation.oldRef} -> ${violation.newRef}`,
+      `::error file=${violation.file},line=${violation.line}::External base image in stage ${violation.stage} must be pinned by sha256 digest: ${violation.ref}`,
     );
   }
 
   throw new Error(
-    `${violations.length} base image reference(s) removed required sha256 digest pinning`,
+    `${violations.length} external base image reference(s) are missing required sha256 digest pinning`,
   );
 }
 

--- a/.github/scripts/base-image-update-report.test.mjs
+++ b/.github/scripts/base-image-update-report.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
+import { detectDigestUnpins } from "./base-image-pin-check.mjs";
 import {
   COMMENT_MARKER,
   canVerifyRegistryUpdate,
@@ -55,6 +56,34 @@ test("detectDigestUpdates also reports pinned tag changes", () => {
   assert.equal(updates.length, 1);
   assert.equal(updates[0].oldImage.tag, "1.26");
   assert.equal(updates[0].newImage.tag, "1.27");
+});
+
+test("detectDigestUnpins reports pinned-to-unpinned changes", () => {
+  const base = `FROM golang:1.26@${OLD} AS build\nFROM public.ecr.aws/lambda/provided:al2023@${OLD}\n`;
+  const head = "FROM golang:1.26 AS build\nFROM public.ecr.aws/lambda/provided:al2023\n";
+  const violations = detectDigestUnpins(base, head);
+
+  assert.deepEqual(violations, [
+    {
+      stage: 1,
+      line: 1,
+      oldRef: `golang:1.26@${OLD}`,
+      newRef: "golang:1.26",
+    },
+    {
+      stage: 2,
+      line: 2,
+      oldRef: `public.ecr.aws/lambda/provided:al2023@${OLD}`,
+      newRef: "public.ecr.aws/lambda/provided:al2023",
+    },
+  ]);
+});
+
+test("detectDigestUnpins allows pinned digest and tag updates", () => {
+  const base = `FROM golang:1.26@${OLD} AS build\n`;
+  const head = `FROM golang:1.27@${NEW} AS build\n`;
+
+  assert.deepEqual(detectDigestUnpins(base, head), []);
 });
 
 test("registry verification is restricted to the existing image repository and known registries", () => {
@@ -154,14 +183,22 @@ test("renderReport is explicit when registry verification fails", () => {
   assert.match(report, /One or more pinned digests could not be verified/);
 });
 
-test("report workflow remains advisory and catches stale-comment cleanup", () => {
+test("digest pin safety is blocking while registry reporting remains advisory", () => {
   const workflow = readFileSync(".github/workflows/base-image-update-report.yml", "utf8");
 
   assert.match(workflow, /pull_request_target:[\s\S]*?types: \[opened, synchronize, reopened\]/);
   assert.doesNotMatch(workflow, /pull_request_target:[\s\S]*?paths:/);
   assert.doesNotMatch(workflow, /Verify Docker Buildx availability/);
-  assert.match(workflow, /name: Checkout trusted base revision[\s\S]*?continue-on-error: true/);
+
+  const pinCheckStep = workflow.match(
+    /- name: Reject unpinned base image changes[\s\S]*?(?=\n\s*- name:)/,
+  )?.[0];
+  assert.ok(pinCheckStep);
+  assert.match(pinCheckStep, /node \.github\/scripts\/base-image-pin-check\.mjs/);
+  assert.doesNotMatch(pinCheckStep, /continue-on-error:/);
+
   assert.match(workflow, /name: Generate or update PR report[\s\S]*?continue-on-error: true/);
-  assert.match(workflow, /name: Keep report advisory[\s\S]*?if: always\(\)[\s\S]*?continue-on-error: true/);
-  assert.match(workflow, /does not block merging/);
+  assert.match(workflow, /name: Keep registry report advisory[\s\S]*?if: always\(\)[\s\S]*?continue-on-error: true/);
+  assert.match(workflow, /Digest pin removal is a blocking safety check/);
+  assert.match(workflow, /registry digest freshness reporting is advisory/);
 });

--- a/.github/scripts/base-image-update-report.test.mjs
+++ b/.github/scripts/base-image-update-report.test.mjs
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
 
-import { detectDigestUnpins } from "./base-image-pin-check.mjs";
+import {
+  detectUnpinnedExternalBaseImages,
+  parseFromStages,
+} from "./base-image-pin-check.mjs";
 import {
   COMMENT_MARKER,
   canVerifyRegistryUpdate,
@@ -58,32 +61,67 @@ test("detectDigestUpdates also reports pinned tag changes", () => {
   assert.equal(updates[0].newImage.tag, "1.27");
 });
 
-test("detectDigestUnpins reports pinned-to-unpinned changes", () => {
-  const base = `FROM golang:1.26@${OLD} AS build\nFROM public.ecr.aws/lambda/provided:al2023@${OLD}\n`;
-  const head = "FROM golang:1.26 AS build\nFROM public.ecr.aws/lambda/provided:al2023\n";
-  const violations = detectDigestUnpins(base, head);
+test("parseFromStages preserves aliases for internal-stage detection", () => {
+  assert.deepEqual(
+    parseFromStages(`FROM --platform=linux/amd64 golang:1.26@${OLD} AS build\nFROM build AS final\n`),
+    [
+      { stage: 1, line: 1, image: `golang:1.26@${OLD}`, alias: "build" },
+      { stage: 2, line: 2, image: "build", alias: "final" },
+    ],
+  );
+});
 
-  assert.deepEqual(violations, [
+test("pin invariant catches an unpinned existing stage after a pinned stage is inserted first", () => {
+  const head = [
+    `FROM alpine:3.20@${NEW} AS prepare`,
+    `FROM golang:1.26@${OLD} AS build`,
+    "FROM public.ecr.aws/lambda/provided:al2023",
+    "",
+  ].join("\n");
+
+  assert.deepEqual(detectUnpinnedExternalBaseImages(head), [
     {
-      stage: 1,
-      line: 1,
-      oldRef: `golang:1.26@${OLD}`,
-      newRef: "golang:1.26",
-    },
-    {
-      stage: 2,
-      line: 2,
-      oldRef: `public.ecr.aws/lambda/provided:al2023@${OLD}`,
-      newRef: "public.ecr.aws/lambda/provided:al2023",
+      stage: 3,
+      line: 3,
+      ref: "public.ecr.aws/lambda/provided:al2023",
     },
   ]);
 });
 
-test("detectDigestUnpins allows pinned digest and tag updates", () => {
-  const base = `FROM golang:1.26@${OLD} AS build\n`;
-  const head = `FROM golang:1.27@${NEW} AS build\n`;
+test("pin invariant catches an unpinned external stage after stage reordering", () => {
+  const head = [
+    "FROM public.ecr.aws/lambda/provided:al2023",
+    `FROM golang:1.26@${OLD} AS build`,
+    "",
+  ].join("\n");
 
-  assert.deepEqual(detectDigestUnpins(base, head), []);
+  assert.deepEqual(detectUnpinnedExternalBaseImages(head), [
+    {
+      stage: 1,
+      line: 1,
+      ref: "public.ecr.aws/lambda/provided:al2023",
+    },
+  ]);
+});
+
+test("pin invariant rejects a newly added unpinned external stage", () => {
+  assert.deepEqual(detectUnpinnedExternalBaseImages("FROM node:22 AS build\n"), [
+    {
+      stage: 1,
+      line: 1,
+      ref: "node:22",
+    },
+  ]);
+});
+
+test("pin invariant allows references to previously declared internal stages", () => {
+  const head = `FROM golang:1.26@${OLD} AS build\nFROM build AS final\n`;
+  assert.deepEqual(detectUnpinnedExternalBaseImages(head), []);
+});
+
+test("pin invariant allows scratch and pinned external base images", () => {
+  const head = `FROM golang:1.27@${NEW} AS build\nFROM scratch AS final\n`;
+  assert.deepEqual(detectUnpinnedExternalBaseImages(head), []);
 });
 
 test("registry verification is restricted to the existing image repository and known registries", () => {

--- a/.github/workflows/base-image-update-report.yml
+++ b/.github/workflows/base-image-update-report.yml
@@ -63,4 +63,4 @@ jobs:
           if [[ "$REPORT_OUTCOME" == "failure" ]]; then
             echo "::warning::Base image registry verification did not complete successfully. Registry freshness reporting is advisory."
           fi
-          echo "Digest pinning of external base images is a blocking safety check; registry digest freshness reporting is advisory."
+          echo "Digest pin removal is a blocking safety check; all external base images in changed Dockerfiles must remain sha256-pinned; registry digest freshness reporting is advisory."

--- a/.github/workflows/base-image-update-report.yml
+++ b/.github/workflows/base-image-update-report.yml
@@ -1,8 +1,8 @@
 name: Base Image Update Report
 
 # Dependabot-triggered pull_request workflows receive a read-only token.
-# pull_request_target is used only so the trusted base-branch workflow can update
-# the PR comment. Never checkout or execute the PR head revision in this workflow.
+# pull_request_target is used only so the trusted base-branch workflow can inspect
+# PR metadata and update the PR comment. Never checkout or execute the PR head revision.
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
@@ -18,23 +18,33 @@ concurrency:
 
 jobs:
   report:
-    name: Verify and Report Base Image Digests
+    name: Check and Report Base Image Digests
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout trusted base revision
         id: checkout
-        continue-on-error: true
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           persist-credentials: false
 
-      # The script checks the PR changed-files list first. If no system/Dockerfile*
+      # Digest pinning is a reproducibility/supply-chain invariant. This guard reads
+      # PR file contents through the GitHub API and fails before the advisory report
+      # can treat a pinned -> unpinned change as "no digest update".
+      - name: Reject unpinned base image changes
+        id: pin-check
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: node .github/scripts/base-image-pin-check.mjs
+
+      # The report checks the PR changed-files list first. If no system/Dockerfile*
       # remains in the final PR diff, it removes any stale report comment and exits
-      # before invoking Docker Buildx.
+      # before invoking Docker Buildx. Registry freshness verification stays advisory.
       - name: Generate or update PR report
-        if: steps.checkout.outcome == 'success'
         id: report
         continue-on-error: true
         env:
@@ -44,14 +54,13 @@ jobs:
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node .github/scripts/base-image-update-report.mjs
 
-      - name: Keep report advisory
+      - name: Keep registry report advisory
         if: always()
         continue-on-error: true
         env:
-          CHECKOUT_OUTCOME: ${{ steps.checkout.outcome }}
           REPORT_OUTCOME: ${{ steps.report.outcome }}
         run: |
-          if [[ "$CHECKOUT_OUTCOME" != "success" || "$REPORT_OUTCOME" != "success" ]]; then
-            echo "::warning::Base image update reporting did not complete successfully. This check is advisory and does not block merging."
+          if [[ "$REPORT_OUTCOME" == "failure" ]]; then
+            echo "::warning::Base image registry verification did not complete successfully. Registry freshness reporting is advisory."
           fi
-          echo "Base Image Update Report is advisory; merge gating is handled by the normal CI workflow."
+          echo "Digest pin removal is a blocking safety check; registry digest freshness reporting is advisory."

--- a/.github/workflows/base-image-update-report.yml
+++ b/.github/workflows/base-image-update-report.yml
@@ -30,14 +30,14 @@ jobs:
           persist-credentials: false
 
       # Digest pinning is a reproducibility/supply-chain invariant. This guard reads
-      # PR file contents through the GitHub API and fails before the advisory report
-      # can treat a pinned -> unpinned change as "no digest update".
+      # changed system/Dockerfile* files from the PR head through the GitHub API and
+      # rejects any external base image that is not sha256-pinned. Internal stage
+      # aliases and scratch are allowed. The PR head is never checked out or executed.
       - name: Reject unpinned base image changes
         id: pin-check
         env:
           GITHUB_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: node .github/scripts/base-image-pin-check.mjs
 
@@ -63,4 +63,4 @@ jobs:
           if [[ "$REPORT_OUTCOME" == "failure" ]]; then
             echo "::warning::Base image registry verification did not complete successfully. Registry freshness reporting is advisory."
           fi
-          echo "Digest pin removal is a blocking safety check; registry digest freshness reporting is advisory."
+          echo "Digest pinning of external base images is a blocking safety check; registry digest freshness reporting is advisory."


### PR DESCRIPTION
## 概要

PR #1097 の review discussion `discussion_r3996856171` で指摘された、`FROM image:tag@sha256:...` → `FROM image:tag` の変更が digest update 0 件として扱われ、無警告で通る問題を修正します。

レビューで追加指摘された stage index 対応の弱さも踏まえ、実装は差分比較ではなく **head側の不変条件** に変更しました。

> `system/Dockerfile*` の外部base imageは、変更後のDockerfile上ですべて `@sha256:...` で固定されていなければならない。

## 対応内容

- `base-image-pin-check.mjs` を追加し、変更された `system/Dockerfile*` のhead内容を検査
- 外部base imageがdigest未固定なら GitHub Actions annotation 付きでblocking failure
- stage追加・削除・並び替えに依存しないhead-side invariantとして実装
- 新規追加Dockerfileも検査対象
- 既に宣言済みの内部stage alias (`FROM build` 等) は許可
- Docker特殊baseの `scratch` は許可
- pin safety check はblocking、registry current-tag digest照合レポートは従来どおりadvisory
- PR headはcheckout/executeせず、GitHub API経由でDockerfile内容だけ取得

## 回帰テスト

以下を追加しています。

- 先頭にpinned stage追加 + 後続external stageがunpinned → 失敗
- stage並び替え後にexternal stageがunpinned → 失敗
- 新規external stageがunpinned → 失敗
- `FROM build` など既宣言internal stage参照 → 許可
- `scratch` → 許可
- pinned external base image → 許可
- workflow上、pin safetyはblocking / registry freshness reportはadvisoryであることを固定

## 対象

- PR #1097 review follow-up
- https://github.com/kani3camp/youtube-study-space/pull/1097#discussion_r3996856171

> [!IMPORTANT]
> このPRのbaseは `dev` です。プロジェクト運用ルールに従い、エージェントからはマージしません。

> [!NOTE]
> `pull_request_target` はbase/default branch側のworkflow定義を使うため、#1099自身では更新後workflowを本番同等経路で実行できません。PR head側の通常CIでunit testを通し、devへ反映後の後続PRからblocking workflowとして有効になります。