### PR TITLE
fix: v4.29.1 リリースレビュー指摘へ対応

### DIFF
--- a/.github/scripts/base-image-update-report.mjs
+++ b/.github/scripts/base-image-update-report.mjs
@@ -240,6 +240,13 @@ function encodeRepositoryPath(path) {
   return path.split("/").map(encodeURIComponent).join("/");
 }
 
+export function selectModifiedDockerfiles(changedFiles) {
+  return changedFiles
+    .filter((file) => file.status === "modified")
+    .map((file) => file.filename)
+    .filter((filename) => /^system\/Dockerfile[^/]*$/.test(filename));
+}
+
 async function getFileContent(repository, path, ref) {
   const response = await githubRequest(
     `/repos/${repository}/contents/${encodeRepositoryPath(path)}?ref=${encodeURIComponent(ref)}`,
@@ -300,9 +307,7 @@ async function main() {
   }
 
   const changedFiles = await paginatedGithubRequest(`/repos/${repository}/pulls/${pullNumber}/files`);
-  const dockerfiles = changedFiles
-    .map((file) => file.filename)
-    .filter((filename) => /^system\/Dockerfile[^/]*$/.test(filename));
+  const dockerfiles = selectModifiedDockerfiles(changedFiles);
 
   const entries = [];
   for (const file of dockerfiles) {

--- a/.github/scripts/base-image-update-report.test.mjs
+++ b/.github/scripts/base-image-update-report.test.mjs
@@ -16,6 +16,7 @@ import {
   publicGalleryUrl,
   registryHost,
   renderReport,
+  selectModifiedDockerfiles,
 } from "./base-image-update-report.mjs";
 
 const OLD = "sha256:d8d858dc6f7a6552ffc131e029802c28969c8211d311c33f9400449e30cf7442";
@@ -59,6 +60,18 @@ test("detectDigestUpdates also reports pinned tag changes", () => {
   assert.equal(updates.length, 1);
   assert.equal(updates[0].oldImage.tag, "1.26");
   assert.equal(updates[0].newImage.tag, "1.27");
+});
+
+test("selectModifiedDockerfiles skips added and removed files that do not exist on both refs", () => {
+  assert.deepEqual(
+    selectModifiedDockerfiles([
+      { filename: "system/Dockerfile.lambda", status: "modified" },
+      { filename: "system/Dockerfile.new", status: "added" },
+      { filename: "system/Dockerfile.old", status: "removed" },
+      { filename: "system/internal/app.go", status: "modified" },
+    ]),
+    ["system/Dockerfile.lambda"],
+  );
 });
 
 test("parseFromStages preserves aliases for internal-stage detection", () => {

--- a/system/internal/awsruntime/credential_test.go
+++ b/system/internal/awsruntime/credential_test.go
@@ -70,6 +70,7 @@ func TestWIFConfigFromEnv(t *testing.T) {
 }
 
 func TestWIFConfigFromEnvRequiresProjectID(t *testing.T) {
+	t.Setenv(googleCloudProjectEnv, "")
 	t.Setenv(gcpWIFAudienceEnv, "audience")
 	t.Setenv(gcpWIFServiceAccountEmailEnv, "runtime@example.iam.gserviceaccount.com")
 

--- a/tools/room-image-prompt/cmd/room-image-prompt/main.go
+++ b/tools/room-image-prompt/cmd/room-image-prompt/main.go
@@ -166,7 +166,11 @@ func resolveStyle(fsys fs.FS, styleName, styleFile string) (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("-style-file %q: %w", styleFile, err)
 		}
-		return string(b), nil
+		text := strings.ReplaceAll(string(b), "\r\n", "\n")
+		if strings.TrimSpace(text) == "" {
+			return "", fmt.Errorf("-style-file %q: テキストが空です", styleFile)
+		}
+		return text, nil
 	}
 
 	switch styleName {

--- a/tools/room-image-prompt/cmd/room-image-prompt/main_e2e_test.go
+++ b/tools/room-image-prompt/cmd/room-image-prompt/main_e2e_test.go
@@ -134,7 +134,11 @@ func TestResolveStyle(t *testing.T) {
 		"style_direction_a.generated.txt": {Data: []byte("DIRECTION_A\n")},
 	}
 	customPath := filepath.Join(t.TempDir(), "custom-style.txt")
-	if err := os.WriteFile(customPath, []byte("CUSTOM_STYLE\n"), 0o644); err != nil {
+	if err := os.WriteFile(customPath, []byte("CUSTOM_STYLE\r\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	emptyPath := filepath.Join(t.TempDir(), "empty-style.txt")
+	if err := os.WriteFile(emptyPath, []byte(" \r\n\t"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -147,7 +151,8 @@ func TestResolveStyle(t *testing.T) {
 	}{
 		{name: "default legacy", want: "LEGACY_STYLE\n"},
 		{name: "explicit legacy", styleName: legacyStyleName, want: "LEGACY_STYLE\n"},
-		{name: "custom file", styleFile: customPath, want: "CUSTOM_STYLE\n"},
+		{name: "custom file normalizes CRLF", styleFile: customPath, want: "CUSTOM_STYLE\n"},
+		{name: "empty custom file", styleFile: emptyPath, wantErr: true},
 		{name: "direction style", styleName: "direction-a", want: "DIRECTION_A\n"},
 		{name: "conflicting sources", styleName: legacyStyleName, styleFile: customPath, wantErr: true},
 		{name: "missing direction style", styleName: "direction-z", wantErr: true},
@@ -353,6 +358,27 @@ func TestPurpleLooksRespectPastelDirections(t *testing.T) {
 				t.Fatalf("look %q is missing pastel compatibility guidance %q:\n%s", tt.name, tt.required, got.Text)
 			}
 		})
+	}
+}
+
+func TestAiryGardenLookDoesNotInjectSceneContent(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveLook(data.FS, "airy-garden", "", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{
+		"fantasy-garden",
+		"stone, tile or architectural surfaces",
+		"bookshelves, wood furniture",
+	} {
+		if strings.Contains(got.Text, forbidden) {
+			t.Fatalf("airy-garden Look still injects scene content %q:\n%s", forbidden, got.Text)
+		}
+	}
+	if !strings.Contains(got.Text, "do not introduce scenery, architecture, furniture or vegetation") {
+		t.Fatalf("airy-garden Look is missing the no-content-injection contract:\n%s", got.Text)
 	}
 }
 

--- a/tools/room-image-prompt/data/look_airy_garden.txt
+++ b/tools/room-image-prompt/data/look_airy_garden.txt
@@ -1,9 +1,10 @@
 ## Look profile: Airy Garden
 
 - use a fresh palette built from clear sky blue, foliage green, ivory, cream, pale beige and warm medium-brown wood
-- create an airy fantasy-garden feeling with clean light, open color separation and a pleasant balance between cool sky/green areas and warm wood/cream areas
-- favor light stone, tile or architectural surfaces that read clean and luminous without becoming blank white or overexposed
-- keep bookshelves, wood furniture and small warm details visibly richer and browner than the surrounding pale architecture
-- let plants provide confident natural greens instead of muted gray-green; use turquoise or clear blue accents sparingly where they strengthen freshness
+- create an airy, fresh feeling with clean light, open color separation and a pleasant balance between cool blue/green areas and warm cream/brown accents
+- keep broad light-toned surfaces clean and luminous without becoming blank white or overexposed
+- use warm medium-brown as a localized accent, with slightly richer color than the surrounding pale tones
+- preserve natural-looking greens when they already occur in the selected Theme; use turquoise or clear blue accents sparingly where they strengthen freshness
+- do not introduce scenery, architecture, furniture or vegetation that is not already called for by the selected Theme
 - preserve the requested time of day and weather; at evening or night keep the same palette relationships while adapting their brightness and light source naturally
 - keep the active Direction's rendering language intact; this Look controls palette, lighting mood and material emphasis, not the underlying illustration / anime / CG grammar


### PR DESCRIPTION
## Goal

PR #1097 で未解決になっているレビュー指摘5件を、次回の `dev` → `main` 反映前に修正します。

## Changes

- base image report は base/head の両方に存在する modified Dockerfile のみ比較
- `-style-file` の CRLF を正規化し、空白のみのStyleを拒否
- WIFのproject ID欠落テストを外部環境変数から隔離
- `airy-garden` Lookを配色・光・材質感に限定し、題材・建築・家具を注入しない契約を追加
- 各不具合の回帰テストを追加

## Invariants / Non-goals

- digest pin自体のblocking検証は変更しません。
- bundled Direction、Theme選択、WIF本体の認証動作は変更しません。
- PR #1097 のリリース差分やbase image digestそのものの更新は対象外です。

## Verification

- `node --test .github/scripts/base-image-update-report.test.mjs`
- `bash .github/scripts/test-detect-ci-paths.sh`
- `cd tools/room-image-prompt && go test ./...`
- `cd system && GOOGLE_CLOUD_PROJECT=inherited-project go test ./internal/awsruntime -run TestWIFConfigFromEnv -count=1`
- `cd system && go test -shuffle=on ./...`
- `cd system && golangci-lint run --timeout=5m --config=.golangci.yml`
- `git diff --check`

Related: #1097