### PR TITLE
feat: add book office room 2 to member rotations

### DIFF
--- a/youtube-monitor/src/rooms/layouts/book-office-room-2.ts
+++ b/youtube-monitor/src/rooms/layouts/book-office-room-2.ts
@@ -1,0 +1,25 @@
+import type { RoomLayout } from '../../types/room-layout'
+
+export const BookOfficeRoom2: RoomLayout = {
+	floor_image: '/images/rooms/book-office-room-2.png',
+	font_size_ratio: 0.017,
+	room_shape: {
+		width: 1520,
+		height: 1000,
+	},
+	seat_shape: {
+		width: 230,
+		height: 150,
+	},
+	partition_shapes: [],
+	seats: [
+		{ id: 1, x: 84, y: 481, rotate: 0 },
+		{ id: 2, x: 330, y: 412, rotate: 0 },
+		{ id: 3, x: 577, y: 331, rotate: 0 },
+		{ id: 4, x: 1009, y: 384, rotate: 0 },
+		{ id: 5, x: 1267, y: 412, rotate: 0 },
+		{ id: 6, x: 530, y: 697, rotate: 0 },
+		{ id: 7, x: 973, y: 785, rotate: 0 },
+	],
+	partitions: [],
+}

--- a/youtube-monitor/src/rooms/room-registry.ts
+++ b/youtube-monitor/src/rooms/room-registry.ts
@@ -1,6 +1,7 @@
 import type { RoomLayout } from '../types/room-layout'
 import { Anonymous1Room } from './layouts/anonymous1'
 import { BookOfficeRoom } from './layouts/book-office-room'
+import { BookOfficeRoom2 } from './layouts/book-office-room-2'
 import { CafeRainyRoom } from './layouts/cafe-rainy-room'
 import { CafeWinterNightRoom } from './layouts/cafe-winter-night-room'
 import { CampRoom } from './layouts/camp-room'
@@ -53,6 +54,7 @@ export const roomRegistry = {
 	freepik5: { displayName: 'Freepik 5', layout: Freepik5Room },
 	freepik7: { displayName: 'Freepik 7', layout: Freepik7Room },
 	bookOffice: { displayName: 'Book Office', layout: BookOfficeRoom },
+	bookOffice2: { displayName: 'Book Office 2', layout: BookOfficeRoom2 },
 	memberBoxRooms2: {
 		displayName: 'Member Box Rooms 2',
 		layout: MemberBoxRooms2,

--- a/youtube-monitor/src/rooms/rooms-config.ts
+++ b/youtube-monitor/src/rooms/rooms-config.ts
@@ -40,6 +40,7 @@ export const roomConfigs = {
 		],
 		memberBasicRooms: [
 			'bookOffice',
+			'bookOffice2',
 			'memberBoxRooms2',
 			'memberBoxRooms3',
 			'memberIllustratedRoomSpring',
@@ -47,6 +48,7 @@ export const roomConfigs = {
 		],
 		memberTemporaryRooms: [
 			'bookOffice',
+			'bookOffice2',
 			'memberBoxRooms2',
 			'memberBoxRooms3',
 			'memberIllustratedRoomSpring',
@@ -56,8 +58,8 @@ export const roomConfigs = {
 	DEV: {
 		generalBasicRooms: ['moonNight1', 'moonNight2'],
 		generalTemporaryRooms: ['moonNight1', 'moonNight2'],
-		memberBasicRooms: ['bookOffice'],
-		memberTemporaryRooms: ['bookOffice'],
+		memberBasicRooms: ['bookOffice', 'bookOffice2'],
+		memberTemporaryRooms: ['bookOffice', 'bookOffice2'],
 	},
 } as const satisfies Record<RoomConfigName, RoomConfig>
 

--- a/youtube-monitor/src/rooms/runtime-room-registry.ts
+++ b/youtube-monitor/src/rooms/runtime-room-registry.ts
@@ -1,6 +1,7 @@
 import type { RoomLayout } from '../types/room-layout'
 import { Anonymous1Room } from './layouts/anonymous1'
 import { BookOfficeRoom } from './layouts/book-office-room'
+import { BookOfficeRoom2 } from './layouts/book-office-room-2'
 import { CafeRainyRoom } from './layouts/cafe-rainy-room'
 import { CampRoom } from './layouts/camp-room'
 import { Chabio1Room } from './layouts/chabio1-room'
@@ -30,6 +31,7 @@ export const runtimeRoomRegistry = {
 	freepik5: Freepik5Room,
 	freepik7: Freepik7Room,
 	bookOffice: BookOfficeRoom,
+	bookOffice2: BookOfficeRoom2,
 	memberBoxRooms2: MemberBoxRooms2,
 	memberBoxRooms3: MemberBoxRooms3,
 	resortSea: ResortSeaRoom,


### PR DESCRIPTION
## Summary
- add `BookOfficeRoom2` with the seven provided member-seat positions
- register `bookOffice2` in the runtime room registry
- include it in member basic and temporary rotations for both PROD and DEV configurations

## Asset
The corresponding image is intentionally managed in the private repository:
- `kani3camp/private-youtube-study-space`
- `youtube-monitor/public/images/rooms/book-office-room-2.png`

## Seat layout
- room frame: 1520 × 1000
- member seat frame: 230 × 150
- seats: 7
- source coordinates: `upload/book-office-room-2.txt`

Not merged.