### PR TITLE
fix: checkout pull_request_target workflow revision

### DIFF
--- a/.github/scripts/base-image-update-report.test.mjs
+++ b/.github/scripts/base-image-update-report.test.mjs
@@ -228,6 +228,13 @@ test("digest pin safety is blocking while registry reporting remains advisory", 
   assert.doesNotMatch(workflow, /pull_request_target:[\s\S]*?paths:/);
   assert.doesNotMatch(workflow, /Verify Docker Buildx availability/);
 
+  const checkoutStep = workflow.match(
+    /- name: Checkout trusted workflow revision[\s\S]*?(?=\n\s*- name:)/,
+  )?.[0];
+  assert.ok(checkoutStep);
+  assert.match(checkoutStep, /ref: \$\{\{ github\.workflow_sha \}\}/);
+  assert.doesNotMatch(checkoutStep, /github\.event\.pull_request\.base\.sha/);
+
   const pinCheckStep = workflow.match(
     /- name: Reject unpinned base image changes[\s\S]*?(?=\n\s*- name:)/,
   )?.[0];

--- a/.github/workflows/base-image-update-report.yml
+++ b/.github/workflows/base-image-update-report.yml
@@ -22,11 +22,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Checkout trusted base revision
+      # pull_request_target loads this workflow from a trusted revision that can differ
+      # from the PR base (for example dev workflow checking a dev -> main release PR).
+      # Checkout the exact workflow revision so its companion scripts always exist.
+      - name: Checkout trusted workflow revision
         id: checkout
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.workflow_sha }}
           persist-credentials: false
 
       # Digest pinning is a reproducibility/supply-chain invariant. This guard reads


### PR DESCRIPTION
## 概要

PR #1097 (`dev` → `main`) で `Base Image Update Report` が `MODULE_NOT_FOUND` になった問題を修正します。

`pull_request_target` では trusted workflow が既定ブランチ側から読み込まれる一方、workflow内の checkout は `github.event.pull_request.base.sha` を指定していました。そのため、#1097 では #1099 で追加された workflow が実行されつつ、checkout先は古い `main` になり、`.github/scripts/base-image-pin-check.mjs` が存在しない状態になっていました。

## 対応

- trusted code の checkout ref を `github.event.pull_request.base.sha` から `github.workflow_sha` へ変更
- workflow定義と companion script を必ず同一revisionから実行するようにする
- PR head は引き続き checkout / execute せず、Dockerfile内容のみGitHub API経由で読む
- 回帰テストで以下を固定
  - checkoutは `github.workflow_sha`
  - checkout stepで `github.event.pull_request.base.sha` を使用しない

## 影響範囲

変更は以下の2ファイルのみです。

- `.github/workflows/base-image-update-report.yml`
- `.github/scripts/base-image-update-report.test.mjs`

## 背景

- Follow-up for PR #1097 Base Image Update Report failure
- Follow-up for #1099

> [!IMPORTANT]
> このPRのbaseは `dev` です。プロジェクト運用ルールに従い、エージェントからはマージしません。